### PR TITLE
Update enqueue functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 _No documentation available about unreleased changes as of yet._
 
+## [2.0.3]
+
+### Added
+
+- Add enqueue abstract class that can be extended in the project.
+
 ## [2.0.2]
 
 ### Fixed

--- a/src/enqueue/class-assets.php
+++ b/src/enqueue/class-assets.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * The Assets abstract class.
+ *
+ * @package Eightshift_Libs\Enqueue
+ */
+
+declare( strict_types=1 );
+
+namespace Eightshift_Libs\Enqueue;
+
+use Eightshift_Libs\Core\Service;
+
+/**
+ * Class Assets
+ *
+ * This abstract class holds helper methods that can be used and overwritten in
+ * user defined classes that extend the enqueue classes in their project.
+ *
+ * @package Eightshift_Libs\Enqueue
+ */
+abstract class Assets implements Service {
+
+  const MEDIA_ALL    = 'all';
+  const MEDIA_PRINT  = 'print';
+  const MEDIA_SCREEN = 'screen';
+
+  /**
+   * Get frontend script dependencies
+   *
+   * @link https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-included-and-registered-by-wordpress
+   *
+   * @return array List of all the script dependencies.
+   *
+   * @since 2.0.3
+   */
+  protected function get_frontend_script_dependencies() : array {
+  	return [];
+  }
+
+  /**
+   * Get admin script dependencies
+   *
+   * @link https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-included-and-registered-by-wordpress
+   *
+   * @return array List of all the script dependencies.
+   *
+   * @since 2.0.3
+   */
+  protected function get_admin_script_dependencies() : array {
+  	return [];
+  }
+
+  /**
+   * Get script localizations
+   *
+   * * Example: $localization_array => [
+   *  'localizationHandler' => [
+   *      'someValue'    => esc_html__( 'Hi there!', 'text-domain' ),
+   *      'anotherValue' => $variableValue,
+   *  ]
+   * ];
+   *
+   * @link https://developer.wordpress.org/reference/functions/wp_localize_script/
+   *
+   * @return array Key value pair of different localizations.
+   *
+   * @since 2.0.3
+   */
+  protected function get_localizations() : array {
+  	return [];
+  }
+
+  /**
+   * Get front end style dependencies
+   *
+   * @link https://developer.wordpress.org/reference/functions/wp_enqueue_style/
+   *
+   * @return array List of all the style dependencies.
+   *
+   * @since 2.0.3
+   */
+  protected function get_frontend_style_dependencies() : array {
+  	return [];
+  }
+
+  /**
+   * Get admin style dependencies
+   *
+   * @link https://developer.wordpress.org/reference/functions/wp_enqueue_style/
+   *
+   * @return array List of all the style dependencies.
+   *
+   * @since 2.0.3
+   */
+  protected function get_admin_style_dependencies() : array {
+  	return [];
+  }
+
+  /**
+   * Get style media definition
+   *
+   * @link https://developer.wordpress.org/reference/functions/wp_enqueue_style/
+   *
+   * @return string The media for which this stylesheet has been defined.
+   * Accepts media types like 'all', 'print' and 'screen',
+   * or media queries like '(orientation: portrait)' and '(max-width: 640px)'.
+   * Default value: 'all'
+   *
+   * @since 2.0.3
+   */
+  protected function get_media() : string {
+  	return static::MEDIA_ALL;
+  }
+}

--- a/src/enqueue/class-assets.php
+++ b/src/enqueue/class-assets.php
@@ -25,6 +25,8 @@ abstract class Assets implements Service {
   const MEDIA_PRINT  = 'print';
   const MEDIA_SCREEN = 'screen';
 
+  const IN_FOOTER = false;
+
   /**
    * Get frontend script dependencies
    *

--- a/src/enqueue/class-enqueue-admin.php
+++ b/src/enqueue/class-enqueue-admin.php
@@ -21,6 +21,12 @@ use Eightshift_Libs\Core\Config_Data;
  * @since 2.0.0
  */
 class Enqueue_Admin extends Assets {
+
+  const IN_FOOTER = true;
+
+  const ADMIN_SCRIPT_URI = 'applicationAdmin.js';
+  const ADMIN_STYLE_URI  = 'applicationAdmin.css';
+
   /**
    * Instance variable of project config data.
    *
@@ -80,7 +86,7 @@ class Enqueue_Admin extends Assets {
 
     \wp_register_style(
       $handle,
-      $this->manifest->get_assets_manifest_item( 'applicationAdmin.css' ),
+      $this->manifest->get_assets_manifest_item( static::ADMIN_STYLE_URI ),
       $this->get_admin_style_dependencies(),
       $this->config::get_project_version(),
       $this->get_media()
@@ -104,10 +110,10 @@ class Enqueue_Admin extends Assets {
 
     \wp_register_script(
       $handle,
-      $this->manifest->get_assets_manifest_item( 'applicationAdmin.js' ),
+      $this->manifest->get_assets_manifest_item( static::ADMIN_SCRIPT_URI ),
       $this->get_admin_script_dependencies(),
       $this->config::get_project_version(),
-      true
+      $this->script_in_footer()
     );
 
     \wp_enqueue_script( $handle );

--- a/src/enqueue/class-enqueue-admin.php
+++ b/src/enqueue/class-enqueue-admin.php
@@ -20,8 +20,7 @@ use Eightshift_Libs\Core\Config_Data;
  *
  * @since 2.0.0
  */
-class Enqueue_Admin implements Service {
-
+class Enqueue_Admin extends Assets {
   /**
    * Instance variable of project config data.
    *
@@ -73,17 +72,21 @@ class Enqueue_Admin implements Service {
    * @return void
    *
    * @since 2.0.0
+   * @since 2.0.3 Added methods for overrides.
+   *              Fixed static calls from config class.
    */
   public function enqueue_styles() {
-    $handler = "{$this->config->get_project_prefix()}-styles";
+    $handle = "{$this->config::get_project_prefix()}-styles";
 
     \wp_register_style(
-      $handler,
+      $handle,
       $this->manifest->get_assets_manifest_item( 'applicationAdmin.css' ),
-      [],
-      $this->config->get_project_version()
+      $this->get_admin_style_dependencies(),
+      $this->config::get_project_version(),
+      $this->get_media()
     );
-    \wp_enqueue_style( $handler );
+
+    \wp_enqueue_style( $handle );
 
   }
 
@@ -93,17 +96,24 @@ class Enqueue_Admin implements Service {
    * @return void
    *
    * @since 2.0.0
+   * @since 2.0.3 Added methods for overrides.
+   *              Fixed static calls from config class.
    */
   public function enqueue_scripts() {
-    $handler = "{$this->config->get_project_prefix()}-scripts";
+    $handle = "{$this->config::get_project_prefix()}-scripts";
 
     \wp_register_script(
-      $handler,
+      $handle,
       $this->manifest->get_assets_manifest_item( 'applicationAdmin.js' ),
-      [],
-      $this->config->get_project_version(),
+      $this->get_admin_script_dependencies(),
+      $this->config::get_project_version(),
       true
     );
-    \wp_enqueue_script( $handler );
+
+    \wp_enqueue_script( $handle );
+
+    foreach ( $this->get_localizations() as $object_name => $data_array ) {
+      \wp_localize_script( $handle, $object_name, $data_array );
+    }
   }
 }

--- a/src/enqueue/class-enqueue-blocks.php
+++ b/src/enqueue/class-enqueue-blocks.php
@@ -184,6 +184,13 @@ class Enqueue_Blocks extends Assets {
     return [ "{$this->config::get_project_prefix()}-block-style" ];
   }
 
+    /**
+     * List of admin script dependencies
+     *
+     * @return array List of all the admin dependencies.
+     *
+     * @since 2.0.3
+     */
   protected function get_admin_script_dependencies() : array {
     return [
       'jquery',

--- a/src/enqueue/class-enqueue-blocks.php
+++ b/src/enqueue/class-enqueue-blocks.php
@@ -18,7 +18,7 @@ use Eightshift_Libs\Core\Config_Data;
  *
  * @since 1.0.0
  */
-class Enqueue_Blocks implements Service {
+class Enqueue_Blocks extends Assets {
 
   /**
    * Instance variable of project config data.
@@ -76,29 +76,19 @@ class Enqueue_Blocks implements Service {
    * Enqueue blocks script for editor only.
    *
    * @since 1.0.0
+   * @since 2.0.3 Added methods for overrides.
+   *              Fixed static calls from config class.
    *
    * @return void
    */
   public function enqueue_block_editor_script() {
-    $handler = "{$this->config->get_project_prefix()}-block-editor-scripts";
+    $handler = "{$this->config::get_project_prefix()}-block-editor-scripts";
 
     \wp_register_script(
       $handler,
       $this->manifest->get_assets_manifest_item( 'applicationBlocksEditor.js' ),
-      array(
-        'jquery',
-        'wp-components',
-        'wp-blocks',
-        'wp-element',
-        'wp-editor',
-        'wp-date',
-        'wp-data',
-        'wp-i18n',
-        'wp-viewport',
-        'wp-blob',
-        'wp-url',
-      ),
-      $this->config->get_project_version(),
+      $this->get_admin_script_dependencies(),
+      $this->config::get_project_version(),
       true
     );
     \wp_enqueue_script( $handler );
@@ -108,20 +98,22 @@ class Enqueue_Blocks implements Service {
    * Enqueue blocks style for editor only.
    *
    * @since 1.0.0
+   * @since 2.0.3 Added methods for overrides.
+   *              Fixed static calls from config class.
    *
    * @return void
    */
   public function enqueue_block_editor_style() {
-    $handler    = "{$this->config->get_project_prefix()}-block-editor-style";
-    $dependency = "{$this->config->get_project_prefix()}-block-style";
+    $handler = "{$this->config::get_project_prefix()}-block-editor-style";
 
     \wp_register_style(
       $handler,
       $this->manifest->get_assets_manifest_item( 'applicationBlocksEditor.css' ),
-      [ $dependency ],
-      $this->config->get_project_version(),
-      false
+      $this->get_admin_style_dependencies(),
+      $this->config::get_project_version(),
+      $this->get_media()
     );
+
     \wp_enqueue_style( $handler );
   }
 
@@ -129,19 +121,22 @@ class Enqueue_Blocks implements Service {
    * Enqueue blocks style for editor and frontend.
    *
    * @since 1.0.0
+   * @since 2.0.3 Added methods for overrides.
+   *              Fixed static calls from config class.
    *
    * @return void
    */
   public function enqueue_block_style() {
-    $handler = "{$this->config->get_project_prefix()}-block-style";
+    $handler = "{$this->config::get_project_prefix()}-block-style";
 
     \wp_register_style(
       $handler,
       $this->manifest->get_assets_manifest_item( 'applicationBlocks.css' ),
-      [],
-      $this->config->get_project_version(),
+      $this->get_frontend_style_dependencies(),
+      $this->config::get_project_version(),
       false
     );
+
     \wp_enqueue_style( $handler );
   }
 
@@ -149,19 +144,51 @@ class Enqueue_Blocks implements Service {
    * Enqueue blocks script for frontend only.
    *
    * @since 1.0.0
+   * @since 2.0.3 Added methods for overrides.
+   *              Fixed static calls from config class.
    *
    * @return void
    */
   public function enqueue_block_script() {
-    $handler = "{$this->config->get_project_prefix()}-block-scripts";
+    $handler = "{$this->config::get_project_prefix()}-block-scripts";
 
     \wp_register_script(
       $handler,
       $this->manifest->get_assets_manifest_item( 'applicationBlocks.js' ),
-      [],
-      $this->config->get_project_version(),
+      $this->get_frontend_script_dependencies(),
+      $this->config::get_project_version(),
       true
     );
+
     \wp_enqueue_script( $handler );
+  }
+
+  /**
+   * Get style dependencies
+   *
+   * @link https://developer.wordpress.org/reference/functions/wp_enqueue_style/
+   *
+   * @return array List of all the style dependencies.
+   *
+   * @since 2.0.3
+   */
+  protected function get_admin_style_dependencies() : array {
+    return [ "{$this->config::get_project_prefix()}-block-style" ];
+  }
+
+  protected function get_admin_script_dependencies() : array {
+    return [
+      'jquery',
+      'wp-components',
+      'wp-blocks',
+      'wp-element',
+      'wp-editor',
+      'wp-date',
+      'wp-data',
+      'wp-i18n',
+      'wp-viewport',
+      'wp-blob',
+      'wp-url',
+    ];
   }
 }

--- a/src/enqueue/class-enqueue-blocks.php
+++ b/src/enqueue/class-enqueue-blocks.php
@@ -20,6 +20,14 @@ use Eightshift_Libs\Core\Config_Data;
  */
 class Enqueue_Blocks extends Assets {
 
+  const IN_FOOTER = true;
+
+  const BLOCKS_EDITOR_SCRIPT_URI = 'applicationBlocksEditor.js';
+  const BLOCKS_EDITOR_STYLE_URI  = 'applicationBlocksEditor.css';
+
+  const BLOCKS_STYLE_URI  = 'applicationBlocks.css';
+  const BLOCKS_SCRIPT_URI = 'applicationBlocks.js';
+
   /**
    * Instance variable of project config data.
    *
@@ -86,10 +94,10 @@ class Enqueue_Blocks extends Assets {
 
     \wp_register_script(
       $handler,
-      $this->manifest->get_assets_manifest_item( 'applicationBlocksEditor.js' ),
+      $this->manifest->get_assets_manifest_item( static::BLOCKS_EDITOR_SCRIPT_URI ),
       $this->get_admin_script_dependencies(),
       $this->config::get_project_version(),
-      true
+      $this->script_in_footer()
     );
     \wp_enqueue_script( $handler );
   }
@@ -108,7 +116,7 @@ class Enqueue_Blocks extends Assets {
 
     \wp_register_style(
       $handler,
-      $this->manifest->get_assets_manifest_item( 'applicationBlocksEditor.css' ),
+      $this->manifest->get_assets_manifest_item( static::BLOCKS_EDITOR_STYLE_URI ),
       $this->get_admin_style_dependencies(),
       $this->config::get_project_version(),
       $this->get_media()
@@ -131,10 +139,10 @@ class Enqueue_Blocks extends Assets {
 
     \wp_register_style(
       $handler,
-      $this->manifest->get_assets_manifest_item( 'applicationBlocks.css' ),
+      $this->manifest->get_assets_manifest_item( static::BLOCKS_STYLE_URI ),
       $this->get_frontend_style_dependencies(),
       $this->config::get_project_version(),
-      false
+      $this->get_media()
     );
 
     \wp_enqueue_style( $handler );
@@ -154,10 +162,10 @@ class Enqueue_Blocks extends Assets {
 
     \wp_register_script(
       $handler,
-      $this->manifest->get_assets_manifest_item( 'applicationBlocks.js' ),
+      $this->manifest->get_assets_manifest_item( static::BLOCKS_SCRIPT_URI ),
       $this->get_frontend_script_dependencies(),
       $this->config::get_project_version(),
-      true
+      $this->script_in_footer()
     );
 
     \wp_enqueue_script( $handler );

--- a/src/enqueue/class-enqueue-theme.php
+++ b/src/enqueue/class-enqueue-theme.php
@@ -18,7 +18,7 @@ use Eightshift_Libs\Core\Config_Data;
  *
  * @since 2.0.0
  */
-class Enqueue_Theme implements Service {
+class Enqueue_Theme extends Assets {
 
   /**
    * Instance variable of project config data.
@@ -64,50 +64,52 @@ class Enqueue_Theme implements Service {
   }
 
   /**
-   * Register the Stylesheets for the theme area.
+   * Register the Stylesheets for the front end of the theme.
    *
    * @return void
    *
    * @since 2.0.0
+   * @since 2.0.3 Added methods for overrides.
+   *              Fixed static calls from config class.
    */
   public function enqueue_styles() {
-    $handler = "{$this->config->get_project_prefix()}-theme-styles";
+    $handle = "{$this->config::get_project_prefix()}-theme-styles";
 
     \wp_register_style(
-      $handler,
+      $handle,
       $this->manifest->get_assets_manifest_item( 'application.css' ),
-      [],
-      $this->config->get_project_version()
+      $this->get_frontend_style_dependencies(),
+      $this->config::get_project_version(),
+      $this->get_media()
     );
-    \wp_enqueue_style( $handler );
+
+    \wp_enqueue_style( $handle );
   }
 
   /**
-   * Register the JavaScript for the theme area.
+   * Register the JavaScript for the front end of the theme.
    *
    * @return void
    *
    * @since 2.0.0
+   * @since 2.0.3 Added methods for overrides.
+   *              Fixed static calls from config class.
    */
   public function enqueue_scripts() {
-    $handler = "{$this->config->get_project_prefix()}-scripts";
+    $handle = "{$this->config::get_project_prefix()}-scripts";
 
     \wp_register_script(
-      $handler,
+      $handle,
       $this->manifest->get_assets_manifest_item( 'application.js' ),
-      [],
-      $this->config->get_project_version(),
+      $this->get_frontend_script_dependencies(),
+      $this->config::get_project_version(),
       true
     );
-    \wp_enqueue_script( $handler );
 
-    // Global variables for ajax and translations.
-    \wp_localize_script(
-      $handler,
-      'projectLocalization',
-      [
-        'ajaxurl' => \admin_url( 'admin-ajax.php' ),
-      ]
-    );
+    \wp_enqueue_script( $handle );
+
+    foreach ( $this->get_localizations() as $object_name => $data_array ) {
+      \wp_localize_script( $handle, $object_name, $data_array );
+    }
   }
 }

--- a/src/enqueue/class-enqueue-theme.php
+++ b/src/enqueue/class-enqueue-theme.php
@@ -20,6 +20,11 @@ use Eightshift_Libs\Core\Config_Data;
  */
 class Enqueue_Theme extends Assets {
 
+  const IN_FOOTER = true;
+
+  const THEME_SCRIPT_URI = 'application.js';
+  const THEME_STYLE_URI  = 'application.css';
+
   /**
    * Instance variable of project config data.
    *
@@ -77,7 +82,7 @@ class Enqueue_Theme extends Assets {
 
     \wp_register_style(
       $handle,
-      $this->manifest->get_assets_manifest_item( 'application.css' ),
+      $this->manifest->get_assets_manifest_item( static::THEME_STYLE_URI ),
       $this->get_frontend_style_dependencies(),
       $this->config::get_project_version(),
       $this->get_media()
@@ -100,10 +105,10 @@ class Enqueue_Theme extends Assets {
 
     \wp_register_script(
       $handle,
-      $this->manifest->get_assets_manifest_item( 'application.js' ),
+      $this->manifest->get_assets_manifest_item( static::THEME_SCRIPT_URI ),
       $this->get_frontend_script_dependencies(),
       $this->config::get_project_version(),
-      true
+      $this->script_in_footer()
     );
 
     \wp_enqueue_script( $handle );


### PR DESCRIPTION
I've added an abstract class to avoid repeating the method calls for dependencies. Also, config interface has static methods so the handle names and other config related methods had to be changed into static calls.

This PR should enable people to add additional handlers in their enqueue classes with something like:

```php
use Eightshift_Libs\Enqueue\Enqueue_Admin;

class My_Enqeueue extends Enqueue_Admin {
  public function enqueue_scripts() {
    parent::enqueue_scripts();

    // Enqueue additional scripts?
  }

  protected function get_admin_script_dependencies() {
    return [ 'wp-pointer', 'jquery-ui-sortable' ];
  }

  protected function get_localizations() {
    return [
      'randomStuff' => esc_html__( 'Hi!', 'text-domain' );
    ];
  }
}
```

Feel free to test before approving this 😄 