### PR TITLE
Add public get colors function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 
+- Returns all colors from settings
+
 ### Changed
 
 - Made get_service_classes_prepared_array() more flat.

--- a/src/blocks/class-blocks.php
+++ b/src/blocks/class-blocks.php
@@ -101,11 +101,20 @@ class Blocks implements Service, Renderable_Block {
    */
   public function change_editor_color_palette() {
 
-    $colors = $this->get_settings()['globalVariables']['colors'] ?? [];
+    $colors = $this->get_colors_from_settings();
 
     if ( $colors ) {
       \add_theme_support( 'editor-color-palette', $colors );
     }
+  }
+
+  /**
+   * Function to read and return all colors as defined in block global settings
+   *
+   * @return array
+   */
+  public function get_colors_from_settings() {
+    return $this->get_settings()['globalVariables']['colors'] ?? [];
   }
 
   /**


### PR DESCRIPTION
Add a way to read colors from manifest inside PHP - for example if you need to define a custom page background color select in ACF. (You still then have a dependancy on `class-blocks.php` ideally these would be exposed as static functions but IMO it's good enough for now).