### PR TITLE
adding block-attributes-override filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 
-* Added build_di_container() method to class Main
-* Added class-components.php helper class for easier component rendering
+### Added
+* class-main.php - Added build_di_container() method.
+* class-components.php - Added helper class for easier component rendering.
+* class-blocks.php - Added custom filter `block-attributes-override` to be able to override attributes depending on the post type.
+* class-invalid-block.php - Fixed error msg.
 
 ## [2.0.7] - 2020-01-29
 

--- a/composer.lock
+++ b/composer.lock
@@ -310,16 +310,16 @@
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4"
+                "reference": "16ec91cb06998b609501b55b7177b7d7c02badb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
-                "reference": "53dd1cdf3cb986893ccf2b96665b25b3abb384f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/16ec91cb06998b609501b55b7177b7d7c02badb3",
+                "reference": "16ec91cb06998b609501b55b7177b7d7c02badb3",
                 "shasum": ""
             },
             "require": {
@@ -329,7 +329,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -362,20 +362,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         },
         {
             "name": "symfony/polyfill-util",
-            "version": "v1.13.1",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f"
+                "reference": "ba3cfcea6d0192cae46c62041f61cbb704b526d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/964a67f293b66b95883a5ed918a65354fcd2258f",
-                "reference": "964a67f293b66b95883a5ed918a65354fcd2258f",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/ba3cfcea6d0192cae46c62041f61cbb704b526d3",
+                "reference": "ba3cfcea6d0192cae46c62041f61cbb704b526d3",
                 "shasum": ""
             },
             "require": {
@@ -384,7 +384,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13-dev"
+                    "dev-master": "1.14-dev"
                 }
             },
             "autoload": {
@@ -414,7 +414,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2019-11-27T13:56:44+00:00"
+            "time": "2020-01-13T11:15:53+00:00"
         }
     ],
     "packages-dev": [
@@ -704,16 +704,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.3",
+            "version": "3.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
+                "reference": "dceec07328401de6211037abbb18bda423677e26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
-                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
+                "reference": "dceec07328401de6211037abbb18bda423677e26",
                 "shasum": ""
             },
             "require": {
@@ -751,20 +751,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-12-04T04:46:47+00:00"
+            "time": "2020-01-30T22:20:29+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a"
+                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f90e8692ce97b693633db7ab20bfa78d930f536a",
-                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b5a453203114cc2284b1a614c4953456fbe4f546",
+                "reference": "b5a453203114cc2284b1a614c4953456fbe4f546",
                 "shasum": ""
             },
             "require": {
@@ -772,12 +772,12 @@
                 "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -796,7 +796,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-11-11T12:34:03+00:00"
+            "time": "2020-02-04T02:52:06+00:00"
         }
     ],
     "aliases": [],

--- a/src/blocks/class-blocks.php
+++ b/src/blocks/class-blocks.php
@@ -50,6 +50,15 @@ class Blocks implements Service, Renderable_Block {
   const BLOCK_VIEW_FILTER_NAME = 'block-view-data';
 
   /**
+   * Block attributes override filter name constant.
+   *
+   * @var string
+   *
+   * @since 2.0.0
+   */
+  const BLOCK_ATTRIBUTES_FILTER_NAME = 'block-attributes-override';
+
+  /**
    * Create a new instance that injects config data to get project specific details.
    *
    * @param Config_Data $config Inject config which holds data regarding project details.
@@ -479,14 +488,24 @@ class Blocks implements Service, Renderable_Block {
       ),
     ];
 
-    $block_attributes        = $block_details['attributes'];
-    $block_shared_attributes = ( $block_details['hasWrapper'] === true ) ? $this->blocks['wrapper']['attributes'] : [];
+    $block_attributes         = $block_details['attributes'];
+    $block_wrapper_attributes = ( $block_details['hasWrapper'] === true ) ? $this->blocks['wrapper']['attributes'] : [];
 
-    return array_merge(
+    $output = array_merge(
       $default_attributes,
-      $block_attributes,
-      $block_shared_attributes
+      $block_wrapper_attributes,
+      $block_attributes
     );
+
+    $filter_name = $this->config->get_config( static::BLOCK_ATTRIBUTES_FILTER_NAME );
+
+    if ( has_filter( $filter_name ) ) {
+      $override_attributes = apply_filters( $filter_name, $output );
+
+      $output = array_merge( $output, $override_attributes );
+    }
+
+    return $output;
   }
 
   /**

--- a/src/exception/class-invalid-block.php
+++ b/src/exception/class-invalid-block.php
@@ -118,7 +118,7 @@ class Invalid_Block extends \InvalidArgumentException implements General_Excepti
   public static function missing_wrapper_manifest_exception( string $settings_manifest_path ) {
     return new static(
       sprintf(
-        esc_html__( 'Global blocks settings manifest.json is missing on this location: %s.', 'eightshift-libs' ),
+        esc_html__( 'Wrapper blocks settings manifest.json is missing on this location: %s.', 'eightshift-libs' ),
         $settings_manifest_path
       )
     );


### PR DESCRIPTION
* class-blocks.php - Added custom filter `block-attributes-override` to be able to override attributes depending on the post type.
* class-invalid-block.php - Fixed error msg.

Usage:
In project>src>blocks>class-blocks.php add filter

```php
  /**
   * Register all the hooks
   *
   * @since 1.0.0
   *
   * @return void
   */
  public function register() {
    parent::register();

    add_filter( $this->config->get_config( static::BLOCK_ATTRIBUTES_FILTER_NAME ), [ $this, 'override_wrapper' ] );
  }

  /**
   * Override wrapper on all blocks.
   *
   * @param array $attr Array of blocks details.
   * @return array
   */
  public function override_wrapper ( $attr ) : array {

    $attr['styleBackgroundColor']['default'] = 'black';

    return $attr;
  }
```