### PR TITLE
Add editor-color-pallete in libs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ### Changed
 * Removed config dependency from the Asset classes and exposed config through Manifest. 
+* `editor-color-pallete` - Add theme support for editor color pallete.
 
 ## [2.1.1] - 2020-03-05
 

--- a/src/blocks/class-blocks.php
+++ b/src/blocks/class-blocks.php
@@ -108,7 +108,7 @@ class Blocks implements Service, Renderable_Block {
       array(
         'name' => esc_html__( 'Primary', 'eightshift-libs' ),
         'slug' => 'primary',
-        'color' => '#FF86D6',
+        'color' => '#C3151B',
       ),
     ) );
   }

--- a/src/blocks/class-blocks.php
+++ b/src/blocks/class-blocks.php
@@ -95,6 +95,12 @@ class Blocks implements Service, Renderable_Block {
 
   /**
    * Changes the default Gutenberg color pallete. Add your colors below.
+   * 
+   * !IMPORTANT - Regarding Eightshift custom blocks:
+   * - Color (when selected) should be added as element's modifier class like so:
+   *   block-class--white
+   * - You need an perform an additional step of styling (coloring) your attribute
+   *   based on color's slug class modifier in the block's `block-style.scss`
    *
    * @return void
    */

--- a/src/blocks/class-blocks.php
+++ b/src/blocks/class-blocks.php
@@ -89,6 +89,28 @@ class Blocks implements Service, Renderable_Block {
     add_filter( 'block_categories', [ $this, 'get_custom_category' ] );
 
     add_action( 'after_setup_theme', [ $this, 'add_theme_support' ], 25 );
+
+    add_action( 'after_setup_theme', [ $this, 'change_editor_color_pallete' ], 11 );
+  }
+
+  /**
+   * Changes the default Gutenberg color pallete. Add your colors below.
+   *
+   * @return void
+   */
+  public function change_editor_color_pallete() {
+    add_theme_support( 'editor-color-palette', array(
+      array(
+        'name' => esc_html__( 'mine', 'eightshift-libs' ),
+        'slug' => 'mine',
+        'color' => '#333333',
+      ),
+      array(
+        'name' => esc_html__( 'Primary', 'eightshift-libs' ),
+        'slug' => 'primary',
+        'color' => '#FF86D6',
+      ),
+    ) );
   }
 
   /**


### PR DESCRIPTION
Changelog
---
* Add theme support for editor color pallete.

Should be merged along with (or before) https://github.com/infinum/eightshift-frontend-libs/pull/99