### PR TITLE
Fix phpstan issues

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,10 +5,17 @@ parameters:
     level: max
     inferPrivatePropertyTypeFromConstructor: true
     checkMissingIterableValueType: false
+    treatPhpDocTypesAsCertain: false
     paths:
         - src/
     excludes_analyse:
         - src/Core/CompiledContainer.php
+        - src/menu/class-bem-menu-walker.php
     autoload_files:
         - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
     ignoreErrors:
+        - '#Call to an undefined method [a-zA-Z0-9\\_]+::get\(\)#'
+        - '#Call to an undefined method [a-zA-Z0-9\\_]+::get_config\(\)#'
+        - '#Call to an undefined method [a-zA-Z0-9\\_]+::get_project_path\(\)#'
+        - '#Call to an undefined method [a-zA-Z0-9\\_]+::get_assets_manifest_item\(\)#'
+        - '#Call to an undefined method [a-zA-Z0-9\\_]+::get_project_name\(\)#'

--- a/src/blocks/class-blocks.php
+++ b/src/blocks/class-blocks.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Class Blocks holds base class for Gutenberg blocks registration.
- * It provides ability to register custom blocks using manifest.json setup.
+ * Class Blocks is the base class for Gutenberg blocks registration.
+ * It provides the ability to register custom blocks using manifest.json.
  *
  * @package Eightshift_Libs\Blocks
  */
@@ -191,7 +191,7 @@ class Blocks implements Service, Renderable_Block {
   /**
    * Method used to register all custom blocks with data fetched from blocks manifest.json.
    *
-   * @throws Exception\Invalid_Block Throws error if blocks are missing.
+   * @throws Invalid_Block Throws error if blocks are missing.
    *
    * @return void
    *
@@ -242,8 +242,8 @@ class Blocks implements Service, Renderable_Block {
    * @param array  $attributes          Array of attributes as defined in block's manifest.json.
    * @param string $inner_block_content Block's content if using inner blocks.
    *
-   * @throws Exception\Invalid_Block Throws error if block wrapper view is missing.
-   * @throws Exception\Invalid_Block Throws error if block view is missing.
+   * @throws Invalid_Block Throws error if block wrapper view is missing.
+   * @throws Invalid_Block Throws error if block view is missing.
    *
    * @return string Html template for block.
    *
@@ -260,7 +260,7 @@ class Blocks implements Service, Renderable_Block {
     // Get block wrapper view path.
     $wrapper_path = "{$this->get_wrapper_path()}/wrapper.php";
 
-    // Check if wrapper componet exists.
+    // Check if wrapper component exists.
     if ( ! file_exists( $wrapper_path ) ) {
       throw Invalid_Block::missing_wrapper_view_exception( $wrapper_path );
     }
@@ -275,7 +275,7 @@ class Blocks implements Service, Renderable_Block {
     include $wrapper_path;
     $output = ob_get_clean();
     unset( $block_name, $template_path, $wrapper_path, $attributes, $inner_block_content );
-    return $output;
+    return (string) $output;
   }
 
   /**
@@ -285,7 +285,7 @@ class Blocks implements Service, Renderable_Block {
    * @param array  $attributes          Array of attributes as defined in block's manifest.json.
    * @param string $inner_block_content Block's content if using inner blocks.
    *
-   * @throws Exception\Invalid_Block Throws error if block view is missing.
+   * @throws Invalid_Block Throws error if block view is missing.
    *
    * @return string Html template for block.
    *
@@ -316,7 +316,7 @@ class Blocks implements Service, Renderable_Block {
     include $template_path;
     $output = ob_get_clean();
     unset( $block_name, $template_path, $attributes, $inner_block_content, $custom_data );
-    return $output;
+    return (string) $output;
   }
 
 
@@ -350,11 +350,13 @@ class Blocks implements Service, Renderable_Block {
    * @param array  $attributes           Attributes array to pass in template.
    * @param string $inner_block_content If using inner blocks content pass the data.
    *
-   * @throws Exception\Invalid_Block Throws error if wrapper view template is missing.
+   * @return void Includes an HTML view, or throws an error if the view is missing.
+   *
+   * @throws Invalid_Block Throws error if wrapper view template is missing.
    *
    * @since 2.0.0
    */
-  public function render_wrapper_view( string $src, array $attributes, $inner_block_content = null ) {
+  public function render_wrapper_view( string $src, array $attributes, $inner_block_content = null ) : void {
     if ( ! file_exists( $src ) ) {
       throw Invalid_Block::missing_wrapper_view_exception( $src );
     }
@@ -371,11 +373,13 @@ class Blocks implements Service, Renderable_Block {
    * @param array  $attributes           Attributes array to pass in template.
    * @param string $inner_block_content If using inner blocks content pass the data.
    *
-   * @throws Exception\Invalid_Block Throws error if render block view is missing.
+   * @return void Includes an HTML view, or throws an error if the view is missing.
+   *
+   * @throws Invalid_Block Throws error if render block view is missing.
    *
    * @since 2.0.0
    */
-  public function render_block_view( string $src, array $attributes, $inner_block_content = null ) {
+  public function render_block_view( string $src, array $attributes, $inner_block_content = null ) : void {
     $path = $this->get_blocks_path() . $src;
 
     if ( ! file_exists( $path ) ) {
@@ -436,7 +440,7 @@ class Blocks implements Service, Renderable_Block {
   /**
    * Get wrapper manifest data from wrapper manifest.json file.
    *
-   * @throws Exception\Invalid_Block Throws error if wrapper settings manifest.json is missing.
+   * @throws Invalid_Block Throws error if wrapper settings manifest.json is missing.
    *
    * @return array
    *
@@ -449,7 +453,7 @@ class Blocks implements Service, Renderable_Block {
       throw Invalid_Block::missing_wrapper_manifest_exception( $manifest_path );
     }
 
-    $settings = implode( ' ', file( ( $manifest_path ) ) );
+    $settings = implode( ' ', (array) file( ( $manifest_path ) ) );
     $settings = json_decode( $settings, true );
 
     return $settings;
@@ -458,8 +462,8 @@ class Blocks implements Service, Renderable_Block {
   /**
    * Get blocks global settings manifest data from settings manifest.json file.
    *
-   * @throws Exception\Invalid_Block Throws error if global settings manifest.json is missing.
-   * @throws Exception\Invalid_Block Throws error if global manifest settings key namespace is missing.
+   * @throws Invalid_Block Throws error if global settings manifest.json is missing.
+   * @throws Invalid_Block Throws error if global manifest settings key namespace is missing.
    *
    * @return array
    *
@@ -472,7 +476,7 @@ class Blocks implements Service, Renderable_Block {
       throw Invalid_Block::missing_settings_manifest_exception( $manifest_path );
     }
 
-    $settings = implode( ' ', file( ( $manifest_path ) ) );
+    $settings = implode( ' ', (array) file( ( $manifest_path ) ) );
     $settings = json_decode( $settings, true );
 
     if ( ! isset( $settings['namespace'] ) ) {
@@ -541,7 +545,7 @@ class Blocks implements Service, Renderable_Block {
    * Throws error if manifest key blockName is missing.
    * You should never call this method directly.
    *
-   * @throws Exception\Invalid_Block Throws error if block name is missing.
+   * @throws Invalid_Block Throws error if block name is missing.
    *
    * @return array
    *
@@ -550,8 +554,8 @@ class Blocks implements Service, Renderable_Block {
   private function get_blocks_data() : array {
 
     return array_map(
-      function( $block_path ) {
-        $block = implode( ' ', file( ( $block_path ) ) );
+      function( string $block_path ) {
+        $block = implode( ' ', (array) file( ( $block_path ) ) );
 
         $block = $this->parse_manifest( $block );
 
@@ -577,7 +581,7 @@ class Blocks implements Service, Renderable_Block {
 
         return $block;
       },
-      glob( "{$this->get_blocks_custom_path()}/*/manifest.json" )
+      (array) glob( "{$this->get_blocks_custom_path()}/*/manifest.json" )
     );
   }
 

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -210,7 +210,7 @@ abstract class Main implements Service {
    *
    * @throws Exception\Invalid_Service If the service is not valid.
    *
-   * @return Service
+   * @return Registrable
    *
    * @since 0.1.0
    */

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -144,7 +144,7 @@ abstract class Main implements Service {
     $output = [];
 
     foreach ( $this->get_service_classes() as $class => $dependencies ) {
-      if ( is_array( $dependencies ) ) {
+      if ( is_array( $dependencies ) ) { /** @phpstan-ignore-line */
         $output[ $class ] = $dependencies;
         continue;
       }

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -144,7 +144,7 @@ abstract class Main implements Service {
     $output = [];
 
     foreach ( $this->get_service_classes() as $class => $dependencies ) {
-      if ( is_array( $dependencies ) ) { /** @phpstan-ignore-line */
+      if ( is_array( $dependencies ) ) { /** @phpstan-ignore-line phpcs:ignore */
         $output[ $class ] = $dependencies;
         continue;
       }

--- a/src/class-main.php
+++ b/src/class-main.php
@@ -144,7 +144,7 @@ abstract class Main implements Service {
     $output = [];
 
     foreach ( $this->get_service_classes() as $class => $dependencies ) {
-      if ( is_array( $dependencies ) ) { /** @phpstan-ignore-line phpcs:ignore */
+      if ( is_array( $dependencies ) ) {
         $output[ $class ] = $dependencies;
         continue;
       }
@@ -232,7 +232,7 @@ abstract class Main implements Service {
    *
    * A list of classes which contain hooks.
    *
-   * @return array<string> Array of fully qualified class names.
+   * @return array<class-string, string|string[]> Array of fully qualified service class names.
    *
    * @since 0.1.0
    */

--- a/src/exception/class-component-exception.php
+++ b/src/exception/class-component-exception.php
@@ -12,7 +12,7 @@ namespace Eightshift_Libs\Exception;
 /**
  * Class Component_Exception.
  */
-class Component_Exception extends \InvalidArgumentException implements General_Exception {
+final class Component_Exception extends \InvalidArgumentException implements General_Exception {
 
   /**
    * Throws exception if ensure_string argument is invalid.

--- a/src/exception/class-failed-to-load-view.php
+++ b/src/exception/class-failed-to-load-view.php
@@ -14,7 +14,7 @@ namespace Eightshift_Libs\Exception;
  *
  * @since 0.1.0
  */
-class Failed_To_Load_View extends \RuntimeException implements General_Exception {
+final class Failed_To_Load_View extends \RuntimeException implements General_Exception {
 
   /**
    * Create a new instance of the exception if the view file itself created

--- a/src/exception/class-invalid-block.php
+++ b/src/exception/class-invalid-block.php
@@ -24,12 +24,7 @@ final class Invalid_Block extends \InvalidArgumentException implements General_E
    * @since 2.0.0
    */
   public static function missing_blocks_exception() {
-    return new static(
-      sprintf(
-        esc_html__( 'There are no blocks added in your project.', 'eightshift-libs' ),
-        $name
-      )
-    );
+    return new static(esc_html__( 'There are no blocks added in your project.', 'eightshift-libs' ));
   }
 
   /**
@@ -151,10 +146,7 @@ final class Invalid_Block extends \InvalidArgumentException implements General_E
    */
   public static function missing_namespace_exception() {
     return new static(
-      sprintf(
-        esc_html__( 'Global Blocks settings manifest.json is missing a key called namespace. This key prefixes all block names.', 'eightshift-libs' ),
-        $name
-      )
+      esc_html__( 'Global Blocks settings manifest.json is missing a key called namespace. This key prefixes all block names.', 'eightshift-libs' )
     );
   }
 }

--- a/src/exception/class-invalid-block.php
+++ b/src/exception/class-invalid-block.php
@@ -14,7 +14,7 @@ namespace Eightshift_Libs\Exception;
  *
  * @since 2.0.0
  */
-class Invalid_Block extends \InvalidArgumentException implements General_Exception {
+final class Invalid_Block extends \InvalidArgumentException implements General_Exception {
 
   /**
    * Throws error if blocks are missing.

--- a/src/exception/class-invalid-block.php
+++ b/src/exception/class-invalid-block.php
@@ -24,7 +24,7 @@ final class Invalid_Block extends \InvalidArgumentException implements General_E
    * @since 2.0.0
    */
   public static function missing_blocks_exception() {
-    return new static(esc_html__( 'There are no blocks added in your project.', 'eightshift-libs' ));
+    return new static( esc_html__( 'There are no blocks added in your project.', 'eightshift-libs' ) );
   }
 
   /**

--- a/src/exception/class-invalid-callback.php
+++ b/src/exception/class-invalid-callback.php
@@ -14,7 +14,7 @@ namespace Eightshift_Libs\Exception;
  *
  * @since 0.1.0
  */
-class Invalid_Callback extends \InvalidArgumentException implements General_Exception {
+final class Invalid_Callback extends \InvalidArgumentException implements General_Exception {
 
   /**
    * Create a new instance of the exception for a callback class name that is

--- a/src/exception/class-invalid-manifest.php
+++ b/src/exception/class-invalid-manifest.php
@@ -14,7 +14,7 @@ namespace Eightshift_Libs\Exception;
  *
  * @since 0.1.0
  */
-class Invalid_Manifest extends \InvalidArgumentException implements General_Exception {
+final class Invalid_Manifest extends \InvalidArgumentException implements General_Exception {
 
   /**
    * Throws error if manifest key is missing.

--- a/src/exception/class-invalid-nouns.php
+++ b/src/exception/class-invalid-nouns.php
@@ -14,7 +14,7 @@ namespace Eightshift_Libs\Exception;
  *
  * @since 0.1.0
  */
-class Invalid_Nouns extends \InvalidArgumentException implements General_Exception {
+final class Invalid_Nouns extends \InvalidArgumentException implements General_Exception {
 
   /**
    * Create a new instance of the exception for an array of nouns that is

--- a/src/exception/class-invalid-service.php
+++ b/src/exception/class-invalid-service.php
@@ -14,7 +14,7 @@ namespace Eightshift_Libs\Exception;
  *
  * @since 0.1.0
  */
-class Invalid_Service extends \InvalidArgumentException implements General_Exception {
+final class Invalid_Service extends \InvalidArgumentException implements General_Exception {
 
   /**
    * Create a new instance of the exception for a service class name that is

--- a/src/exception/class-plugin-activation-failure.php
+++ b/src/exception/class-plugin-activation-failure.php
@@ -13,7 +13,7 @@ namespace Eightshift_Libs\Exception;
 /**
  * Class Plugin_Activation_Failure.
  */
-class Plugin_Activation_Failure extends \RuntimeException implements General_Exception {
+final class Plugin_Activation_Failure extends \RuntimeException implements General_Exception {
 
   /**
    * Create a new instance of the exception in case plugin cannot be activated.

--- a/src/helpers/class-components.php
+++ b/src/helpers/class-components.php
@@ -25,6 +25,8 @@ class Components {
    * @throws Component_Exception When $variable is not a string or array.
    */
   public static function ensure_string( $variable ) : string {
+    $output = '';
+
     if ( is_array( $variable ) ) {
       $output = implode( '', $variable );
     } elseif ( is_string( $variable ) ) {
@@ -88,7 +90,7 @@ class Components {
       echo '</div>';
     }
 
-    return ob_get_clean();
+    return (string) ob_get_clean();
   }
 
   /**
@@ -110,7 +112,7 @@ class Components {
     $output = [];
 
     foreach ( $items as $item_key => $item_value ) {
-      if ( empty( $item_value ) || $item_value === false ) {
+      if ( empty( $item_value ) || $item_value == false ) {
         continue;
       }
 

--- a/src/manifest/class-manifest.php
+++ b/src/manifest/class-manifest.php
@@ -75,30 +75,31 @@ class Manifest implements Service, Manifest_Data {
    * @return void
    */
   public function register() {
-    add_action( 'init', [ $this, 'get_assets_manifest_raw' ] );
+    add_action( 'init', [ $this, 'set_assets_manifest_raw' ] );
     add_filter( $this->config->get_config( static::MANIFEST_ITEM_FILTER_NAME ), [ $this, 'get_assets_manifest_item' ] );
   }
 
   /**
-   * Return full manifest data with site url prefix.
-   * You should never call this method directly insted you should call $this->manifest.
+   * Set the manifest data with site url prefix.
+   * You should never call this method directly instead you should call $this->manifest.
    *
-   * @throws Exception\Invalid_Manifest Throws error if manifest.json file is missing.
+   * @throws Invalid_Manifest Throws error if manifest.json file is missing.
+   *
+   * @return void Sets the manifest variable.
    *
    * @since 2.0.0
-   *
-   * @return array
    */
-  public function get_assets_manifest_raw() {
+  public function set_assets_manifest_raw() : void {
     $path = $this->config->get_project_path() . '/public/manifest.json';
 
     if ( ! file_exists( $path ) ) {
       throw Invalid_Manifest::missing_manifest_exception( $path );
     }
 
-    $data = json_decode( implode( ' ', file( $path ) ), true );
+    $data = json_decode( implode( ' ', (array) file( $path ) ), true );
+
     if ( empty( $data ) ) {
-      return [];
+      return;
     }
 
     $this->manifest = array_map(
@@ -114,7 +115,7 @@ class Manifest implements Service, Manifest_Data {
    *
    * @param string $key File name key you want to get from manifest.
    *
-   * @throws Exception\Invalid_Manifest Throws error if manifest key is missing.
+   * @throws Invalid_Manifest Throws error if manifest key is missing.
    *
    * @since 2.0.0 Returned data from manifest and not global variable.
    * @since 0.7.0 Changed to non static method and added Exception for missing key.

--- a/src/menu/class-bem-menu-walker.php
+++ b/src/menu/class-bem-menu-walker.php
@@ -18,15 +18,24 @@ namespace Eightshift_Libs\Menu;
  */
 class Bem_Menu_Walker extends \Walker_Nav_Menu {
   /**
+   * CSS class prefix string - unique for a theme.
+   *
    * @var string
    */
   public $css_class_prefix;
 
   /**
+   * Menu item CSS suffixes.
+   *
    * @var string[]
    */
   public $item_css_class_suffixes;
 
+  /**
+   * Database fields to use.
+   *
+   * @var array
+   */
   public $db_fields;
 
   /**

--- a/src/menu/class-bem-menu-walker.php
+++ b/src/menu/class-bem-menu-walker.php
@@ -17,15 +17,26 @@ namespace Eightshift_Libs\Menu;
  * @since 1.0.0
  */
 class Bem_Menu_Walker extends \Walker_Nav_Menu {
+  /**
+   * @var string
+   */
+  public $css_class_prefix;
+
+  /**
+   * @var string[]
+   */
+  public $item_css_class_suffixes;
+
+  public $db_fields;
 
   /**
    * Constructor function
    *
-   * @param array $css_class_prefix load menu prefixes for class.
+   * @param string $css_class_prefix load menu prefix for class.
    *
    * @since 1.0.0
    */
-  public function __construct( $css_class_prefix ) {
+  public function __construct( string $css_class_prefix ) {
 
     $this->css_class_prefix = $css_class_prefix;
 
@@ -43,16 +54,16 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
   }
 
   /**
-   * Dispaly element for wlaker
+   * Display element for walker
    *
-   * @param array   $element element.
-   * @param array   $children_elements children_elements.
-   * @param array   $max_depth max_depth.
-   * @param integer $depth depth.
-   * @param array   $args args.
-   * @param array   $output output.
-   * @return element
+   * @param object $element element.
+   * @param array  $children_elements children_elements.
+   * @param int    $max_depth max_depth.
+   * @param int    $depth depth.
+   * @param array  $args args.
+   * @param string $output output.
    *
+   * @return void Parent Display element
    * @since 1.0.0
    */
   public function display_element( $element, &$children_elements, $max_depth, $depth = 0, $args, &$output ) {
@@ -63,16 +74,16 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
       $args[0]->has_children = ! empty( $children_elements[ $element->$id_field ] );
     }
 
-    return parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
-
+    parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
   }
 
   /**
    * Start level
    *
-   * @param array   $output output.
-   * @param integer $depth depth.
-   * @param array   $args args.
+   * @param string $output output.
+   * @param int    $depth depth.
+   * @param array  $args args.
+   *
    * @return void
    *
    * @since 1.0.0
@@ -100,11 +111,12 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
   /**
    * Add main/sub classes to li's and links.
    *
-   * @param array   $output output.
-   * @param array   $item item.
-   * @param integer $depth depth.
-   * @param array   $args args.
-   * @param integer $id id.
+   * @param string $output output.
+   * @param object $item item.
+   * @param int    $depth depth.
+   * @param array  $args args.
+   * @param int    $id id.
+   *
    * @return void
    *
    * @since 1.0.0
@@ -176,7 +188,7 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
     $attributes .= ! empty( $item->xfn ) ? ' rel="' . esc_attr( $item->xfn ) . '"' : '';
     $attributes .= ! empty( $item->url ) ? ' href="' . esc_attr( $item->url ) . '"' : '';
 
-    // Creatre link markup.
+    // Create link markup.
     $item_output  = $args->before;
     $item_output .= '<a' . $attributes . ' ' . $link_class_output . '><span ' . $link_text_class_output . '>';
     $item_output .= $args->link_before;

--- a/src/menu/class-menu.php
+++ b/src/menu/class-menu.php
@@ -44,7 +44,7 @@ abstract class Menu implements Service, Menu_Positions {
   }
 
   /**
-   * Return all menu poistions
+   * Return all menu positions
    *
    * @return array Of menu positions with name and slug.
    *
@@ -59,7 +59,7 @@ abstract class Menu implements Service, Menu_Positions {
    *
    * @param  string     $location            This must be the same as what is set in wp-admin/settings/menus for menu location and registrated in register_menu_positions function.
    * @param  string     $css_class_prefix    This string will prefix all of the menu's classes, BEM syntax friendly.
-   * @param  arr|string $css_class_modifiers Provide either a string or array of values to apply extra classes to the <ul> but not the <li's>.
+   * @param  string $css_class_modifiers Provide either a string or array of values to apply extra classes to the <ul> but not the <li's>.
    * @param  bool       $echo                Echo the menu.
    *
    * @return string|false|void Menu output if $echo is false, false if there are no items or no menu was found.

--- a/src/menu/class-menu.php
+++ b/src/menu/class-menu.php
@@ -57,10 +57,10 @@ abstract class Menu implements Service, Menu_Positions {
   /**
    * Bem_menu returns an instance of the Bem_Menu_Walker class with the following arguments
    *
-   * @param  string     $location            This must be the same as what is set in wp-admin/settings/menus for menu location and registrated in register_menu_positions function.
-   * @param  string     $css_class_prefix    This string will prefix all of the menu's classes, BEM syntax friendly.
+   * @param  string $location            This must be the same as what is set in wp-admin/settings/menus for menu location and registered in register_menu_positions function.
+   * @param  string $css_class_prefix    This string will prefix all of the menu's classes, BEM syntax friendly.
    * @param  string $css_class_modifiers Provide either a string or array of values to apply extra classes to the <ul> but not the <li's>.
-   * @param  bool       $echo                Echo the menu.
+   * @param  bool   $echo                Echo the menu.
    *
    * @return string|false|void Menu output if $echo is false, false if there are no items or no menu was found.
    *


### PR DESCRIPTION
I've had to exclude some checks as they are false positive. Most of the config calls are false-positive because they depend on the `Config_Data` interface, which dictates that those methods have to exist - but they will be implemented in the theme or a plugin, and there are no concrete implementations in the libs, so it says it's an error when it's not.

Walker has core inconsistencies (https://core.trac.wordpress.org/ticket/50261) that are throwing false-positives.

I've made some changes so it would be great if we test this before merging 😬 

Ideally, we'd have automated tests but I need to work on those...