### PR TITLE
Removed dependency from the enqueue classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 
+### Changed
+* Removed config dependency from the Asset classes and exposed config through Manifest. 
+
 ## [2.1.1] - 2020-03-05
 
 ### Fixed

--- a/src/enqueue/class-enqueue-admin.php
+++ b/src/enqueue/class-enqueue-admin.php
@@ -25,15 +25,6 @@ class Enqueue_Admin extends Assets {
   const ADMIN_STYLE_URI  = 'applicationAdmin.css';
 
   /**
-   * Instance variable of project config data.
-   *
-   * @var object
-   *
-   * @since 2.0.0
-   */
-  protected $config;
-
-  /**
    * Instance variable of manifest data.
    *
    * @var object
@@ -45,23 +36,21 @@ class Enqueue_Admin extends Assets {
   /**
    * Create a new admin instance.
    *
-   * @param Config_Data   $config Inject config which holds data regarding project details.
    * @param Manifest_Data $manifest Inject manifest which holds data about assets from manifest.json.
    *
    * @since 2.0.0 Adding Config as a new DI.
-   * @since 2.0.0
+   * @since 2.2.0 removed Config from the dependency.
    */
-  public function __construct( Config_Data $config, Manifest_Data $manifest ) {
-    $this->config   = $config;
+  public function __construct( Manifest_Data $manifest ) {
     $this->manifest = $manifest;
   }
 
   /**
    * Register all the hooks
    *
-   * @return void
-   *
    * @since 2.0.0
+   *
+   * @return void
    */
   public function register() {
     add_action( 'login_enqueue_scripts', [ $this, 'enqueue_styles' ] );
@@ -72,20 +61,21 @@ class Enqueue_Admin extends Assets {
   /**
    * Register the Stylesheets for the admin area.
    *
-   * @return void
-   *
    * @since 2.0.0
    * @since 2.0.3 Added methods for overrides.
    *              Fixed static calls from config class.
+   * @since 2.2.0 Removed config dependency.
+   *
+   * @return void
    */
   public function enqueue_styles() {
-    $handle = "{$this->config::get_project_prefix()}-styles";
+    $handle = "{$this->manifest->get_config()->get_project_prefix()}-styles";
 
     \wp_register_style(
       $handle,
       $this->manifest->get_assets_manifest_item( static::ADMIN_STYLE_URI ),
       $this->get_admin_style_dependencies(),
-      $this->config::get_project_version(),
+      $this->manifest->get_config()->get_project_version(),
       $this->get_media()
     );
 
@@ -96,20 +86,21 @@ class Enqueue_Admin extends Assets {
   /**
    * Register the JavaScript for the admin area.
    *
-   * @return void
-   *
    * @since 2.0.0
    * @since 2.0.3 Added methods for overrides.
    *              Fixed static calls from config class.
+   * @since 2.2.0 Removed config dependency.
+   *
+   * @return void
    */
   public function enqueue_scripts() {
-    $handle = "{$this->config::get_project_prefix()}-scripts";
+    $handle = "{$this->manifest->get_config()->get_project_prefix()}-scripts";
 
     \wp_register_script(
       $handle,
       $this->manifest->get_assets_manifest_item( static::ADMIN_SCRIPT_URI ),
       $this->get_admin_script_dependencies(),
-      $this->config::get_project_version(),
+      $this->manifest->get_config()->get_project_version(),
       $this->script_in_footer()
     );
 

--- a/src/enqueue/class-enqueue-blocks.php
+++ b/src/enqueue/class-enqueue-blocks.php
@@ -26,15 +26,6 @@ class Enqueue_Blocks extends Assets {
   const BLOCKS_SCRIPT_URI = 'applicationBlocks.js';
 
   /**
-   * Instance variable of project config data.
-   *
-   * @var object
-   *
-   * @since 2.0.0
-   */
-  protected $config;
-
-  /**
    * Instance variable of manifest data.
    *
    * @var object
@@ -46,14 +37,12 @@ class Enqueue_Blocks extends Assets {
   /**
    * Create a new admin instance.
    *
-   * @param Config_Data   $config Inject config which holds data regarding project details.
    * @param Manifest_Data $manifest Inject manifest which holds data about assets from manifest.json.
    *
    * @since 2.0.0 Adding Config as a new DI.
-   * @since 2.0.0
+   * @since 2.2.0 removed Config from the dependency.
    */
-  public function __construct( Config_Data $config, Manifest_Data $manifest ) {
-    $this->config   = $config;
+  public function __construct( Manifest_Data $manifest ) {
     $this->manifest = $manifest;
   }
 
@@ -83,17 +72,18 @@ class Enqueue_Blocks extends Assets {
    * @since 1.0.0
    * @since 2.0.3 Added methods for overrides.
    *              Fixed static calls from config class.
+   * @since 2.2.0 Removed config dependency.
    *
    * @return void
    */
   public function enqueue_block_editor_script() {
-    $handler = "{$this->config::get_project_prefix()}-block-editor-scripts";
+    $handler = "{$this->manifest->get_config()->get_project_prefix()}-block-editor-scripts";
 
     \wp_register_script(
       $handler,
       $this->manifest->get_assets_manifest_item( static::BLOCKS_EDITOR_SCRIPT_URI ),
       $this->get_admin_script_dependencies(),
-      $this->config::get_project_version(),
+      $this->manifest->get_config()->get_project_version(),
       $this->script_in_footer()
     );
     \wp_enqueue_script( $handler );
@@ -105,17 +95,18 @@ class Enqueue_Blocks extends Assets {
    * @since 1.0.0
    * @since 2.0.3 Added methods for overrides.
    *              Fixed static calls from config class.
+   * @since 2.2.0 Removed config dependency.
    *
    * @return void
    */
   public function enqueue_block_editor_style() {
-    $handler = "{$this->config::get_project_prefix()}-block-editor-style";
+    $handler = "{$this->manifest->get_config()->get_project_prefix()}-block-editor-style";
 
     \wp_register_style(
       $handler,
       $this->manifest->get_assets_manifest_item( static::BLOCKS_EDITOR_STYLE_URI ),
       $this->get_admin_style_dependencies(),
-      $this->config::get_project_version(),
+      $this->manifest->get_config()->get_project_version(),
       $this->get_media()
     );
 
@@ -128,17 +119,18 @@ class Enqueue_Blocks extends Assets {
    * @since 1.0.0
    * @since 2.0.3 Added methods for overrides.
    *              Fixed static calls from config class.
+   * @since 2.2.0 Removed config dependency.
    *
    * @return void
    */
   public function enqueue_block_style() {
-    $handler = "{$this->config::get_project_prefix()}-block-style";
+    $handler = "{$this->manifest->get_config()->get_project_prefix()}-block-style";
 
     \wp_register_style(
       $handler,
       $this->manifest->get_assets_manifest_item( static::BLOCKS_STYLE_URI ),
       $this->get_frontend_style_dependencies(),
-      $this->config::get_project_version(),
+      $this->manifest->get_config()->get_project_version(),
       $this->get_media()
     );
 
@@ -151,17 +143,18 @@ class Enqueue_Blocks extends Assets {
    * @since 1.0.0
    * @since 2.0.3 Added methods for overrides.
    *              Fixed static calls from config class.
+   * @since 2.2.0 Removed config dependency.
    *
    * @return void
    */
   public function enqueue_block_script() {
-    $handler = "{$this->config::get_project_prefix()}-block-scripts";
+    $handler = "{$this->manifest->get_config()->get_project_prefix()}-block-scripts";
 
     \wp_register_script(
       $handler,
       $this->manifest->get_assets_manifest_item( static::BLOCKS_SCRIPT_URI ),
       $this->get_frontend_script_dependencies(),
-      $this->config::get_project_version(),
+      $this->manifest->get_config()->get_project_version(),
       $this->script_in_footer()
     );
 
@@ -176,9 +169,10 @@ class Enqueue_Blocks extends Assets {
    * @return array List of all the style dependencies.
    *
    * @since 2.0.3
+   * @since 2.2.0 Removed config dependency.
    */
   protected function get_admin_style_dependencies() : array {
-    return [ "{$this->config::get_project_prefix()}-block-style" ];
+    return [ "{$this->manifest->get_config()->get_project_prefix()}-block-style" ];
   }
 
     /**

--- a/src/enqueue/class-enqueue-theme.php
+++ b/src/enqueue/class-enqueue-theme.php
@@ -23,15 +23,6 @@ class Enqueue_Theme extends Assets {
   const THEME_STYLE_URI  = 'application.css';
 
   /**
-   * Instance variable of project config data.
-   *
-   * @var object
-   *
-   * @since 2.0.0
-   */
-  protected $config;
-
-  /**
    * Instance variable of manifest data.
    *
    * @var object
@@ -43,22 +34,21 @@ class Enqueue_Theme extends Assets {
   /**
    * Create a new admin instance.
    *
-   * @param Config_Data   $config Inject config which holds data regarding project details.
    * @param Manifest_Data $manifest Inject manifest which holds data about assets from manifest.json.
    *
    * @since 2.0.0
+   * @since 2.2.0 removed Config from the dependency.
    */
-  public function __construct( Config_Data $config, Manifest_Data $manifest ) {
-    $this->config   = $config;
+  public function __construct( Manifest_Data $manifest ) {
     $this->manifest = $manifest;
   }
 
   /**
    * Register all the hooks
    *
-   * @return void
-   *
    * @since 2.0.0
+   *
+   * @return void
    */
   public function register() {
     add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_styles' ], 10 );
@@ -68,20 +58,21 @@ class Enqueue_Theme extends Assets {
   /**
    * Register the Stylesheets for the front end of the theme.
    *
-   * @return void
-   *
    * @since 2.0.0
    * @since 2.0.3 Added methods for overrides.
    *              Fixed static calls from config class.
+   * @since 2.2.0 Removed config dependency.
+   *
+   * @return void
    */
   public function enqueue_styles() {
-    $handle = "{$this->config::get_project_prefix()}-theme-styles";
+    $handle = "{$this->manifest->get_config()->get_project_prefix()}-theme-styles";
 
     \wp_register_style(
       $handle,
       $this->manifest->get_assets_manifest_item( static::THEME_STYLE_URI ),
       $this->get_frontend_style_dependencies(),
-      $this->config::get_project_version(),
+      $this->manifest->get_config()->get_project_version(),
       $this->get_media()
     );
 
@@ -91,20 +82,21 @@ class Enqueue_Theme extends Assets {
   /**
    * Register the JavaScript for the front end of the theme.
    *
-   * @return void
-   *
    * @since 2.0.0
    * @since 2.0.3 Added methods for overrides.
    *              Fixed static calls from config class.
+   * @since 2.2.0 Removed config dependency.
+   *
+   * @return void
    */
   public function enqueue_scripts() {
-    $handle = "{$this->config::get_project_prefix()}-scripts";
+    $handle = "{$this->manifest->get_config()->get_project_prefix()}-scripts";
 
     \wp_register_script(
       $handle,
       $this->manifest->get_assets_manifest_item( static::THEME_SCRIPT_URI ),
       $this->get_frontend_script_dependencies(),
-      $this->config::get_project_version(),
+      $this->manifest->get_config()->get_project_version(),
       $this->script_in_footer()
     );
 

--- a/src/manifest/class-manifest.php
+++ b/src/manifest/class-manifest.php
@@ -27,6 +27,15 @@ use Eightshift_Libs\Core\Config_Data;
 class Manifest implements Service, Manifest_Data {
 
   /**
+   * Manifest item filter name constant.
+   *
+   * @var string
+   *
+   * @since 0.9.0 Init.
+   */
+  const MANIFEST_ITEM_FILTER_NAME = 'manifest-item';
+
+  /**
    * Instance variable of project config data.
    *
    * @var object
@@ -52,27 +61,18 @@ class Manifest implements Service, Manifest_Data {
    * @since 2.0.0
    */
   public function __construct( Config_Data $config ) {
-      $this->config = $config;
+    $this->config = $config;
   }
 
   /**
-   * Manifest item filter name constant.
-   *
-   * @var string
-   *
-   * @since 0.9.0 Init.
-   */
-  const MANIFEST_ITEM_FILTER_NAME = 'manifest-item';
-
-  /**
    * Register all hooks.
-   *
-   * @return void
    *
    * @since 2.0.0 Changed filter name to manifest.
    * @since 0.9.0 Adding manifest item filter.
    * @since 0.8.0 Removing type hinting void for php 7.0.
    * @since 0.6.0 Init.
+   *
+   * @return void
    */
   public function register() {
     add_action( 'init', [ $this, 'get_assets_manifest_raw' ] );
@@ -85,9 +85,9 @@ class Manifest implements Service, Manifest_Data {
    *
    * @throws Exception\Invalid_Manifest Throws error if manifest.json file is missing.
    *
-   * @return array
-   *
    * @since 2.0.0
+   *
+   * @return array
    */
   public function get_assets_manifest_raw() {
     $path = $this->config->get_project_path() . '/public/manifest.json';
@@ -116,11 +116,11 @@ class Manifest implements Service, Manifest_Data {
    *
    * @throws Exception\Invalid_Manifest Throws error if manifest key is missing.
    *
-   * @return string Full path to asset.
-   *
    * @since 2.0.0 Returned data from manifest and not global variable.
    * @since 0.7.0 Changed to non static method and added Exception for missing key.
    * @since 0.6.0 Init
+   *
+   * @return string Full path to asset.
    */
   public function get_assets_manifest_item( string $key ) : string {
     $manifest = $this->manifest;
@@ -133,11 +133,22 @@ class Manifest implements Service, Manifest_Data {
   }
 
   /**
+   * Config getter
+   *
+   * @since 2.2.0 Added config getter.
+   *
+   * @return Config_Data|object
+   */
+  public function get_config() {
+  	return $this->config;
+  }
+
+  /**
    * This method appends full site url to the relative manifest data item.
    *
-   * @return string
-   *
    * @since 0.6.0
+   *
+   * @return string
    */
   protected function get_assets_manifest_output_prefix() : string {
     return site_url();


### PR DESCRIPTION
Added `get_config` getter in the manifest class, so the config is exposed from the manifest.

This PR addresses the https://github.com/infinum/eightshift-boilerplate/issues/201 issue.

