### PR TITLE
Bugfix in BEM menu walker 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 ## [Unreleased]
 
+### Changed
+- `class-bem-menu-walker.php` - removed declaration of db_fields.
+
 ## [2.4.0] - 2020-07-08
 
 ### Removed

--- a/src/menu/class-bem-menu-walker.php
+++ b/src/menu/class-bem-menu-walker.php
@@ -32,13 +32,6 @@ class Bem_Menu_Walker extends \Walker_Nav_Menu {
   public $item_css_class_suffixes;
 
   /**
-   * Database fields to use.
-   *
-   * @var array
-   */
-  public $db_fields;
-
-  /**
    * Constructor function
    *
    * @param string $css_class_prefix load menu prefix for class.


### PR DESCRIPTION
I've removed the declaration and documentation of db_fields which was causing override of the variable from the parent class.

This will fix the problem of non displaying the submenus at frontend.