### PR TITLE
Add method for fetching DI container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 
-_No documentation available about unreleased changes as of yet._
+* Added build_di_container() method to class Main
 
 ## [2.0.7] - 2020-01-29
 

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -90,6 +90,18 @@ abstract class Main implements Service {
   }
 
   /**
+   * Returns the DI container and allow it to be used in different context (for example in tests outside of WP environment)
+   *
+   * @return object
+   */
+  public function build_di_container() {
+    if ( empty( $this->container ) ) {
+      $this->container = $this->get_di_container($this->get_service_classes_prepared_array());
+    }
+    return $this->container;
+  }
+
+  /**
    * Return array of services with Dependency Injection parameters.
    *
    * @return array


### PR DESCRIPTION
Changelog
---
* Added `build_di_container()` method to class Main allowing the container to be used outside of WP environment (for example to inject built objects into test cases)