### PR TITLE
Added block manifest registration

### DIFF
--- a/src/blocks/class-blocks.php
+++ b/src/blocks/class-blocks.php
@@ -109,10 +109,13 @@ class Blocks implements Service, Renderable_Block {
   
       $blocks = array_map(
         function( $block ) use ( $settings ) {
-  
+
           // Add additional data to the block settings.
-          $block['namespace']     = $settings['namespace'];
-          $block['blockFullName'] = "{$settings['namespace']}/{$block['blockName']}";
+          $namespace = $block['namespace'] ?? '';
+
+          // Check if namespace is defined in block or in global manifest settings.
+          $block['namespace']     = ! empty( $namespace ) ? $namespace : $settings['namespace'];
+          $block['blockFullName'] = "{$block['namespace']}/{$block['blockName']}";
   
           return $block;
         },


### PR DESCRIPTION
Added block manifest registration ability to register blocks in different namespace than global settings.

By default all blocks take namespace from global namespace but now you can provide namespace in each block and it will take that as default.

This is in combination with PR on the Eightshift-Frontend-Libs (https://github.com/infinum/eightshift-frontend-libs/pull/84)