### PR TITLE
Fix lint issues

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,54 +1,40 @@
 <?xml version="1.0"?>
 <ruleset name="Eightshift Library">
-  <description>Eightshift Library uses extended WordPress coding standards with some minor corections. TBD</description>
+    <description>Eightshift Library uses extended WordPress coding standards with some minor corrections.</description>
 
-  <rule ref="Infinum" />
+    <rule ref="Infinum"/>
 
-  <exclude-pattern>*/tests/*</exclude-pattern>
-  <exclude-pattern>*/vendor/*</exclude-pattern>
-  <exclude-pattern>*/node_modules/*</exclude-pattern>
-  <exclude-pattern>*/src/commands/templates/*</exclude-pattern>
+    <exclude-pattern>*/tests/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
+    <exclude-pattern>*/src/commands/templates/*</exclude-pattern>
 
-  <!-- Additional arguments. -->
-  <arg value="sp"/>
-  <arg name="basepath" value="."/>
-  <arg name="parallel" value="8"/>
-  <arg name="cache"/>
-  <arg name="extensions" value="php"/>
+    <!-- Additional arguments. -->
+    <arg value="sp"/>
+    <arg name="basepath" value="."/>
+    <arg name="parallel" value="8"/>
+    <arg name="cache"/>
+    <arg name="extensions" value="php"/>
 
-  <file>.</file>
+    <file>.</file>
 
-  <exclude-pattern>/src/CompiledContainer\.php</exclude-pattern>
+    <exclude-pattern>/src/CompiledContainer\.php</exclude-pattern>
 
-  <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.Found">
-    <severity>0</severity>
-  </rule>
+    <rule ref="WordPress.PHP.DiscouragedPHPFunctions.system_calls_system">
+        <exclude-pattern>*/src/**/*Cli</exclude-pattern>
+    </rule>
 
-  <rule ref="WordPress.WP.GlobalVariablesOverride.OverrideProhibited">
-    <severity>0</severity>
-  </rule>
+    <rule ref="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents">
+        <exclude-pattern>*/src/**/*Cli</exclude-pattern>
+    </rule>
 
-  <rule ref="PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.objectFound">
-    <severity>0</severity>
-  </rule>
+    <rule ref="WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec">
+        <exclude-pattern>*/src/Db/*</exclude-pattern>
+        <exclude-pattern>*/src/Build/*</exclude-pattern>
+        <exclude-pattern>*/src/LintPhp/LintPhpCli.php</exclude-pattern>
+    </rule>
 
-  <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassAfterLastUsed">
-    <severity>0</severity>
-  </rule>
-
-  <rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
-    <severity>0</severity>
-  </rule>
-
-  <rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
-    <severity>0</severity>
-  </rule>
-
-  <rule ref="WordPress.Files.FileName.InvalidClassFileName">
-    <severity>0</severity>
-  </rule>
-
-  <rule ref="WordPress.PHP.DiscouragedPHPFunctions.system_calls_system">
-    <severity>0</severity>
-  </rule>
+    <rule ref="Generic.Files.LineLength">
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+    </rule>
 </ruleset>

--- a/src/Blocks/AbstractBlocks.php
+++ b/src/Blocks/AbstractBlocks.php
@@ -151,12 +151,9 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 			throw InvalidBlock::missingBlocksException();
 		}
 
-		\array_map(
-			function ($block) {
-				$this->registerBlock($block);
-			},
-			$blocks
-		);
+		foreach ($blocks as $block) {
+			$this->registerBlock($block);
+		}
 	}
 
 	/**

--- a/src/Blocks/AbstractBlocks.php
+++ b/src/Blocks/AbstractBlocks.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Class Blocks is the base class for Gutenberg blocks registration.
  * It provides the ability to register custom blocks using manifest.json.
@@ -6,7 +7,7 @@
  * @package EightshiftLibs\Blocks
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Blocks;
 
@@ -17,7 +18,8 @@ use EightshiftLibs\Services\ServiceInterface;
 /**
  * Class Blocks
  */
-abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterface {
+abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterface
+{
 
 	/**
 	 * Full data of blocks, settings and wrapper data.
@@ -46,12 +48,13 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return void
 	 */
-	public function changeEditorColorPalette() : void {
+	public function changeEditorColorPalette(): void
+	{
 
 		$colors = $this->getColorsFromSettings();
 
-		if ( $colors ) {
-			\add_theme_support( 'editor-color-palette', $colors );
+		if ($colors) {
+			\add_theme_support('editor-color-palette', $colors);
 		}
 	}
 
@@ -60,7 +63,8 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return array
 	 */
-	public function getColorsFromSettings() {
+	public function getColorsFromSettings()
+	{
 		return $this->getSettings()['globalVariables']['colors'] ?? [];
 	}
 
@@ -69,8 +73,9 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return void
 	 */
-	public function addThemeSupport() : void {
-		add_theme_support( 'align-wide' );
+	public function addThemeSupport(): void
+	{
+		add_theme_support('align-wide');
 	}
 
 	/**
@@ -79,20 +84,21 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return void
 	 */
-	public function getBlocksDataFullRaw() : void {
+	public function getBlocksDataFullRaw(): void
+	{
 
-		if ( ! $this->blocks ) {
+		if (! $this->blocks) {
 			$settings = $this->getSettings();
 			$wrapper  = $this->getWrapper();
 
 			$blocks = array_map(
-				function( $block ) use ( $settings ) {
+				function ($block) use ($settings) {
 
 					// Add additional data to the block settings.
 					$namespace = $block['namespace'] ?? '';
 
 					// Check if namespace is defined in block or in global manifest settings.
-					$block['namespace']     = ! empty( $namespace ) ? $namespace : $settings['namespace'];
+					$block['namespace']     = ! empty($namespace) ? $namespace : $settings['namespace'];
 					$block['blockFullName'] = "{$block['namespace']}/{$block['blockName']}";
 
 					return $block;
@@ -114,9 +120,10 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return array
 	 */
-	public function getAllBlocksList() : array {
+	public function getAllBlocksList(): array
+	{
 		$blocks = array_map(
-			function( $block ) {
+			function ($block) {
 				return $block['blockFullName'];
 			},
 			$this->blocks['blocks']
@@ -136,21 +143,20 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return void
 	 */
-	public function registerBlocks() : void {
+	public function registerBlocks(): void
+	{
 		$blocks = $this->blocks['blocks'];
 
-		if ( empty( $blocks ) ) {
+		if (empty($blocks)) {
 			throw InvalidBlock::missingBlocksException();
 		}
 
-		if ( ! empty( $blocks ) ) {
-			\array_map(
-				function( $block ) {
-					$this->registerBlock( $block );
-				},
-				$blocks
-			);
-		}
+		\array_map(
+			function ($block) {
+				$this->registerBlock($block);
+			},
+			$blocks
+		);
 	}
 
 	/**
@@ -161,12 +167,13 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return void
 	 */
-	public function registerBlock( array $blockDetails ) : void {
+	public function registerBlock(array $blockDetails): void
+	{
 		\register_block_type(
 			$blockDetails['blockFullName'],
 			array(
 				'render_callback' => [ $this, 'render' ],
-				'attributes' => $this->getAttributes( $blockDetails ),
+				'attributes' => $this->getAttributes($blockDetails),
 			)
 		);
 	}
@@ -182,32 +189,33 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return string Html template for block.
 	 */
-	public function render( array $attributes, $innerBlockContent ) : string {
+	public function render(array $attributes, $innerBlockContent): string
+	{
 
 		// Block details is unavailable in this method so we are fetching block name via attributes.
 		$blockName = $attributes['blockName'] ?? '';
 
 		// Get block view path.
-		$templatePath = $this->getBlockViewPath( $blockName );
+		$templatePath = $this->getBlockViewPath($blockName);
 
 		// Get block wrapper view path.
 		$wrapperPath = "{$this->getWrapperPath()}/wrapper.php";
 
 		// Check if wrapper component exists.
-		if ( ! file_exists( $wrapperPath ) ) {
-			throw InvalidBlock::missingWrapperViewException( $wrapperPath );
+		if (! file_exists($wrapperPath)) {
+			throw InvalidBlock::missingWrapperViewException($wrapperPath);
 		}
 
 		// Check if actual block exists.
-		if ( ! file_exists( $templatePath ) ) {
-			throw InvalidBlock::missingViewException( $blockName, $templatePath );
+		if (! file_exists($templatePath)) {
+			throw InvalidBlock::missingViewException($blockName, $templatePath);
 		}
 
 		// If everything is ok, return the contents of the template (return, NOT echo).
 		ob_start();
 		include $wrapperPath;
 		$output = ob_get_clean();
-		unset( $blockName, $templatePath, $wrapperPath, $attributes, $innerBlockContent );
+		unset($blockName, $templatePath, $wrapperPath, $attributes, $innerBlockContent);
 		return (string) $output;
 	}
 
@@ -218,13 +226,14 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 * @param array $categories Array of all blocks categories.
 	 * @return array
 	 */
-	public function getCustomCategory( $categories ) {
+	public function getCustomCategory($categories)
+	{
 		return array_merge(
 			$categories,
 			[
 				[
 					'slug'  => 'eightshift',
-					'title' => \esc_html__( 'Eightshift', 'eightshift-libs' ),
+					'title' => \esc_html__('Eightshift', 'eightshift-libs'),
 					'icon'  => 'admin-settings',
 				],
 			]
@@ -237,19 +246,21 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @param string $src                  String with URL path to template.
 	 * @param array  $attributes           Attributes array to pass in template.
-	 * @param string $innerBlockContent If using inner blocks content pass the data.
+	 * @param string $innerBlockContent    If using inner blocks content pass the data.
 	 *
 	 * @return void Includes an HTML view, or throws an error if the view is missing.
 	 *
 	 * @throws InvalidBlock Throws error if wrapper view template is missing.
 	 */
-	public function renderWrapperView( string $src, array $attributes, $innerBlockContent = null ) : void {
-		if ( ! file_exists( $src ) ) {
-			throw InvalidBlock::missingWrapperViewException( $src );
+	public function renderWrapperView(string $src, array $attributes, $innerBlockContent = null): void
+	{
+		if (! file_exists($src)) {
+			throw InvalidBlock::missingWrapperViewException($src);
 		}
 
 		include $src;
-		unset( $src, $attributes, $innerBlockContent );
+
+		unset($src, $attributes, $innerBlockContent);
 	}
 
 	/**
@@ -258,14 +269,15 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return string
 	 */
-	abstract protected function getBlocksPath() : string;
+	abstract protected function getBlocksPath(): string;
 
 	/**
 	 * Get blocks custom folder absolute path.
 	 *
 	 * @return string
 	 */
-	protected function getBlocksCustomPath() : string {
+	protected function getBlocksCustomPath(): string
+	{
 		return "{$this->getBlocksPath()}/custom";
 	}
 
@@ -276,7 +288,8 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return string
 	 */
-	protected function getBlockViewPath( string $blockName ) : string {
+	protected function getBlockViewPath(string $blockName): string
+	{
 		return "{$this->getBlocksCustomPath()}/{$blockName}/{$blockName}.php";
 	}
 
@@ -285,7 +298,8 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return string
 	 */
-	protected function getWrapperPath() : string {
+	protected function getWrapperPath(): string
+	{
 		return "{$this->getBlocksPath()}/wrapper";
 	}
 
@@ -296,15 +310,16 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return array
 	 */
-	protected function getWrapper() : array {
+	protected function getWrapper(): array
+	{
 		$manifestPath = "{$this->getWrapperPath()}/manifest.json";
 
-		if ( ! file_exists( $manifestPath ) ) {
-			throw InvalidBlock::missingWrapperManifestException( $manifestPath );
+		if (! file_exists($manifestPath)) {
+			throw InvalidBlock::missingWrapperManifestException($manifestPath);
 		}
 
-		$settings = implode( ' ', (array) file( ( $manifestPath ) ) );
-		$settings = json_decode( $settings, true );
+		$settings = implode(' ', (array) file(( $manifestPath )));
+		$settings = json_decode($settings, true);
 
 		return $settings;
 	}
@@ -317,17 +332,18 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return array
 	 */
-	protected function getSettings() : array {
+	protected function getSettings(): array
+	{
 		$manifestPath = "{$this->getBlocksPath()}/manifest.json";
 
-		if ( ! file_exists( $manifestPath ) ) {
-			throw InvalidBlock::missingSettingsManifestException( $manifestPath );
+		if (! file_exists($manifestPath)) {
+			throw InvalidBlock::missingSettingsManifestException($manifestPath);
 		}
 
-		$settings = implode( ' ', (array) file( ( $manifestPath ) ) );
-		$settings = json_decode( $settings, true );
+		$settings = implode(' ', (array) file(( $manifestPath )));
+		$settings = json_decode($settings, true);
 
-		if ( ! isset( $settings['namespace'] ) ) {
+		if (! isset($settings['namespace'])) {
 			throw InvalidBlock::missingNamespaceException();
 		}
 
@@ -344,11 +360,12 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return array
 	 */
-	protected function getAttributes( array $blockDetails ) : array {
+	protected function getAttributes(array $blockDetails): array
+	{
 
 		$blockName = $blockDetails['blockName'];
 
-		$output = array_merge(
+		return array_merge(
 			[
 				'blockName' => array(
 					'type' => 'string',
@@ -370,8 +387,6 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 			$this->blocks['wrapper']['attributes'],
 			$blockDetails['attributes']
 		);
-
-		return $output;
 	}
 
 	/**
@@ -382,23 +397,24 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 *
 	 * @return array
 	 */
-	private function getBlocksData() : array {
+	private function getBlocksData(): array
+	{
 
 		return array_map(
-			function( string $block_path ) {
-				$block = implode( ' ', (array) file( ( $block_path ) ) );
+			function (string $block_path) {
+				$block = implode(' ', (array) file(( $block_path )));
 
-				$block = $this->parseManifest( $block );
+				$block = $this->parseManifest($block);
 
-				if ( ! isset( $block['blockName'] ) ) {
-					throw InvalidBlock::missingNameException( $block_path );
+				if (! isset($block['blockName'])) {
+					throw InvalidBlock::missingNameException($block_path);
 				}
 
-				if ( ! isset( $block['classes'] ) ) {
+				if (! isset($block['classes'])) {
 					$block['classes'] = [];
 				}
 
-				if ( ! isset( $block['attributes'] ) ) {
+				if (! isset($block['attributes'])) {
 					$block['attributes'] = [];
 				}
 

--- a/src/Blocks/BlockCli.php
+++ b/src/Blocks/BlockCli.php
@@ -53,13 +53,7 @@ class BlockCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Creates a block
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Blocks/BlockCli.php
+++ b/src/Blocks/BlockCli.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Class that registers WPCLI command for Blocks Block.
  *
  * @package EightshiftLibs\Blocks
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Blocks;
 
@@ -14,7 +15,8 @@ use EightshiftLibs\Cli\AbstractCli;
 /**
  * Class BlockCli
  */
-class BlockCli extends AbstractCli {
+class BlockCli extends AbstractCli
+{
 
 	/**
 	 * Output dir relative path.
@@ -26,16 +28,18 @@ class BlockCli extends AbstractCli {
 	 *
 	 * @return string
 	 */
-	public function getCommandName() : string {
+	public function getCommandName(): string
+	{
 		return 'use_block';
 	}
 
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
-	public function getDoc() : array {
+	public function getDoc(): array
+	{
 		return [
 			'shortdesc' => 'Copy Block from library to your project.',
 			'synopsis' => [
@@ -49,7 +53,14 @@ class BlockCli extends AbstractCli {
 		];
 	}
 
-	public function __invoke( array $args, array $assocArgs ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Creates a block
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
+	{
 
 		// Get Props.
 		$block = $assocArgs['block'] ?? '';
@@ -61,21 +72,27 @@ class BlockCli extends AbstractCli {
 		$destinationPath = "{$root}/src/Blocks/Custom/{$block}";
 
 		// Source doesn't exist.
-		if ( ! file_exists( $sourcePath ) ) {
+		if (! file_exists($sourcePath)) {
 			\WP_CLI::error(
-				sprintf( 'The block "%s" doesn\'t exist in our library. Please check the docs for all available blocks.', $sourcePath )
+				sprintf(
+					'The block "%s" doesn\'t exist in our library. Please check the docs for all available blocks.',
+					$sourcePath
+				)
 			);
 		}
 
 		// Destination exists.
-		if ( file_exists( $destinationPath ) ) {
+		if (file_exists($destinationPath)) {
 			\WP_CLI::error(
-				sprintf( 'The block in you project exists on this "%s" path. Please check or remove that folder before running this command again.', $destinationPath )
+				sprintf(
+					'The block in you project exists on this "%s" path. Please check or remove that folder before running this command again.',
+					$destinationPath
+				)
 			);
 		}
 
-		system( "cp -R {$sourcePath}/. {$destinationPath}/" );
+		system("cp -R {$sourcePath}/. {$destinationPath}/");
 
-		\WP_CLI::success( 'Block successfully created.' );
+		\WP_CLI::success('Block successfully created.');
 	}
 }

--- a/src/Blocks/BlockComponentCli.php
+++ b/src/Blocks/BlockComponentCli.php
@@ -53,13 +53,7 @@ class BlockComponentCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the Block component
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Blocks/BlockComponentCli.php
+++ b/src/Blocks/BlockComponentCli.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Class that registers WPCLI command for Blocks Components.
  *
  * @package EightshiftLibs\Blocks
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Blocks;
 
@@ -14,7 +15,8 @@ use EightshiftLibs\Cli\AbstractCli;
 /**
  * Class BlockComponentCli
  */
-class BlockComponentCli extends AbstractCli {
+class BlockComponentCli extends AbstractCli
+{
 
 	/**
 	 * Output dir relative path.
@@ -26,16 +28,18 @@ class BlockComponentCli extends AbstractCli {
 	 *
 	 * @return string
 	 */
-	public function getCommandName() : string {
+	public function getCommandName(): string
+	{
 		return 'use_component';
 	}
 
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
-	public function getDoc() : array {
+	public function getDoc(): array
+	{
 		return [
 			'shortdesc' => 'Copy Component from library to your project.',
 			'synopsis' => [
@@ -49,7 +53,14 @@ class BlockComponentCli extends AbstractCli {
 		];
 	}
 
-	public function __invoke( array $args, array $assocArgs ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the Block component
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
+	{
 
 		// Get Props.
 		$component = $assocArgs['component'] ?? '';
@@ -61,21 +72,23 @@ class BlockComponentCli extends AbstractCli {
 		$destinationPath = "{$root}/src/Blocks/Components/{$component}";
 
 		// Source doesn't exist.
-		if ( ! file_exists( $sourcePath ) ) {
+		if (! file_exists($sourcePath)) {
 			\WP_CLI::error(
-				sprintf( 'The component "%s" doesn\'t exist in our library. Please check the docs for all available components', $sourcePath )
+				/* translators: %s will be replaced with the path. */
+				sprintf('The component "%s" doesn\'t exist in our library. Please check the docs for all available components', $sourcePath)
 			);
 		}
 
 		// Destination exists.
-		if ( file_exists( $destinationPath ) ) {
+		if (file_exists($destinationPath)) {
 			\WP_CLI::error(
-				sprintf( 'The component in you project exists on this "%s" path. Please check or remove that folder before running this command again.', $destinationPath )
+				/* translators: %s will be replaced with the path. */
+				sprintf('The component in you project exists on this "%s" path. Please check or remove that folder before running this command again.', $destinationPath)
 			);
 		}
 
-		system( "cp -R {$sourcePath}/. {$destinationPath}/" );
+		system("cp -R {$sourcePath}/. {$destinationPath}/");
 
-		\WP_CLI::success( 'Component successfully created.' );
+		\WP_CLI::success('Component successfully created.');
 	}
 }

--- a/src/Blocks/BlocksCli.php
+++ b/src/Blocks/BlocksCli.php
@@ -65,7 +65,13 @@ class BlocksCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Removes the directory
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();
@@ -93,7 +99,7 @@ class BlocksCli extends AbstractCli
 	 *
 	 * @return void
 	 */
-	public function blocksInit(bool $all = false ): void
+	public function blocksInit(bool $all = false): void
 	{
 		$root     = $this->getProjectRootPath();
 		$rootNode = $this->getFrontendLibsBlockPath();

--- a/src/Blocks/BlocksCli.php
+++ b/src/Blocks/BlocksCli.php
@@ -65,13 +65,7 @@ class BlocksCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Removes the directory
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Blocks/RenderableBlockInterface.php
+++ b/src/Blocks/RenderableBlockInterface.php
@@ -28,5 +28,5 @@ interface RenderableBlockInterface
 	 *
 	 * @return string
 	 */
-	public function render(array $attributes, $innerBlockContent ): string;
+	public function render(array $attributes, $innerBlockContent): string;
 }

--- a/src/Build/BuildCli.php
+++ b/src/Build/BuildCli.php
@@ -85,13 +85,7 @@ class BuildCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Builds the project
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Build/BuildCli.php
+++ b/src/Build/BuildCli.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Class that registers WPCLI command for BuildCli.
  *
  * @package EightshiftLibs\Build
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Build;
 
@@ -14,7 +15,8 @@ use EightshiftLibs\Cli\AbstractCli;
 /**
  * Class BuildCli
  */
-class BuildCli extends AbstractCli {
+class BuildCli extends AbstractCli
+{
 
 	/**
 	 * Output dir relative path.
@@ -26,7 +28,8 @@ class BuildCli extends AbstractCli {
 	 *
 	 * @return string
 	 */
-	public function getCommandName() : string {
+	public function getCommandName(): string
+	{
 		return 'init_build';
 	}
 
@@ -37,7 +40,8 @@ class BuildCli extends AbstractCli {
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs( array $args ) : array {
+	public function getDevelopArgs(array $args): array
+	{
 		return [
 			'root' => $args[1] ?? './',
 		];
@@ -46,9 +50,10 @@ class BuildCli extends AbstractCli {
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
-	public function getDoc() : array {
+	public function getDoc(): array
+	{
 		return [
 			'shortdesc' => 'Initialize Command for building your project with one command, generally used on CI deployments.',
 			'synopsis' => [
@@ -80,29 +85,36 @@ class BuildCli extends AbstractCli {
 		];
 	}
 
-	public function __invoke( array $args, array $assocArgs ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Builds the project
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
+	{
 
 		// Get Props.
 		$root          = $assocArgs['root'] ?? static::OUTPUT_DIR;
 		$skipSetupFile = $assocArgs['skip_setup_file'] ?? true;
 
 		// Read the template contents, and replace the placeholders with provided variables.
-		$class = $this->getExampleTemplate( __DIR__, $this->getClassShortName() );
+		$class = $this->getExampleTemplate(__DIR__, $this->getClassShortName());
 
 		// Replace stuff in file.
-		$class = $this->renameProjectName( $assocArgs, $class );
-		$class = $this->renameProjectType( $assocArgs, $class );
-		$class = $this->renameTextDomain( $assocArgs, $class );
+		$class = $this->renameProjectName($assocArgs, $class);
+		$class = $this->renameProjectType($assocArgs, $class);
+		$class = $this->renameTextDomain($assocArgs, $class);
 
 		// Output final class to new file/folder and finish.
-		$this->outputWrite( $root . 'bin', $this->getClassShortName(), $class );
+		$this->outputWrite($root . 'bin', $this->getClassShortName(), $class);
 
-		if ( ! $skipSetupFile ) {
+		if (! $skipSetupFile) {
 			// Get setup.json file.
-			$json = $this->getExampleTemplate( dirname( __DIR__, 1 ), 'setup/setup.json' );
+			$json = $this->getExampleTemplate(dirname(__DIR__, 1), 'setup/setup.json');
 
 			// Output json file to project root.
-			$this->outputWrite( $root, 'setup.json', $json );
+			$this->outputWrite($root, 'setup.json', $json);
 		}
 	}
 }

--- a/src/Build/BuildExample.php
+++ b/src/Build/BuildExample.php
@@ -18,7 +18,7 @@ $projectRootPath = dirname(__FILE__, 2);
 $projectPath = "{$projectRootPath}/wp-content/themes/eightshift-boilerplate";
 
 // Check if folder exists.
-if ( ! file_exists($projectPath)) {
+if (! file_exists($projectPath)) {
 	\WP_CLI::error("Provided folder path {$projectPath} is missing.");
 }
 
@@ -26,15 +26,15 @@ if ( ! file_exists($projectPath)) {
 chdir($projectPath);
 
 // Run setup scripts for npm.
-\WP_CLI::log(shell_exec('npm install')); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+\WP_CLI::log(shell_exec('npm install'));
 \WP_CLI::log('--------------------------------------------------');
 
 // Run setup scripts for coomposer.
-\WP_CLI::log(shell_exec('composer install --no-dev --no-scripts')); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+\WP_CLI::log(shell_exec('composer install --no-dev --no-scripts'));
 \WP_CLI::log('--------------------------------------------------');
 
 // Run setup scripts for building assets.
-\WP_CLI::log(shell_exec('npm run build')); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+\WP_CLI::log(shell_exec('npm run build'));
 \WP_CLI::log('--------------------------------------------------');
 
 // Change execution folder back to root.

--- a/src/CiExclude/CiExcludeCli.php
+++ b/src/CiExclude/CiExcludeCli.php
@@ -40,7 +40,7 @@ class CiExcludeCli extends AbstractCli
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs(array $args ): array
+	public function getDevelopArgs(array $args): array
 	{
 		return [
 			'root' => $args[1] ?? './',
@@ -50,7 +50,7 @@ class CiExcludeCli extends AbstractCli
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function getDoc(): array
 	{
@@ -79,7 +79,13 @@ class CiExcludeCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the ci-exclude.txt file
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Get Props.

--- a/src/CiExclude/CiExcludeCli.php
+++ b/src/CiExclude/CiExcludeCli.php
@@ -79,13 +79,7 @@ class CiExcludeCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the ci-exclude.txt file
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -1,19 +1,20 @@
 <?php
+
 /**
  * Abstract class that holds all methods for WPCLI options.
  *
  * @package EightshiftLibs\Cli
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Cli;
 
 /**
  * Class AbstractCli
  */
-abstract class AbstractCli implements CliInterface {
-
+abstract class AbstractCli implements CliInterface
+{
 	/**
 	 * CLI helpers trait.
 	 */
@@ -43,7 +44,8 @@ abstract class AbstractCli implements CliInterface {
 	 *
 	 * @return void
 	 */
-	public function __construct( $commandParentName ) {
+	public function __construct($commandParentName)
+	{
 		$this->commandParentName = $commandParentName;
 	}
 
@@ -52,8 +54,9 @@ abstract class AbstractCli implements CliInterface {
 	 *
 	 * @return void
 	 */
-	public function register() : void {
-		\add_action( 'cli_init', [ $this, 'registerCommand' ] );
+	public function register(): void
+	{
+		\add_action('cli_init', [ $this, 'registerCommand' ]);
 	}
 
 	/**
@@ -61,25 +64,26 @@ abstract class AbstractCli implements CliInterface {
 	 *
 	 * @return array
 	 */
-	public function getGlobalSynopsis() : array {
+	public function getGlobalSynopsis(): array
+	{
 		return [
 			'synopsis' => [
 				[
 					'type'        => 'assoc',
 					'name'        => 'namespace',
-					'description' => 'Define your projects namespace. Default is read from composer autoload psr-4 key.',
+					'description' => 'Define your project namespace. Default is read from composer autoload psr-4 key.',
 					'optional'    => true,
 				],
 				[
 					'type'        => 'assoc',
 					'name'        => 'vendor_prefix',
-					'description' => 'Define your projects vendor_prefix. Default is read from composer extra, imposter, namespace key.',
+					'description' => 'Define your project vendor_prefix. Default is read from composer extra, imposter, namespace key.',
 					'optional'    => true,
 				],
 				[
 					'type'        => 'assoc',
 					'name'        => 'config_path',
-					'description' => 'Define your projects composer apsolute path.',
+					'description' => 'Define your project composer absolute path.',
 					'optional'    => true,
 				],
 			],
@@ -89,11 +93,14 @@ abstract class AbstractCli implements CliInterface {
 	/**
 	 * Method that creates actual WPCLI command in terminal.
 	 *
+	 * @throws \ReflectionException Exception in the case the class is missing.
+	 *
 	 * @return void
 	 */
-	public function registerCommand() : void {
-		$reflectionClass = new \ReflectionClass( $this->getClassName() );
-		$class           = $reflectionClass->newInstanceArgs( [ $this->commandParentName ] );
+	public function registerCommand(): void
+	{
+		$reflectionClass = new \ReflectionClass($this->getClassName());
+		$class           = $reflectionClass->newInstanceArgs([ $this->commandParentName ]);
 
 		\WP_CLI::add_command(
 			$this->commandParentName . ' ' . $this->getCommandName(),
@@ -112,7 +119,8 @@ abstract class AbstractCli implements CliInterface {
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs( array $args ) : array {
+	public function getDevelopArgs(array $args): array
+	{
 		return $args;
 	}
 
@@ -121,8 +129,9 @@ abstract class AbstractCli implements CliInterface {
 	 *
 	 * @return string
 	 */
-	public function getClassName() : string {
-		return get_class( $this );
+	public function getClassName(): string
+	{
+		return get_class($this);
 	}
 
 	/**
@@ -130,10 +139,11 @@ abstract class AbstractCli implements CliInterface {
 	 *
 	 * @return string
 	 */
-	public function getClassShortName() : string {
-		$arr = explode( '\\', $this->getClassName() );
+	public function getClassShortName(): string
+	{
+		$arr = explode('\\', $this->getClassName());
 
-		return str_replace( 'Cli', '', end( $arr ) );
+		return str_replace('Cli', '', end($arr));
 	}
 
 	/**
@@ -141,8 +151,9 @@ abstract class AbstractCli implements CliInterface {
 	 *
 	 * @return string
 	 */
-	public function getCommandName() : string {
-		return 'create_' . strtolower( preg_replace( '/(?<!^)[A-Z]/', '_$0', $this->getClassShortName() ) );
+	public function getCommandName(): string
+	{
+		return 'create_' . strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $this->getClassShortName()));
 	}
 
 	/**
@@ -150,8 +161,8 @@ abstract class AbstractCli implements CliInterface {
 	 *
 	 * @return string
 	 */
-	public function getDoc() : array {
+	public function getDoc(): array
+	{
 		return [];
 	}
-
 }

--- a/src/Cli/Cli.php
+++ b/src/Cli/Cli.php
@@ -153,7 +153,7 @@ class Cli
 	 *
 	 * @return void
 	 */
-	public function loadDevelop(array $args = [] ): void
+	public function loadDevelop(array $args = []): void
 	{
 
 		$commandName = $args[0] ?? '';
@@ -184,7 +184,7 @@ class Cli
 	 *
 	 * @return void
 	 */
-	public function load(string $commandParentName ): void
+	public function load(string $commandParentName): void
 	{
 		$this->commandParentName = $commandParentName;
 

--- a/src/Cli/CliHelpers.php
+++ b/src/Cli/CliHelpers.php
@@ -24,7 +24,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function getFileName(string $fileName ): string
+	public function getFileName(string $fileName): string
 	{
 
 		if (strpos($fileName, ' ') !== false) {
@@ -34,7 +34,7 @@ trait CliHelpers
 		$class = explode('_', str_replace('-', '_', str_replace(' ', '_', strtolower($fileName))));
 
 		$className = array_map(
-			function ($item ) {
+			function ($item) {
 				return ucfirst($item);
 			},
 			$class
@@ -51,7 +51,7 @@ trait CliHelpers
 	 *
 	 * @return string|Error
 	 */
-	public function getExampleTemplate(string $currentDir, string $fileName ): string
+	public function getExampleTemplate(string $currentDir, string $fileName): string
 	{
 
 		// If you pass file name with extension the version will be used.
@@ -78,7 +78,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function getExampleFileName($string ): string
+	public function getExampleFileName($string): string
 	{
 		return "{$string}Example";
 	}
@@ -92,7 +92,7 @@ trait CliHelpers
 	 *
 	 * @return void
 	 */
-	public function outputWrite(string $outputDir, string $outputFile, string $class ): void
+	public function outputWrite(string $outputDir, string $outputFile, string $class): void
 	{
 
 		// Set output paths.
@@ -108,7 +108,7 @@ trait CliHelpers
 		}
 
 		// Create output dir if it doesn't exist.
-		if ( ! is_dir($outputDir)) {
+		if (! is_dir($outputDir)) {
 			mkdir($outputDir, 0755, true);
 		}
 
@@ -116,7 +116,7 @@ trait CliHelpers
 		$fp = fopen($outputFile, 'wb'); // phpcs:ignore WordPress.WP.AlternativeFunctions
 
 		// If there is any error bailout. For example, user permission.
-		if ( ! $fp) {
+		if (! $fp) {
 			\WP_CLI::error("File {$outputFile} couldn\'t be created. There was an error.");
 		}
 
@@ -135,7 +135,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function getOutputDir(string $path = '' ): string
+	public function getOutputDir(string $path = ''): string
 	{
 		if (function_exists('add_action')) {
 			$root = $this->getProjectRootPath();
@@ -159,7 +159,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function getOutputFile(string $file ): string
+	public function getOutputFile(string $file): string
 	{
 		$file = rtrim($file, '/');
 		$file = trim($file, '/');
@@ -184,7 +184,7 @@ trait CliHelpers
 	 * \x6E\x61\x6D\x65\x73\x70\x61\x63\x65 - Corresponds to "namespace".
 	 * \x40\x70\x61\x63\x6B\x61\x67\x65 - Corresponds to "@package".
 	 */
-	public function renameNamespace(array $args = [], string $string ): string
+	public function renameNamespace(array $args = [], string $string = ''): string
 	{
 
 		$namespace = $this->getNamespace($args);
@@ -218,7 +218,7 @@ trait CliHelpers
 	 *
 	 * \x75\x73\x65 - Corresponds to "use".
 	 */
-	public function renameUse(array $args = [], string $string ): string
+	public function renameUse(array $args = [], string $string = ''): string
 	{
 
 		$output = $string;
@@ -256,7 +256,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function renameTextDomain(array $args = [], string $string ): string
+	public function renameTextDomain(array $args = [], string $string = ''): string
 	{
 
 		$namespace = $this->getNamespace($args);
@@ -276,7 +276,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function renameProjectName(array $args = [], string $string ): string
+	public function renameProjectName(array $args = [], string $string = ''): string
 	{
 
 		$projectName = 'eightshift-boilerplate';
@@ -304,7 +304,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function renameProjectType(array $args = [], string $string ): string
+	public function renameProjectType(array $args = [], string $string = ''): string
 	{
 
 		$projectType = 'themes';
@@ -332,13 +332,13 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function renameClassName(string $className, string $string ): string
+	public function renameClassName(string $className, string $string): string
 	{
 		return str_replace($this->getExampleFileName($className), $className, $string);
 	}
 
 	/**
-	 * Change Class full name with sufix.
+	 * Change Class full name with suffix.
 	 *
 	 * @param string $templateName Current template.
 	 * @param string $newName      New Class Name.
@@ -346,7 +346,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function renameClassNameWithSufix(string $templateName, string $newName, string $string ): string
+	public function renameClassNameWithSuffix(string $templateName, string $newName, string $string): string
 	{
 		return str_replace($this->getExampleFileName($templateName), $newName, $string);
 	}
@@ -358,9 +358,9 @@ trait CliHelpers
 	 *
 	 * @return array
 	 */
-	public function getComposer(array $args = [] ): array
+	public function getComposer(array $args = []): array
 	{
-		if ( ! isset($args['config_path'])) {
+		if (! isset($args['config_path'])) {
 			if (function_exists('add_action')) {
 				$composerPath = $this->getProjectRootPath() . '/composer.json';
 			} else {
@@ -370,7 +370,7 @@ trait CliHelpers
 			$composerPath = $args['config_path'];
 		}
 
-		$composerFile = file_get_contents($composerPath); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$composerFile = file_get_contents($composerPath);
 
 		if ($composerFile === false) {
 			\WP_CLI::error("The composer on {$composerPath} path seems to be missing.");
@@ -386,7 +386,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function getNamespace(array $args = [] ): string
+	public function getNamespace(array $args = []): string
 	{
 		$namespace = '';
 
@@ -410,7 +410,7 @@ trait CliHelpers
 	 *
 	 * @return stringgp
 	 */
-	public function arrayKeyFirstChild(array $array ): string
+	public function arrayKeyFirstChild(array $array): string
 	{
 		foreach ($array as $key => $unused) {
 			return $key;
@@ -426,7 +426,7 @@ trait CliHelpers
 	 *
 	 * @return string
 	 */
-	public function getVendorPrefix(array $args = [] ): string
+	public function getVendorPrefix(array $args = []): string
 	{
 		$vendorPrefix = '';
 
@@ -444,13 +444,15 @@ trait CliHelpers
 	}
 
 	/**
-	 * Convert user input string to slug safe format. convert _ to -, empty space to - and convert everything to lovercase.
+	 * Convert user input string to slug safe format.
+	 *
+	 * Convert _ to -, empty space to - and convert everything to lowercase.
 	 *
 	 * @param string $string String to convert.
 	 *
 	 * @return string
 	 */
-	public function prepareSlug(string $string ): string
+	public function prepareSlug(string $string): string
 	{
 		if (strpos($string, ' ') !== false) {
 			$string = strtolower($string);
@@ -464,15 +466,18 @@ trait CliHelpers
 	 *
 	 * @param array $items Array of classes.
 	 * @param bool  $run   Run or log output.
+	 *
+	 * @throws \ReflectionException Exception if the class cannot be found.
+	 *
 	 * @return void
 	 */
-	public function getEvalLoop(array $items = [], bool $run = false ): void
+	public function getEvalLoop(array $items = [], bool $run = false): void
 	{
 		foreach ($items as $item) {
 			$reflectionClass = new \ReflectionClass($item);
 			$class           = $reflectionClass->newInstanceArgs([ null ]);
 
-			if ( ! $run) {
+			if (! $run) {
 				\WP_CLI::log("wp eval-file bin/cli.php {$class->getCommandName()} --skip-wordpress");
 			} else {
 				\WP_CLI::runcommand("eval-file bin/cli.php {$class->getCommandName()} --skip-wordpress");
@@ -492,13 +497,13 @@ trait CliHelpers
 	}
 
 	/**
-	 * Returns projects root folder based on the enviroment.
+	 * Returns projects root folder based on the environment.
 	 *
 	 * @param bool $isDev Returns path based on the env.
 	 *
 	 * @return string
 	 */
-	public function getProjectRootPath(bool $isDev = false ): string
+	public function getProjectRootPath(bool $isDev = false): string
 	{
 		$output = dirname(__DIR__, 5);
 
@@ -510,13 +515,13 @@ trait CliHelpers
 	}
 
 	/**
-	 * Returns projects root where config is instaled based on the enviroment.
+	 * Returns projects root where config is installed based on the environment.
 	 *
 	 * @param bool $isDev Returns path based on the env.
 	 *
 	 * @return string
 	 */
-	public function getProjectConfigRootPath(bool $isDev = false ): string
+	public function getProjectConfigRootPath(bool $isDev = false): string
 	{
 		$output = dirname(__DIR__, 8);
 
@@ -533,7 +538,7 @@ trait CliHelpers
 	 * @param string $path Additional path.
 	 * @return string
 	 */
-	public function getFrontendLibsPath(string $path = '' ): string
+	public function getFrontendLibsPath(string $path = ''): string
 	{
 		return "{$this->getProjectRootPath()}/node_modules/@eightshift/frontend-libs/{$path}";
 	}
@@ -544,7 +549,7 @@ trait CliHelpers
 	 * @param string $path Additional path.
 	 * @return string
 	 */
-	public function getLibsPath(string $path = '' ): string
+	public function getLibsPath(string $path = ''): string
 	{
 		return "{$this->getProjectRootPath()}/vendor/infinum/eightshift-libs/{$path}";
 	}

--- a/src/Cli/CliInitTheme.php
+++ b/src/Cli/CliInitTheme.php
@@ -72,15 +72,7 @@ class CliInitTheme extends AbstractCli
 		];
 	}
 
-	/**
-	 * Initializes a theme
-	 *
-	 * @param array $args Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 *
-	 * @throws \ReflectionException Exception if the class doesn't exist.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		if (! function_exists('add_action')) {

--- a/src/Cli/CliInitTheme.php
+++ b/src/Cli/CliInitTheme.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Class that registers WPCLI command initial setup of theme project.
  *
  * @package EightshiftLibs\Cli
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Cli;
 
@@ -27,7 +28,8 @@ use EightshiftLibs\Setup\SetupCli;
 /**
  * Class CliInitTheme
  */
-class CliInitTheme extends AbstractCli {
+class CliInitTheme extends AbstractCli
+{
 
 	/**
 	 * All classes for initial theme setup for project.
@@ -53,41 +55,52 @@ class CliInitTheme extends AbstractCli {
 	 *
 	 * @return string
 	 */
-	public function getCommandName() : string {
+	public function getCommandName(): string
+	{
 		return 'init_theme';
 	}
 
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
-	public function getDoc() : array {
+	public function getDoc(): array
+	{
 		return [
 			'shortdesc' => 'Generates initial setup for WordPress theme project.',
 		];
 	}
 
-	public function __invoke( array $args, array $assocArgs ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Initializes a theme
+	 *
+	 * @param array $args Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 *
+	 * @throws \ReflectionException Exception if the class doesn't exist.
+	 */
+	public function __invoke(array $args, array $assocArgs)
+	{
 
-		if ( ! function_exists( 'add_action' ) ) {
+		if (! function_exists('add_action')) {
 			$this->runReset();
-			\WP_CLI::log( '--------------------------------------------------' );
+			\WP_CLI::log('--------------------------------------------------');
 		}
 
-		foreach ( static::INIT_THEME_CLASSES as $item ) {
-			$reflectionClass = new \ReflectionClass( $item );
-			$class           = $reflectionClass->newInstanceArgs( [ null ] );
+		foreach (static::INIT_THEME_CLASSES as $item) {
+			$reflectionClass = new \ReflectionClass($item);
+			$class           = $reflectionClass->newInstanceArgs([ null ]);
 
-			if ( function_exists( 'add_action' ) ) {
-				\WP_CLI::runcommand( "{$this->commandParentName} {$class->getCommandName()}" );
+			if (function_exists('add_action')) {
+				\WP_CLI::runcommand("{$this->commandParentName} {$class->getCommandName()}");
 			} else {
-				\WP_CLI::runcommand( "eval-file bin/cli.php {$class->getCommandName()} --skip-wordpress" );
+				\WP_CLI::runcommand("eval-file bin/cli.php {$class->getCommandName()} --skip-wordpress");
 			}
 		}
 
-		\WP_CLI::log( '--------------------------------------------------' );
+		\WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::success( 'All commands are finished.' );
+		\WP_CLI::success('All commands are finished.');
 	}
 }

--- a/src/Cli/CliInterface.php
+++ b/src/Cli/CliInterface.php
@@ -28,7 +28,7 @@ interface CliInterface
 	 *
 	 * @return void
 	 */
-	public function __invoke(array $args, array $assocArgs );
+	public function __invoke(array $args, array $assocArgs);
 
 	/**
 	 * Method that creates actual WPCLI command in terminal.

--- a/src/Cli/CliInterface.php
+++ b/src/Cli/CliInterface.php
@@ -21,9 +21,11 @@ interface CliInterface
 	public function register(): void;
 
 	/**
-	 * Call internal method for passing arguments.
+	 * Make every class implementing this interface invokable.
 	 *
-	 * @param array $args       Array of arguments form terminal.
+	 * This is done because we are using WP-CLI commands to do our bidding.
+	 *
+	 * @param array $args      Array of arguments form terminal.
 	 * @param array $assocArgs Array of arguments form terminal associative.
 	 *
 	 * @return void

--- a/src/Cli/CliReset.php
+++ b/src/Cli/CliReset.php
@@ -30,13 +30,7 @@ class CliReset extends AbstractCli
 		return 'reset';
 	}
 
-	/**
-	 * Removes the directory
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 		$output_dir = $this->getOutputDir('');
 

--- a/src/Cli/CliReset.php
+++ b/src/Cli/CliReset.php
@@ -30,9 +30,14 @@ class CliReset extends AbstractCli
 		return 'reset';
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Removes the directory
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
-
 		$output_dir = $this->getOutputDir('');
 
 		system('rm -rf ' . escapeshellarg($output_dir));

--- a/src/Cli/CliRunAll.php
+++ b/src/Cli/CliRunAll.php
@@ -30,13 +30,7 @@ class CliRunAll extends AbstractCli
 		return 'run_all';
 	}
 
-	/**
-	 * Resets and runs all the commands in the classes list
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$this->runReset();

--- a/src/Cli/CliRunAll.php
+++ b/src/Cli/CliRunAll.php
@@ -30,7 +30,13 @@ class CliRunAll extends AbstractCli
 		return 'run_all';
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Resets and runs all the commands in the classes list
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$this->runReset();

--- a/src/Cli/CliShowAll.php
+++ b/src/Cli/CliShowAll.php
@@ -30,7 +30,15 @@ class CliShowAll extends AbstractCli
 		return 'show_all';
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Shows all commands
+	 *
+	 * @param array $args Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 *
+	 * @throws \ReflectionException Exception in the case a class is missing.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		\WP_CLI::log(\WP_CLI::colorize('%mCommands for wp-cli and development:%n'));

--- a/src/Cli/CliShowAll.php
+++ b/src/Cli/CliShowAll.php
@@ -30,15 +30,7 @@ class CliShowAll extends AbstractCli
 		return 'show_all';
 	}
 
-	/**
-	 * Shows all commands
-	 *
-	 * @param array $args Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 *
-	 * @throws \ReflectionException Exception in the case a class is missing.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		\WP_CLI::log(\WP_CLI::colorize('%mCommands for wp-cli and development:%n'));

--- a/src/Columns/PostType/AbstractPostTypeColumns.php
+++ b/src/Columns/PostType/AbstractPostTypeColumns.php
@@ -28,7 +28,7 @@ abstract class AbstractPostTypeColumns implements ServiceInterface
 	public function register(): void
 	{
 		array_map(
-			function ($post_type ) {
+			function ($post_type) {
 				add_filter("manage_{$post_type}_posts_columns", [ $this, 'addColumnName' ]);
 				add_action("manage_{$post_type}_posts_custom_column", [ $this, 'renderColumnContent' ], 10, 2);
 			},
@@ -43,7 +43,7 @@ abstract class AbstractPostTypeColumns implements ServiceInterface
 	 *
 	 * @return array         Modified column names array.
 	 */
-	abstract public function addColumnName(array $columns ): array;
+	abstract public function addColumnName(array $columns): array;
 
 	/**
 	 * Render the post column content in the custom post column
@@ -53,7 +53,7 @@ abstract class AbstractPostTypeColumns implements ServiceInterface
 	 *
 	 * @return void
 	 */
-	abstract public function renderColumnContent(string $columnName, int $postId ): void;
+	abstract public function renderColumnContent(string $columnName, int $postId): void;
 
 	/**
 	 * Get the slug of the post type where the additional column should appear.

--- a/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
+++ b/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
@@ -28,7 +28,7 @@ abstract class AbstractTaxonomyColumns implements ServiceInterface
 	public function register(): void
 	{
 		array_map(
-			function ($taxonomy ) {
+			function ($taxonomy) {
 				add_filter("manage_edit-{$taxonomy}_columns", [ $this, 'addColumnName' ]);
 				add_filter("manage_{$taxonomy}_custom_column", [ $this, 'renderColumnContent' ], 10, 3);
 			},
@@ -43,7 +43,7 @@ abstract class AbstractTaxonomyColumns implements ServiceInterface
 	 *
 	 * @return array         Modified column names array.
 	 */
-	abstract public function addColumnName(array $columns ): array;
+	abstract public function addColumnName(array $columns): array;
 
 	/**
 	 * Render the taxonomy column content in the custom taxonomy column
@@ -54,7 +54,7 @@ abstract class AbstractTaxonomyColumns implements ServiceInterface
 	 *
 	 * @return string The contetnt to display in the custom column.
 	 */
-	abstract public function renderColumnContent(string $string, string $columnName, int $termId ): string;
+	abstract public function renderColumnContent(string $string, string $columnName, int $termId): string;
 
 	/**
 	 * Get the slug of the taxonomy where the additional column should appear.

--- a/src/Columns/User/AbstractUserColumns.php
+++ b/src/Columns/User/AbstractUserColumns.php
@@ -39,7 +39,7 @@ abstract class AbstractUserColumns implements ServiceInterface
 	 *
 	 * @return array         Modified column names array.
 	 */
-	abstract public function addColumnName(array $columns ): array;
+	abstract public function addColumnName(array $columns): array;
 
 	/**
 	 * Render the user column content in the custom user column
@@ -50,7 +50,7 @@ abstract class AbstractUserColumns implements ServiceInterface
 	 *
 	 * @return string             Output based on the column name.
 	 */
-	abstract public function renderColumnContent(string $output, string $columnName, int $userId ): string;
+	abstract public function renderColumnContent(string $output, string $columnName, int $userId): string;
 
 	/**
 	 * Make user columns sortable
@@ -59,5 +59,5 @@ abstract class AbstractUserColumns implements ServiceInterface
 	 *
 	 * @return array          Modified array of columns.
 	 */
-	abstract public function sortAddedColumns(array $columns ): array;
+	abstract public function sortAddedColumns(array $columns): array;
 }

--- a/src/Config/AbstractConfig.php
+++ b/src/Config/AbstractConfig.php
@@ -24,7 +24,7 @@ abstract class AbstractConfig implements ConfigInterface
 	 *
 	 * @return string Returns key prefixed with project prefix.
 	 */
-	public static function getConfig(string $key ): string
+	public static function getConfig(string $key): string
 	{
 		$projectPrefix = static::getProjectPrefix();
 		$projectPrefix = str_replace(' ', '-', $projectPrefix);
@@ -43,7 +43,7 @@ abstract class AbstractConfig implements ConfigInterface
 	 *
 	 * @return string
 	 */
-	public static function getProjectPath(string $path = '' ): string
+	public static function getProjectPath(string $path = ''): string
 	{
 		$locations = [
 			\trailingslashit(\get_stylesheet_directory()) . $path,

--- a/src/Config/ConfigCli.php
+++ b/src/Config/ConfigCli.php
@@ -85,13 +85,7 @@ class ConfigCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generates the config class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Config/ConfigCli.php
+++ b/src/Config/ConfigCli.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Class that registers WPCLI command for Config.
  *
  * @package EightshiftLibs\Config
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Config;
 
@@ -14,7 +15,8 @@ use EightshiftLibs\Cli\AbstractCli;
 /**
  * Class ConfigCli
  */
-class ConfigCli extends AbstractCli {
+class ConfigCli extends AbstractCli
+{
 
 	/**
 	 * Output dir relative path.
@@ -28,7 +30,8 @@ class ConfigCli extends AbstractCli {
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs( array $args ) : array {
+	public function getDevelopArgs(array $args): array
+	{
 		return [
 			'name'           => $args[1] ?? 'Boilerplate',
 			'version'        => $args[2] ?? '1',
@@ -41,9 +44,10 @@ class ConfigCli extends AbstractCli {
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
-	public function getDoc() : array {
+	public function getDoc(): array
+	{
 		return [
 			'shortdesc' => 'Generates project config class.',
 			'synopsis' => [
@@ -81,7 +85,14 @@ class ConfigCli extends AbstractCli {
 		];
 	}
 
-	public function __invoke( array $args, array $assocArgs ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generates the config class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
+	{
 
 		// Get Props.
 		$name          = $assocArgs['name'] ?? '';
@@ -91,34 +102,34 @@ class ConfigCli extends AbstractCli {
 		$routesVersion = $assocArgs['routes_version'] ?? '';
 
 		// Read the template contents, and replace the placeholders with provided variables.
-		$class = $this->getExampleTemplate( __DIR__, $this->getClassShortName() );
+		$class = $this->getExampleTemplate(__DIR__, $this->getClassShortName());
 
 		// Replace stuff in file.
-		$class = $this->renameClassName( $this->getClassShortName(), $class );
-		$class = $this->renameNamespace( $assocArgs, $class );
-		$class = $this->renameUse( $assocArgs, $class );
+		$class = $this->renameClassName($this->getClassShortName(), $class);
+		$class = $this->renameNamespace($assocArgs, $class);
+		$class = $this->renameUse($assocArgs, $class);
 
-		if ( ! empty( $name ) ) {
-			$class = str_replace( 'eightshift-libs', $name, $class );
+		if (! empty($name)) {
+			$class = str_replace('eightshift-libs', $name, $class);
 		}
 
-		if ( ! empty( $version ) ) {
-			$class = str_replace( '1.0.0', $version, $class );
+		if (! empty($version)) {
+			$class = str_replace('1.0.0', $version, $class);
 		}
 
-		if ( ! empty( $prefix ) ) {
-			$class = str_replace( "'eb'", "'{$prefix}'", $class );
+		if (! empty($prefix)) {
+			$class = str_replace("'eb'", "'{$prefix}'", $class);
 		}
 
-		if ( ! empty( $env ) ) {
-			$class = str_replace( 'EB_ENV', $env, $class );
+		if (! empty($env)) {
+			$class = str_replace('EB_ENV', $env, $class);
 		}
 
-		if ( ! empty( $routesVersion ) ) {
-			$class = str_replace( 'v1', $routesVersion, $class );
+		if (! empty($routesVersion)) {
+			$class = str_replace('v1', $routesVersion, $class);
 		}
 
 		// Output final class to new file/folder and finish.
-		$this->outputWrite( static::OUTPUT_DIR, $this->getClassShortName(), $class );
+		$this->outputWrite(static::OUTPUT_DIR, $this->getClassShortName(), $class);
 	}
 }

--- a/src/Config/ConfigDataInterface.php
+++ b/src/Config/ConfigDataInterface.php
@@ -50,7 +50,7 @@ interface ConfigInterface
 	 *
 	 * @return string
 	 */
-	public static function getProjectPath(string $path = '' ): string;
+	public static function getProjectPath(string $path = ''): string;
 
 	/**
 	 * Method that returns every string prefixed with project prefix based on project type.
@@ -60,5 +60,5 @@ interface ConfigInterface
 	 *
 	 * @return string Returns key prefixed with project prefix.
 	 */
-	public static function getConfig(string $key ): string;
+	public static function getConfig(string $key): string;
 }

--- a/src/CustomPostType/LabelGenerator.php
+++ b/src/CustomPostType/LabelGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing label generator class
  *
@@ -7,7 +8,7 @@
  * @package EightshiftLibs\CustomPostType
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\CustomPostType;
 
@@ -16,7 +17,8 @@ use EightshiftLibs\Exception\InvalidNouns;
 /**
  * Class that generates lables for custom post type.
  */
-final class LabelGenerator {
+final class LabelGenerator
+{
 
 	/**
 	 * Singular name UC Constant
@@ -67,11 +69,12 @@ final class LabelGenerator {
 	 * @return string[] array Array of labels.
 	 * @throws InvalidNouns Invalid nouns exception.
 	 */
-	public function getGeneratedLabels( array $nouns ) : array {
+	public function getGeneratedLabels(array $nouns): array
+	{
 
-		foreach ( self::REQUIRED_NOUNS as $noun_key ) {
-			if ( ! array_key_exists( $noun_key, $nouns ) ) {
-				throw InvalidNouns::fromKey( $noun_key );
+		foreach (self::REQUIRED_NOUNS as $noun_key) {
+			if (! array_key_exists($noun_key, $nouns)) {
+				throw InvalidNouns::fromKey($noun_key);
 			}
 		}
 

--- a/src/CustomPostType/PostTypeCli.php
+++ b/src/CustomPostType/PostTypeCli.php
@@ -99,13 +99,7 @@ class PostTypeCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generates a CPT class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/CustomPostType/PostTypeCli.php
+++ b/src/CustomPostType/PostTypeCli.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Class that registers WPCLI command for Custom Taxonomy.
  *
  * @package EightshiftLibs\CustomPostType
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\CustomPostType;
 
@@ -14,7 +15,8 @@ use EightshiftLibs\Cli\AbstractCli;
 /**
  * Class PostTypeCli
  */
-class PostTypeCli extends AbstractCli {
+class PostTypeCli extends AbstractCli
+{
 
 	/**
 	 * Output dir relative path.
@@ -28,7 +30,8 @@ class PostTypeCli extends AbstractCli {
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs( array $args ) : array {
+	public function getDevelopArgs(array $args): array
+	{
 		return [
 			'label'              => $args[1] ?? 'Products',
 			'slug'               => $args[2] ?? 'product',
@@ -43,9 +46,10 @@ class PostTypeCli extends AbstractCli {
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
-	public function getDoc() : array {
+	public function getDoc(): array
+	{
 		return [
 			'shortdesc' => 'Generates custom post type class file.',
 			'synopsis' => [
@@ -95,47 +99,54 @@ class PostTypeCli extends AbstractCli {
 		];
 	}
 
-	public function __invoke( array $args, array $assocArgs ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generates a CPT class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
+	{
 
 		// Get Props.
 		$label            = $assocArgs['label'];
-		$slug             = $this->prepareSlug( $assocArgs['slug'] );
-		$rewriteUrl       = $this->prepareSlug( $assocArgs['rewrite_url'] );
-		$restEndpointSlug = $this->prepareSlug( $assocArgs['rest_endpoint_slug'] );
+		$slug             = $this->prepareSlug($assocArgs['slug']);
+		$rewriteUrl       = $this->prepareSlug($assocArgs['rewrite_url']);
+		$restEndpointSlug = $this->prepareSlug($assocArgs['rest_endpoint_slug']);
 		$capability       = $assocArgs['capability'] ?? '';
 		$menuPosition     = $assocArgs['menu_position'] ?? '';
 		$menuIcon         = $assocArgs['menu_icon'] ?? '';
 
 		// Get full class name.
-		$className = $this->getFileName( $slug );
+		$className = $this->getFileName($slug);
 		$className = $this->getClassShortName() . $className;
 
 		// Read the template contents, and replace the placeholders with provided variables.
-		$class = $this->getExampleTemplate( __DIR__, $this->getClassShortName() );
+		$class = $this->getExampleTemplate(__DIR__, $this->getClassShortName());
 
 		// Replace stuff in file.
-		$class = $this->renameClassNameWithSufix( $this->getClassShortName(), $className, $class );
-		$class = $this->renameNamespace( $assocArgs, $class );
-		$class = $this->renameUse( $assocArgs, $class );
-		$class = $this->renameTextDomain( $assocArgs, $class );
-		$class = str_replace( 'example-slug', $slug, $class );
-		$class = str_replace( 'example-url-slug', $rewriteUrl, $class );
-		$class = str_replace( 'example-endpoint-slug', $restEndpointSlug, $class );
-		$class = str_replace( 'Example Name', $label, $class );
+		$class = $this->renameClassNameWithSuffix($this->getClassShortName(), $className, $class);
+		$class = $this->renameNamespace($assocArgs, $class);
+		$class = $this->renameUse($assocArgs, $class);
+		$class = $this->renameTextDomain($assocArgs, $class);
+		$class = str_replace('example-slug', $slug, $class);
+		$class = str_replace('example-url-slug', $rewriteUrl, $class);
+		$class = str_replace('example-endpoint-slug', $restEndpointSlug, $class);
+		$class = str_replace('Example Name', $label, $class);
 
-		if ( ! empty( $capability ) ) {
-			$class = str_replace( "'post'", "'{$capability}'", $class );
+		if (! empty($capability)) {
+			$class = str_replace("'post'", "'{$capability}'", $class);
 		}
 
-		if ( ! empty( $menuPosition ) ) {
-			$class = str_replace( '20', $menuPosition, $class );
+		if (! empty($menuPosition)) {
+			$class = str_replace('20', $menuPosition, $class);
 		}
 
-		if ( ! empty( $menuIcon ) ) {
-			$class = str_replace( 'dashicons-analytics', $menuIcon, $class );
+		if (! empty($menuIcon)) {
+			$class = str_replace('dashicons-analytics', $menuIcon, $class);
 		}
 
 		// Output final class to new file/folder and finish.
-		$this->outputWrite( static::OUTPUT_DIR, $className, $class );
+		$this->outputWrite(static::OUTPUT_DIR, $className, $class);
 	}
 }

--- a/src/CustomTaxonomy/TaxonomyCli.php
+++ b/src/CustomTaxonomy/TaxonomyCli.php
@@ -30,7 +30,7 @@ class TaxonomyCli extends AbstractCli
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs(array $args ): array
+	public function getDevelopArgs(array $args): array
 	{
 		return [
 			'label'              => $args[1] ?? 'Locations',
@@ -78,7 +78,13 @@ class TaxonomyCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate a custom taxonomy
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Get Props.
@@ -95,7 +101,7 @@ class TaxonomyCli extends AbstractCli
 		$class = $this->getExampleTemplate(__DIR__, $this->getClassShortName());
 
 		// Replace stuff in file.
-		$class = $this->renameClassNameWithSufix($this->getClassShortName(), $className, $class);
+		$class = $this->renameClassNameWithSuffix($this->getClassShortName(), $className, $class);
 		$class = $this->renameNamespace($assocArgs, $class);
 		$class = $this->renameUse($assocArgs, $class);
 		$class = $this->renameTextDomain($assocArgs, $class);

--- a/src/CustomTaxonomy/TaxonomyCli.php
+++ b/src/CustomTaxonomy/TaxonomyCli.php
@@ -78,13 +78,7 @@ class TaxonomyCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate a custom taxonomy
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/CustomTaxonomy/TaxonomyExample.php
+++ b/src/CustomTaxonomy/TaxonomyExample.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * The Blog_Taxonomy specific functionality.
  *
  * @package EightshiftLibs\CustomTaxonomy
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\CustomTaxonomy;
 
@@ -14,7 +15,8 @@ use EightshiftLibs\CustomTaxonomy\AbstractTaxonomy;
 /**
  * Class TaxonomyExample
  */
-class TaxonomyExample extends AbstractTaxonomy {
+class TaxonomyExample extends AbstractTaxonomy
+{
 
 	/**
 	 * Taxonomy slug costant.
@@ -35,7 +37,8 @@ class TaxonomyExample extends AbstractTaxonomy {
 	 *
 	 * @return string Custom taxonomy slug.
 	 */
-	protected function getTaxonomySlug() : string {
+	protected function getTaxonomySlug(): string
+	{
 		return static::TAXONOMY_SLUG;
 	}
 
@@ -44,7 +47,8 @@ class TaxonomyExample extends AbstractTaxonomy {
 	 *
 	 * @return string|array Custom post type slug or an array of slugs.
 	 */
-	protected function getPostTypeSlug() {
+	protected function getPostTypeSlug()
+	{
 		return 'post';
 	}
 
@@ -53,10 +57,11 @@ class TaxonomyExample extends AbstractTaxonomy {
 	 *
 	 * @return array Array of arguments.
 	 */
-	protected function getTaxonomyArguments() : array {
+	protected function getTaxonomyArguments(): array
+	{
 		return [
 			'hierarchical'      => true,
-			'label'             => \esc_html__( 'Example Name', 'eightshift-libs' ),
+			'label'             => \esc_html__('Example Name', 'eightshift-libs'),
 			'show_ui'           => true,
 			'show_admin_column' => true,
 			'show_in_nav_menus' => false,

--- a/src/Db/DbExport.php
+++ b/src/Db/DbExport.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  *
  * @return void
  */
-function dbExport(string $projectRootPath, array $args = [] )
+function dbExport(string $projectRootPath, array $args = [])
 {
 
 	// Check if optional parameters exists.
@@ -68,7 +68,7 @@ function dbExport(string $projectRootPath, array $args = [] )
 	}
 
 	if (! empty($exportFiles)) {
-		\WP_CLI::log(shell_exec("tar czf {$exportFileName} {$exportFiles}")); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+		\WP_CLI::log(shell_exec("tar czf {$exportFileName} {$exportFiles}"));
 		\WP_CLI::log('Compressing folders success.');
 		\WP_CLI::log('--------------------------------------------------');
 	}

--- a/src/Db/DbImport.php
+++ b/src/Db/DbImport.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
   *
   * @return void
   */
-function dbImport(string $projectRootPath, array $args = [], string $setupFile = 'setup.json' )
+function dbImport(string $projectRootPath, array $args = [], string $setupFile = 'setup.json')
 {
 
 	// Check if mandatory parameters exists.
@@ -34,14 +34,14 @@ function dbImport(string $projectRootPath, array $args = [], string $setupFile =
 	}
 
 	// Change execution folder.
-	if ( ! is_dir($projectRootPath)) {
+	if (! is_dir($projectRootPath)) {
 		\WP_CLI::error("Folder doesn't exist on this path: {$projectRootPath}.");
 	}
 
 	chdir($projectRootPath);
 
 	// Check if setup exists.
-	if ( ! file_exists($setupFile)) {
+	if (! file_exists($setupFile)) {
 		\WP_CLI::error("setup.json is missing at this path: {$setupFile}.");
 	}
 
@@ -61,7 +61,7 @@ function dbImport(string $projectRootPath, array $args = [], string $setupFile =
 	}
 
 	// Die if from key is missing and not valid.
-	if ( ! isset($urls[ $from ]) || empty($urls[ $from ])) {
+	if (! isset($urls[ $from ]) || empty($urls[ $from ])) {
 		\WP_CLI::error("{$from} key is missing or empty in urls.");
 	} else {
 		$from        = \wp_parse_url($urls[ $from ]);
@@ -70,7 +70,7 @@ function dbImport(string $projectRootPath, array $args = [], string $setupFile =
 	}
 
 	// Die if to key is missing and not valid.
-	if ( ! isset($urls[ $to ]) || empty($urls[ $to ])) {
+	if (! isset($urls[ $to ]) || empty($urls[ $to ])) {
 		\WP_CLI::error("{$to} key is missing or empty in urls.");
 	} else {
 		$to        = \wp_parse_url($urls[ $to ]);
@@ -89,7 +89,7 @@ function dbImport(string $projectRootPath, array $args = [], string $setupFile =
 
 	// Remove old db export folder if it exists.
 	if (file_exists($exportFolderName)) {
-		\WP_CLI::log(shell_exec("rm -rf {$exportFolderName}")); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+		\WP_CLI::log(shell_exec("rm -rf {$exportFolderName}"));
 		\WP_CLI::log("Removed old temp {$exportFolderName} folder.");
 		\WP_CLI::log('--------------------------------------------------');
 	}
@@ -100,7 +100,7 @@ function dbImport(string $projectRootPath, array $args = [], string $setupFile =
 	\WP_CLI::log('--------------------------------------------------');
 
 	// Export files to new temp folder.
-	\WP_CLI::log(shell_exec("tar zxf {$exportFileName} -C {$exportFolderName}")); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+	\WP_CLI::log(shell_exec("tar zxf {$exportFileName} -C {$exportFolderName}"));
 	\WP_CLI::log("Exported {$exportFileName} to {$exportFolderName} folder.");
 	\WP_CLI::log('--------------------------------------------------');
 

--- a/src/Db/DbImportCli.php
+++ b/src/Db/DbImportCli.php
@@ -40,7 +40,7 @@ class DbImportCli extends AbstractCli
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs(array $args ): array
+	public function getDevelopArgs(array $args): array
 	{
 		return [
 			'root' => $args[1] ?? './',
@@ -67,7 +67,13 @@ class DbImportCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Writes setup.json to the project root.
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Get Props.

--- a/src/Db/DbImportCli.php
+++ b/src/Db/DbImportCli.php
@@ -67,13 +67,7 @@ class DbImportCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Writes setup.json to the project root.
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Db/ExportCli.php
+++ b/src/Db/ExportCli.php
@@ -54,13 +54,7 @@ class ExportCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Exports the database
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		require $this->getLibsPath('src/Db/DbExport.php');

--- a/src/Db/ExportCli.php
+++ b/src/Db/ExportCli.php
@@ -54,7 +54,13 @@ class ExportCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Exports the database
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		require $this->getLibsPath('src/Db/DbExport.php');

--- a/src/Db/ImportCli.php
+++ b/src/Db/ImportCli.php
@@ -54,13 +54,7 @@ class ImportCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Imports the database
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		require $this->getLibsPath('src/Db/DbImport.php');

--- a/src/Db/ImportCli.php
+++ b/src/Db/ImportCli.php
@@ -54,7 +54,13 @@ class ImportCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Imports the database
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		require $this->getLibsPath('src/Db/DbImport.php');

--- a/src/Enqueue/Admin/EnqueueAdminCli.php
+++ b/src/Enqueue/Admin/EnqueueAdminCli.php
@@ -35,13 +35,7 @@ class EnqueueAdminCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generates the enqueue class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Enqueue/Admin/EnqueueAdminCli.php
+++ b/src/Enqueue/Admin/EnqueueAdminCli.php
@@ -35,7 +35,13 @@ class EnqueueAdminCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generates the enqueue class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Enqueue/Admin/EnqueueAdminExample.php
+++ b/src/Enqueue/Admin/EnqueueAdminExample.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * The Admin Enqueue specific functionality.
  *
  * @package EightshiftLibs\Enqueue\Admin
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Enqueue\Admin;
 
@@ -18,14 +19,16 @@ use EightshiftLibs\Manifest\ManifestInterface;
  *
  * This class handles enqueue scripts and styles.
  */
-class EnqueueAdminExample extends AbstractEnqueueAdmin {
+class EnqueueAdminExample extends AbstractEnqueueAdmin
+{
 
 	/**
 	 * Create a new admin instance.
 	 *
 	 * @param ManifestInterface $manifest Inject manifest which holds data about assets from manifest.json.
 	 */
-	public function __construct( ManifestInterface $manifest ) {
+	public function __construct(ManifestInterface $manifest)
+	{
 		$this->manifest = $manifest;
 	}
 
@@ -34,10 +37,11 @@ class EnqueueAdminExample extends AbstractEnqueueAdmin {
 	 *
 	 * @return void
 	 */
-	public function register() : void {
-		add_action( 'login_enqueue_scripts', [ $this, 'enqueueStyles' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueueStyles' ], 50 );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueueScripts' ] );
+	public function register(): void
+	{
+		add_action('login_enqueue_scripts', [ $this, 'enqueueStyles' ]);
+		add_action('admin_enqueue_scripts', [ $this, 'enqueueStyles' ], 50);
+		add_action('admin_enqueue_scripts', [ $this, 'enqueueScripts' ]);
 	}
 
 	/**
@@ -45,7 +49,8 @@ class EnqueueAdminExample extends AbstractEnqueueAdmin {
 	 *
 	 * @return string
 	 */
-	public function getAssetsPrefix() : string {
+	public function getAssetsPrefix(): string
+	{
 		return Config::getProjectName();
 	}
 
@@ -54,7 +59,8 @@ class EnqueueAdminExample extends AbstractEnqueueAdmin {
 	 *
 	 * @return string
 	 */
-	public function getAssetsVersion() : string {
+	public function getAssetsVersion(): string
+	{
 		return Config::getProjectVersion();
 	}
 }

--- a/src/Enqueue/Blocks/EnqueueBlocksCli.php
+++ b/src/Enqueue/Blocks/EnqueueBlocksCli.php
@@ -26,7 +26,7 @@ class EnqueueBlocksCli extends AbstractCli
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function getDoc(): array
 	{
@@ -35,7 +35,13 @@ class EnqueueBlocksCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the Enqueue Block class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Enqueue/Blocks/EnqueueBlocksCli.php
+++ b/src/Enqueue/Blocks/EnqueueBlocksCli.php
@@ -35,13 +35,7 @@ class EnqueueBlocksCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the Enqueue Block class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Enqueue/Blocks/EnqueueBlocksExample.php
+++ b/src/Enqueue/Blocks/EnqueueBlocksExample.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Enqueue class used to define all script and style enqueues for Gutenberg blocks.
  *
  * @package EightshiftLibs\Enqueue\Blocks
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Enqueue\Blocks;
 
@@ -16,33 +17,36 @@ use EightshiftLibs\Manifest\ManifestInterface;
 /**
  * Enqueue_Blocks class.
  */
-class EnqueueBlocksExample extends AbstractEnqueueBlocks {
+class EnqueueBlocksExample extends AbstractEnqueueBlocks
+{
 
 	/**
 	 * Create a new admin instance.
 	 *
 	 * @param ManifestInterface $manifest Inject manifest which holds data about assets from manifest.json.
 	 */
-	public function __construct( ManifestInterface $manifest ) {
+	public function __construct(ManifestInterface $manifest)
+	{
 		$this->manifest = $manifest;
 	}
 
 	/**
 	 * Register all the hooks
 	 */
-	public function register() : void {
+	public function register(): void
+	{
 
 		// Editor only script.
-		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueueBlockEditorScript' ] );
+		add_action('enqueue_block_editor_assets', [ $this, 'enqueueBlockEditorScript' ]);
 
 		// Editor only style.
-		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueueBlockEditorStyle' ], 50 );
+		add_action('enqueue_block_editor_assets', [ $this, 'enqueueBlockEditorStyle' ], 50);
 
 		// Editor and frontend style.
-		add_action( 'enqueue_block_assets', [ $this, 'enqueueBlockStyle' ], 50 );
+		add_action('enqueue_block_assets', [ $this, 'enqueueBlockStyle' ], 50);
 
 		// Frontend only script.
-		add_action( 'wp_enqueue_scripts', [ $this, 'enqueueBlockScript' ] );
+		add_action('wp_enqueue_scripts', [ $this, 'enqueueBlockScript' ]);
 	}
 
 	/**
@@ -50,7 +54,8 @@ class EnqueueBlocksExample extends AbstractEnqueueBlocks {
 	 *
 	 * @return string
 	 */
-	public function getAssetsPrefix() : string {
+	public function getAssetsPrefix(): string
+	{
 		return Config::getProjectName();
 	}
 
@@ -59,7 +64,8 @@ class EnqueueBlocksExample extends AbstractEnqueueBlocks {
 	 *
 	 * @return string
 	 */
-	public function getAssetsVersion() : string {
+	public function getAssetsVersion(): string
+	{
 		return Config::getProjectVersion();
 	}
 }

--- a/src/Enqueue/Theme/EnqueueThemeCli.php
+++ b/src/Enqueue/Theme/EnqueueThemeCli.php
@@ -35,7 +35,13 @@ class EnqueueThemeCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the Enqueue Theme class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Enqueue/Theme/EnqueueThemeCli.php
+++ b/src/Enqueue/Theme/EnqueueThemeCli.php
@@ -35,13 +35,7 @@ class EnqueueThemeCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the Enqueue Theme class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Enqueue/Theme/EnqueueThemeExample.php
+++ b/src/Enqueue/Theme/EnqueueThemeExample.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * The Theme/Frontend Enqueue specific functionality.
  *
  * @package EightshiftLibs\Enqueue\Theme
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Enqueue\Theme;
 
@@ -16,14 +17,16 @@ use EightshiftLibs\Manifest\ManifestInterface;
 /**
  * Class EnqueueThemeExample
  */
-class EnqueueThemeExample extends AbstractEnqueueTheme {
+class EnqueueThemeExample extends AbstractEnqueueTheme
+{
 
 	/**
 	 * Create a new admin instance.
 	 *
 	 * @param ManifestInterface $manifest Inject manifest which holds data about assets from manifest.json.
 	 */
-	public function __construct( ManifestInterface $manifest ) {
+	public function __construct(ManifestInterface $manifest)
+	{
 		$this->manifest = $manifest;
 	}
 
@@ -32,9 +35,10 @@ class EnqueueThemeExample extends AbstractEnqueueTheme {
 	 *
 	 * @return void
 	 */
-	public function register() : void {
-		add_action( 'wp_enqueue_scripts', [ $this, 'enqueueStyles' ], 10 );
-		add_action( 'wp_enqueue_scripts', [ $this, 'enqueueScripts' ] );
+	public function register(): void
+	{
+		add_action('wp_enqueue_scripts', [ $this, 'enqueueStyles' ], 10);
+		add_action('wp_enqueue_scripts', [ $this, 'enqueueScripts' ]);
 	}
 
 	/**
@@ -42,7 +46,8 @@ class EnqueueThemeExample extends AbstractEnqueueTheme {
 	 *
 	 * @return string
 	 */
-	public function getAssetsPrefix() : string {
+	public function getAssetsPrefix(): string
+	{
 		return Config::getProjectName();
 	}
 
@@ -51,7 +56,8 @@ class EnqueueThemeExample extends AbstractEnqueueTheme {
 	 *
 	 * @return string
 	 */
-	public function getAssetsVersion() : string {
+	public function getAssetsVersion(): string
+	{
 		return Config::getProjectVersion();
 	}
 }

--- a/src/ExampleService/ServiceExampleCli.php
+++ b/src/ExampleService/ServiceExampleCli.php
@@ -35,7 +35,7 @@ class ServiceExampleCli extends AbstractCli
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs(array $args ): array
+	public function getDevelopArgs(array $args): array
 	{
 		return [
 			'folder'    => $args[1] ?? 'testFolder/novi',
@@ -69,7 +69,13 @@ class ServiceExampleCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the service class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Get Props.
@@ -89,7 +95,7 @@ class ServiceExampleCli extends AbstractCli
 
 		// Create new namespace from folder structure.
 		$folderParts = array_map(
-			function ($item ) {
+			function ($item) {
 				return ucfirst($item);
 			},
 			explode('/', $folder)

--- a/src/ExampleService/ServiceExampleCli.php
+++ b/src/ExampleService/ServiceExampleCli.php
@@ -69,13 +69,7 @@ class ServiceExampleCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the service class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Exception/ComponentException.php
+++ b/src/Exception/ComponentException.php
@@ -1,18 +1,20 @@
 <?php
+
 /**
  * File containing the failure exception class when trying to locate a template that doesn't exist.
  *
  * @package EightshiftLibs\Exception
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
 /**
  * Class Component_Exception.
  */
-final class ComponentException extends \InvalidArgumentException implements GeneralExceptionInterface {
+final class ComponentException extends \InvalidArgumentException implements GeneralExceptionInterface
+{
 
 	/**
 	 * Throws exception if ensure_string argument is invalid.
@@ -21,12 +23,14 @@ final class ComponentException extends \InvalidArgumentException implements Gene
 	 *
 	 * @return static
 	 */
-	public static function throwNotStringOrVariable( $variable ) {
+	public static function throwNotStringOrVariable($variable)
+	{
 		return new static(
 			sprintf(
-				esc_html__( '%1$s variable is not a string or array but rather %2$s', 'eightshift-libs' ),
+				/* translators: %1$s is replaced with the name of the variable, and %2$s with its type. */
+				esc_html__('%1$s variable is not a string or array but rather %2$s', 'eightshift-libs'),
 				$variable,
-				gettype( $variable )
+				gettype($variable)
 			)
 		);
 	}
@@ -37,10 +41,12 @@ final class ComponentException extends \InvalidArgumentException implements Gene
 	 * @param string $component Missing component name.
 	 * @return static
 	 */
-	public static function throwUnableToLocateComponent( string $component ) {
+	public static function throwUnableToLocateComponent(string $component)
+	{
 		return new static(
 			sprintf(
-				esc_html__( 'Unable to locate component by path: %s', 'eightshift-libs' ),
+				/* translators: %s is replaced with the path of the component. */
+				esc_html__('Unable to locate component by path: %s', 'eightshift-libs'),
 				$component
 			)
 		);

--- a/src/Exception/FailedToLoadView.php
+++ b/src/Exception/FailedToLoadView.php
@@ -1,18 +1,20 @@
 <?php
+
 /**
  * File containing failed to load view class
  *
  * @package EightshiftLibs\Exception
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
 /**
  * Class Failed_To_Load_View.
  */
-final class FailedToLoadView extends \RuntimeException implements GeneralExceptionInterface {
+final class FailedToLoadView extends \RuntimeException implements GeneralExceptionInterface
+{
 
 	/**
 	 * Create a new instance of the exception if the view file itself created
@@ -24,13 +26,15 @@ final class FailedToLoadView extends \RuntimeException implements GeneralExcepti
 	 *
 	 * @return static
 	 */
-	public static function viewException( $uri, $exception ) {
+	public static function viewException($uri, $exception)
+	{
 		$message = sprintf(
-			esc_html__( 'Could not load the View URI: %1$s. Reason: %2$s.', 'eightshift-libs' ),
+			/* translators: %1$s will be replaced with view URI, and %2$s with error. */
+			esc_html__('Could not load the View URI: %1$s. Reason: %2$s.', 'eightshift-libs'),
 			$uri,
 			$exception->getMessage()
 		);
 
-		return new static( $message, $exception->getCode(), $exception );
+		return new static($message, $exception->getCode(), $exception);
 	}
 }

--- a/src/Exception/InvalidBlock.php
+++ b/src/Exception/InvalidBlock.php
@@ -22,7 +22,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	 * @return static
 	 */
 	public static function missingBlocksException()
-{
+	{
 		return new static(esc_html__('There are no blocks added in your project.', 'eightshift-libs'));
 	}
 
@@ -33,9 +33,11 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	 *
 	 * @return static
 	 */
-	public static function missingNameException(string $blockPath )  {
+	public static function missingNameException(string $blockPath)
+	{
 		return new static(
 			sprintf(
+				/* translators: %s will be replaced with the path where the block should be. */
 				esc_html__('Block in this path %s is missing blockName key in its manifest.json.', 'eightshift-libs'),
 				$blockPath
 			)
@@ -50,9 +52,11 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	 *
 	 * @return static
 	 */
-	public static function missingViewException(string $blockName, string $blockPath )  {
+	public static function missingViewException(string $blockName, string $blockPath)
+	{
 		return new static(
 			sprintf(
+				/* translators: %1$s is going to be replaced with the template name, %2$s with the template path. */
 				esc_html__('Block with this name %1$s is missing view template. Template name should be called %1$s.php, and it should be located in this path %2$s', 'eightshift-libs'),
 				$blockName,
 				$blockPath
@@ -67,10 +71,12 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	 *
 	 * @return static
 	 */
-	public static function missingRenderViewException(string $blockPath )   {
+	public static function missingRenderViewException(string $blockPath)
+	{
 		return new static(
 			sprintf(
-				esc_html__('Block view is missing in the provided path. Please chech if %s is the right path for your block view.', 'eightshift-libs'),
+				/* translators: %s will be replaced with the block path. */
+				esc_html__('Block view is missing in the provided path. Please check if %s is the right path for your block view.', 'eightshift-libs'),
 				$blockPath
 			)
 		);
@@ -83,9 +89,11 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	 *
 	 * @return static
 	 */
-	public static function missingSettingsManifestException(string $settings_manifest_path )     {
+	public static function missingSettingsManifestException(string $settings_manifest_path)
+	{
 		return new static(
 			sprintf(
+				/* translators: %s will be replaced with the location of the manifest for the block. */
 				esc_html__('Global blocks settings manifest.json is missing on this location: %s.', 'eightshift-libs'),
 				$settings_manifest_path
 			)
@@ -99,9 +107,11 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	 *
 	 * @return static
 	 */
-	public static function missingWrapperManifestException(string $settings_manifest_path )  {
+	public static function missingWrapperManifestException(string $settings_manifest_path)
+	{
 		return new static(
 			sprintf(
+				/* translators: %s will be replaced with the manifest path location. */
 				esc_html__('Wrapper blocks settings manifest.json is missing on this location: %s.', 'eightshift-libs'),
 				$settings_manifest_path
 			)
@@ -115,9 +125,11 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	 *
 	 * @return static
 	 */
-	public static function missingWrapperViewException(string $wrapper_path )    {
+	public static function missingWrapperViewException(string $wrapper_path)
+	{
 		return new static(
 			sprintf(
+				/* translators: %s will be replaced with the view template path location. */
 				esc_html__('Wrapper view is missing. Template should be located in this path %s', 'eightshift-libs'),
 				$wrapper_path
 			)
@@ -129,7 +141,8 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	 *
 	 * @return static
 	 */
-	public static function missingNamespaceException()    {
+	public static function missingNamespaceException()
+	{
 		return new static(
 			esc_html__('Global Blocks settings manifest.json is missing a key called namespace. This key prefixes all block names.', 'eightshift-libs')
 		);

--- a/src/Exception/InvalidCallback.php
+++ b/src/Exception/InvalidCallback.php
@@ -1,18 +1,20 @@
 <?php
+
 /**
  * File containing the invalid callback exception class
  *
  * @package EightshiftLibs\Exception
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
 /**
  * Class Invalid_Callback.
  */
-final class InvalidCallback extends \InvalidArgumentException implements GeneralExceptionInterface {
+final class InvalidCallback extends \InvalidArgumentException implements GeneralExceptionInterface
+{
 
 	/**
 	 * Create a new instance of the exception for a callback class name that is
@@ -22,14 +24,16 @@ final class InvalidCallback extends \InvalidArgumentException implements General
 	 *
 	 * @return static
 	 */
-	public static function fromCallback( $callback ) {
+	public static function fromCallback($callback)
+	{
 		$message = sprintf(
-			esc_html__( 'The callback %s is not recognized and cannot be registered.', 'eightshift-libs' ),
-			is_object( $callback )
-				? get_class( $callback )
+			/* translators: %s is replaced with callback name. */
+			esc_html__('The callback %s is not recognized and cannot be registered.', 'eightshift-libs'),
+			is_object($callback)
+				? get_class($callback)
 				: (string) $callback
 		);
 
-		return new static( $message );
+		return new static($message);
 	}
 }

--- a/src/Exception/InvalidManifest.php
+++ b/src/Exception/InvalidManifest.php
@@ -1,18 +1,20 @@
 <?php
+
 /**
  * File containing the failure exception class when assets aren't bundled or missing.
  *
  * @package EightshiftLibs\Exception
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
 /**
  * Class Invalid_Manifest.
  */
-final class InvalidManifest extends \InvalidArgumentException implements GeneralExceptionInterface {
+final class InvalidManifest extends \InvalidArgumentException implements GeneralExceptionInterface
+{
 
 	/**
 	 * Throws error if manifest key is missing.
@@ -21,10 +23,12 @@ final class InvalidManifest extends \InvalidArgumentException implements General
 	 *
 	 * @return static
 	 */
-	public static function missingManifestItemException( string $key ) {
+	public static function missingManifestItemException(string $key)
+	{
 		return new static(
 			sprintf(
-				esc_html__( '%s key does not exist in manifest.json. Please check if provided key is correct.', 'eightshift-libs' ),
+				/* translators: %s is replaced by the missing key in the manifest.json */
+				esc_html__('%s key does not exist in manifest.json. Please check if provided key is correct.', 'eightshift-libs'),
 				$key
 			)
 		);
@@ -37,10 +41,12 @@ final class InvalidManifest extends \InvalidArgumentException implements General
 	 *
 	 * @return static
 	 */
-	public static function missingManifestException( string $path ) {
+	public static function missingManifestException(string $path)
+	{
 		return new static(
 			sprintf(
-				esc_html__( 'manifest.json is missing at this path: %s. Bundle the theme before using it. Or your bundling process is returning and error.', 'eightshift-libs' ),
+				/* translators: %s is replaced by the path where the manifest.json should be */
+				esc_html__('manifest.json is missing at this path: %s. Bundle the theme before using it. Or your bundling process is returning an error.', 'eightshift-libs'),
 				$path
 			)
 		);
@@ -55,7 +61,8 @@ final class InvalidManifest extends \InvalidArgumentException implements General
 	 *
 	 * @return static
 	 */
-	public static function manifestStructureException( string $error ) {
-		return new static( $error );
+	public static function manifestStructureException(string $error)
+	{
+		return new static($error);
 	}
 }

--- a/src/Exception/InvalidNouns.php
+++ b/src/Exception/InvalidNouns.php
@@ -1,18 +1,20 @@
 <?php
+
 /**
  * File containing invalid nouns exception
  *
  * @package EightshiftLibs\Exception
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
 /**
  * Class Invalid_Nouns.
  */
-final class InvalidNouns extends \InvalidArgumentException implements GeneralExceptionInterface {
+final class InvalidNouns extends \InvalidArgumentException implements GeneralExceptionInterface
+{
 
 	/**
 	 * Create a new instance of the exception for an array of nouns that is
@@ -22,12 +24,14 @@ final class InvalidNouns extends \InvalidArgumentException implements GeneralExc
 	 *
 	 * @return static
 	 */
-	public static function fromKey( string $key ) {
+	public static function fromKey(string $key)
+	{
 		$message = sprintf(
-			esc_html__( 'The array of nouns passed into the Label_Generator is missing the %s noun.', 'eightshift-libs' ),
+			/* translators: %s is replaced with name of the noun. */
+			esc_html__('The array of nouns passed into the Label_Generator is missing the %s noun.', 'eightshift-libs'),
 			$key
 		);
 
-		return new static( $message );
+		return new static($message);
 	}
 }

--- a/src/Exception/InvalidService.php
+++ b/src/Exception/InvalidService.php
@@ -1,18 +1,20 @@
 <?php
+
 /**
  * File containing the invalid service exception class
  *
  * @package EightshiftLibs\Exception
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
 /**
  * Class Invalid_Service.
  */
-final class InvalidService extends \InvalidArgumentException implements GeneralExceptionInterface {
+final class InvalidService extends \InvalidArgumentException implements GeneralExceptionInterface
+{
 
 	/**
 	 * Create a new instance of the exception for a service class name that is
@@ -22,14 +24,16 @@ final class InvalidService extends \InvalidArgumentException implements GeneralE
 	 *
 	 * @return static
 	 */
-	public static function fromService( $service ) {
+	public static function fromService($service)
+	{
 		$message = sprintf(
-			esc_html__( 'The service %s is not recognized and cannot be registered.', 'eightshift-libs' ),
-			is_object( $service )
-				? get_class( $service )
+			/* translators: %s is replaced with name of the service. */
+			esc_html__('The service %s is not recognized and cannot be registered.', 'eightshift-libs'),
+			is_object($service)
+				? get_class($service)
 				: (string) $service
 		);
 
-		return new static( $message );
+		return new static($message);
 	}
 }

--- a/src/Exception/PluginActivationFailure.php
+++ b/src/Exception/PluginActivationFailure.php
@@ -1,18 +1,20 @@
 <?php
+
 /**
  * File containing the plugin activation failure exception class
  *
  * @package EightshiftLibs\Exception
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
 /**
  * Class Plugin_Activation_Failure.
  */
-final class PluginActivationFailure extends \RuntimeException implements GeneralExceptionInterface {
+final class PluginActivationFailure extends \RuntimeException implements GeneralExceptionInterface
+{
 
 	/**
 	 * Create a new instance of the exception in case plugin cannot be activated.
@@ -21,7 +23,8 @@ final class PluginActivationFailure extends \RuntimeException implements General
 	 *
 	 * @return static
 	 */
-	public static function activationMessage( $message ) {
-		return new static( $message );
+	public static function activationMessage($message)
+	{
+		return new static($message);
 	}
 }

--- a/src/Gitignore/GitIgnoreCli.php
+++ b/src/Gitignore/GitIgnoreCli.php
@@ -40,7 +40,7 @@ class GitIgnoreCli extends AbstractCli
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs(array $args ): array
+	public function getDevelopArgs(array $args): array
 	{
 		return [
 			'root' => $args[1] ?? './',
@@ -50,7 +50,7 @@ class GitIgnoreCli extends AbstractCli
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function getDoc(): array
 	{
@@ -67,7 +67,13 @@ class GitIgnoreCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the gitignore class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Get Props.

--- a/src/Gitignore/GitIgnoreCli.php
+++ b/src/Gitignore/GitIgnoreCli.php
@@ -67,13 +67,7 @@ class GitIgnoreCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the gitignore class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Helpers for components
  *
  * @package EightshiftLibs\Helpers
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Helpers;
 
@@ -14,7 +15,8 @@ use EightshiftLibs\Exception\ComponentException;
 /**
  * Helpers for components
  */
-class Components {
+class Components
+{
 
 	/**
 	 * Makes sure the output is string. Useful for converting an array of components into a string.
@@ -24,15 +26,16 @@ class Components {
 	 *
 	 * @throws ComponentException When $variable is not a string or array.
 	 */
-	public static function ensureString( $variable ) : string {
+	public static function ensureString($variable): string
+	{
 		$output = '';
 
-		if ( is_array( $variable ) ) {
-			$output = implode( '', $variable );
-		} elseif ( is_string( $variable ) ) {
+		if (is_array($variable)) {
+			$output = implode('', $variable);
+		} elseif (is_string($variable)) {
 			$output = $variable;
 		} else {
-			ComponentException::throwNotStringOrVariable( $variable );
+			ComponentException::throwNotStringOrVariable($variable);
 		}
 
 		return $output;
@@ -44,8 +47,9 @@ class Components {
 	 * @param  array $classes Array of classes.
 	 * @return string
 	 */
-	public static function classnames( array $classes ) : string {
-		return trim( implode( ' ', $classes ) );
+	public static function classnames(array $classes): string
+	{
+		return trim(implode(' ', $classes));
 	}
 
 	/**
@@ -57,39 +61,41 @@ class Components {
 	 *
 	 * @param  string $component  Component's name or full path (ending with .php).
 	 * @param  array  $attributes Array of attributes that's implicitly passed to component.
-	 * @param  string $parentPath If parent path is provides it will be appended to the file location, if not get_template_directory_uri() will be used as a default parent path.
+	 * @param  string $parentPath If parent path is provides it will be appended to the file location.
+	 *                            If not get_template_directory_uri() will be used as a default parent path.
 	 * @return string
 	 *
 	 * @throws \Exception When we're unable to find the component by $component.
 	 */
-	public static function render( string $component, array $attributes = [], string $parentPath = '' ) {
+	public static function render(string $component, array $attributes = [], string $parentPath = '')
+	{
 
-		if ( empty( $parentPath ) ) {
+		if (empty($parentPath)) {
 			$parentPath = \get_template_directory();
 		}
 
 		// Detect if user passed component name or path.
-		if ( strpos( $component, '.php' ) !== false ) {
+		if (strpos($component, '.php') !== false) {
 			$componentPath = "{$parentPath}/$component";
 		} else {
 			$componentPath = "{$parentPath}/src/Blocks/Components/{$component}/{$component}.php";
 		}
 
-		if ( ! file_exists( $componentPath ) ) {
-			ComponentException::throwUnableToLocateComponent( $componentPath );
+		if (! file_exists($componentPath)) {
+			ComponentException::throwUnableToLocateComponent($componentPath);
 		}
 
 		ob_start();
 
 		// Wrap component with parent BEM selector if parent's class is provided. Used
 		// for setting specific styles for components rendered inside other components.
-		if ( isset( $attributes['parentClass'] ) ) {
-			echo \wp_kses_post( "<div class=\"{$attributes['parentClass']}__{$component}\">" );
+		if (isset($attributes['parentClass'])) {
+			echo \wp_kses_post("<div class=\"{$attributes['parentClass']}__{$component}\">");
 		}
 
 		require $componentPath;
 
-		if ( isset( $attributes['parentClass'] ) ) {
+		if (isset($attributes['parentClass'])) {
 			echo '</div>';
 		}
 
@@ -111,21 +117,22 @@ class Components {
 	 * Output:
 	 * block-column__width-large--4
 	 */
-	public static function responsiveSelectors( array $items, string $selector, string $parent, $useModifier = true ) {
+	public static function responsiveSelectors(array $items, string $selector, string $parent, $useModifier = true)
+	{
 		$output = [];
 
-		foreach ( $items as $itemKey => $itemValue ) {
-			if ( empty( $itemValue ) && $itemValue !== 0 ) {
+		foreach ($items as $itemKey => $itemValue) {
+			if (empty($itemValue) && $itemValue !== 0) {
 				continue;
 			}
 
-			if ( $useModifier ) {
+			if ($useModifier) {
 				$output[] = "{$parent}__{$selector}-{$itemKey}--{$itemValue}";
 			} else {
 				$output[] = "{$parent}__{$selector}-{$itemKey}";
 			}
 		}
 
-		return static::classnames( $output );
+		return static::classnames($output);
 	}
 }

--- a/src/Helpers/ErrorLoggerTrait.php
+++ b/src/Helpers/ErrorLoggerTrait.php
@@ -1,18 +1,20 @@
 <?php
+
 /**
  * The object helper specific functionality for errors.
  *
  * @package EightshiftLibs\Helpers
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Helpers;
 
 /**
  * Error logger trait.
  */
-trait ErrorLoggerTrait {
+trait ErrorLoggerTrait
+{
 
 	/**
 	 * Ensure correct response for rest using handler function.
@@ -24,7 +26,8 @@ trait ErrorLoggerTrait {
 	 *
 	 * @return \WP_Error|array \WP_Error instance with error message and status or array.
 	 */
-	public function restResponseHandler( int $code, string $status, $msg, $data = null ) {
+	public function restResponseHandler(int $code, string $status, $msg, $data = null)
+	{
 		$output = [
 			'code'    => $code,
 			'status'  => $status,
@@ -32,14 +35,14 @@ trait ErrorLoggerTrait {
 			'data'    => $data,
 		];
 
-		if ( $code === 404 ) {
-			return \rest_ensure_response( new \WP_Error( $output ) );
+		if ($code === 404) {
+			return \rest_ensure_response(new \WP_Error($output));
 		}
 
-		if ( $code === 200 ) {
-			return \rest_ensure_response( wp_send_json_success( $output, $code ) );
+		if ($code === 200) {
+			return \rest_ensure_response(wp_send_json_success($output, $code));
 		}
 
-		return \rest_ensure_response( wp_send_json_error( $output, $code ) );
+		return \rest_ensure_response(wp_send_json_error($output, $code));
 	}
 }

--- a/src/Helpers/ObjectHelperTrait.php
+++ b/src/Helpers/ObjectHelperTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The object helper specific functionality inside classes.
  * Used in admin or theme side but only inside a class.
@@ -6,14 +7,15 @@
  * @package EightshiftLibs\Helpers
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Helpers;
 
 /**
  * Class Object Helper
  */
-trait ObjectHelperTrait {
+trait ObjectHelperTrait
+{
 
 	/**
 	 * Check if XML is valid file used for svg.
@@ -22,12 +24,13 @@ trait ObjectHelperTrait {
 	 *
 	 * @return boolean
 	 */
-	public function isValidXml( $xml ) {
-		libxml_use_internal_errors( true );
-		$doc = new \DOMDocument( '1.0', 'utf-8' );
-		$doc->loadXML( $xml );
+	public function isValidXml($xml)
+	{
+		libxml_use_internal_errors(true);
+		$doc = new \DOMDocument('1.0', 'utf-8');
+		$doc->loadXML($xml);
 		$errors = libxml_get_errors();
-		return empty( $errors );
+		return empty($errors);
 	}
 
 	/**
@@ -37,8 +40,9 @@ trait ObjectHelperTrait {
 	 *
 	 * @return bool
 	 */
-	public static function isJson( string $string ) : bool {
-		json_decode( $string );
+	public static function isJson(string $string): bool
+	{
+		json_decode($string);
 		return ( json_last_error() === JSON_ERROR_NONE );
 	}
 
@@ -49,13 +53,14 @@ trait ObjectHelperTrait {
 	 *
 	 * @return array
 	 */
-	public static function flattenArray( array $array ) : array {
+	public static function flattenArray(array $array): array
+	{
 		$output = [];
 
 		array_walk_recursive(
 			$array,
-			function( $a ) use ( &$output ) {
-				if ( ! empty( $a ) ) {
+			function ($a) use (&$output) {
+				if (! empty($a)) {
 					$output[] = $a;
 				}
 			}
@@ -74,13 +79,14 @@ trait ObjectHelperTrait {
 	 *
 	 * @return array
 	 */
-	public static function sanitizeArray( array $array, string $sanitizationFunction ) : array {
-		foreach ( $array as $key => $value ) {
-			if ( is_array( $value ) ) {
-					$value = sanitizeArray( $value );
+	public static function sanitizeArray(array $array, string $sanitizationFunction): array
+	{
+		foreach ($array as $key => $value) {
+			if (is_array($value)) {
+					$value = sanitizeArray($value);
 			}
 
-			$value = $sanitizationFunction( $value );
+			$value = $sanitizationFunction($value);
 		}
 
 		return $array;
@@ -92,10 +98,11 @@ trait ObjectHelperTrait {
 	 * @param array $items Items array to sort. Must have order key.
 	 * @return array
 	 */
-	public static function sortArrayByOrderKey( array $items ) : array {
+	public static function sortArrayByOrderKey(array $items): array
+	{
 		usort(
 			$items,
-			function( $item1, $item2 ) {
+			function ($item1, $item2) {
 				return $item1['order'] <=> $item2['order'];
 			}
 		);

--- a/src/Helpers/Shortcode.php
+++ b/src/Helpers/Shortcode.php
@@ -1,18 +1,20 @@
 <?php
+
 /**
  * The Shortcode specific functionality.
  *
  * @package EightshiftLibs\Helpers
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Helpers;
 
 /**
  * Class Shortcode
  */
-class Shortcode {
+class Shortcode
+{
 
 	/**
 	 * Call a shortcode function by tag name.
@@ -26,14 +28,15 @@ class Shortcode {
 	 *
 	 * @return string|bool False on failure, the result of the shortcode on success.
 	 */
-	public function getShortcode( string $tag, array $atts = [], $content = null ) {
+	public function getShortcode(string $tag, array $atts = [], $content = null)
+	{
 
 		global $shortcodeTags;
 
-		if ( ! isset( $shortcodeTags[ $tag ] ) ) {
+		if (! isset($shortcodeTags[ $tag ])) {
 			return false;
 		}
 
-		return \call_user_func( $shortcodeTags[ $tag ], $atts, $content, $tag );
+		return \call_user_func($shortcodeTags[ $tag ], $atts, $content, $tag);
 	}
 }

--- a/src/I18n/AbstractI18n.php
+++ b/src/I18n/AbstractI18n.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * The Language specific functionality.
  *
  * @package EightshiftLibs\I18n
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\I18n;
 
@@ -16,14 +17,16 @@ use EightshiftLibs\Services\ServiceInterface;
  *
  * This class handles theme or admin languages.
  */
-abstract class AbstractI18n implements ServiceInterface {
+abstract class AbstractI18n implements ServiceInterface
+{
 
 	/**
 	 * Load the plugin text domain for translation.
 	 *
 	 * @return void
 	 */
-	public function loadThemeTextdomain() {
+	public function loadThemeTextdomain()
+	{
 		\load_theme_textdomain(
 			$this->getTextdomainName(),
 			$this->getTranslationFilePath()
@@ -35,12 +38,12 @@ abstract class AbstractI18n implements ServiceInterface {
 	 *
 	 * @return string
 	 */
-	abstract public function getTextdomainName() : string;
+	abstract public function getTextdomainName(): string;
 
 	/**
 	 * Path to the directory containing the .mo file.
 	 *
 	 * @return string
 	 */
-	abstract public function getTranslationFilePath() : string;
+	abstract public function getTranslationFilePath(): string;
 }

--- a/src/I18n/I18nCli.php
+++ b/src/I18n/I18nCli.php
@@ -35,7 +35,13 @@ class I18nCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the translation class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();

--- a/src/I18n/I18nCli.php
+++ b/src/I18n/I18nCli.php
@@ -35,13 +35,7 @@ class I18nCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the translation class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/LintPhp/LintPhpCli.php
+++ b/src/LintPhp/LintPhpCli.php
@@ -45,13 +45,7 @@ class LintPhpCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Lints the project
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 		$output = shell_exec('composer run standards:check');
 

--- a/src/LintPhp/LintPhpCli.php
+++ b/src/LintPhp/LintPhpCli.php
@@ -45,9 +45,15 @@ class LintPhpCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Lints the project
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
-		$output = shell_exec('composer run standards:check'); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
+		$output = shell_exec('composer run standards:check');
 
 		\WP_CLI::log($output);
 

--- a/src/Login/LoginCli.php
+++ b/src/Login/LoginCli.php
@@ -26,7 +26,7 @@ class LoginCli extends AbstractCli
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function getDoc(): array
 	{
@@ -35,7 +35,13 @@ class LoginCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the translation class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Login/LoginCli.php
+++ b/src/Login/LoginCli.php
@@ -35,13 +35,7 @@ class LoginCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the translation class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * File containing the main intro class for your project.
  *
  * @package EightshiftLibs\Main
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Main;
 
@@ -20,7 +21,8 @@ use EightshiftLibs\Services\ServiceInterface;
  * The main start class.
  * This is used to define instantiate all classes used in the lib.
  */
-abstract class AbstractMain implements ServiceInterface {
+abstract class AbstractMain implements ServiceInterface
+{
 
 	/**
 	 * Array of instantiated services.
@@ -48,7 +50,8 @@ abstract class AbstractMain implements ServiceInterface {
 	 *
 	 * @param ClassLoader $autowiring Autowiring functionality.
 	 */
-	public function __construct( $autowiring ) {
+	public function __construct($autowiring)
+	{
 		$this->autowiring = $autowiring;
 	}
 
@@ -59,10 +62,11 @@ abstract class AbstractMain implements ServiceInterface {
 	 *
 	 * @return void
 	 */
-	public function registerServices() {
+	public function registerServices()
+	{
 
 		// Bail early so we don't instantiate services twice.
-		if ( ! empty( $this->services ) ) {
+		if (! empty($this->services)) {
 			return;
 		}
 
@@ -70,8 +74,8 @@ abstract class AbstractMain implements ServiceInterface {
 
 		array_walk(
 			$this->services,
-			function( $class ) {
-				if ( ! $class instanceof RegistrableInterface ) {
+			function ($class) {
+				if (! $class instanceof RegistrableInterface) {
 					return;
 				}
 
@@ -81,14 +85,17 @@ abstract class AbstractMain implements ServiceInterface {
 	}
 
 	/**
-	 * Returns the DI container and allow it to be used in different context (for example in tests outside of WP environment)
+	 * Returns the DI container
+	 *
+	 * Allows it to be used in different context (for example in tests outside of WP environment).
 	 *
 	 * @return Container
 	 * @throws \Exception Exception thrown by the DI container.
 	 */
-	public function buildDiContainer() {
-		if ( empty( $this->container ) ) {
-			$this->container = $this->getDiContainer( $this->getServiceClassesPreparedArray() );
+	public function buildDiContainer()
+	{
+		if (empty($this->container)) {
+			$this->container = $this->getDiContainer($this->getServiceClassesPreparedArray());
 		}
 		return $this->container;
 	}
@@ -99,8 +106,9 @@ abstract class AbstractMain implements ServiceInterface {
 	 *
 	 * @return array<array>
 	 */
-	private function getServiceClassesWithAutowire() {
-		return array_merge( $this->autowiring->buildServiceClasses(), $this->getServiceClasses() );
+	private function getServiceClassesWithAutowire()
+	{
+		return array_merge($this->autowiring->buildServiceClasses(), $this->getServiceClasses());
 	}
 
 	/**
@@ -110,16 +118,17 @@ abstract class AbstractMain implements ServiceInterface {
 	 *
 	 * @throws \Exception Exception thrown by the DI container.
 	 */
-	private function getServiceClassesWithDi() : array {
+	private function getServiceClassesWithDi(): array
+	{
 		$services = $this->getServiceClassesPreparedArray();
 
-		$container = $this->getDiContainer( $services );
+		$container = $this->getDiContainer($services);
 
 		return array_map(
-			function( $class ) use ( $container ) {
-				return $container->get( $class );
+			function ($class) use ($container) {
+				return $container->get($class);
 			},
-			array_keys( $services )
+			array_keys($services)
 		);
 	}
 
@@ -129,11 +138,12 @@ abstract class AbstractMain implements ServiceInterface {
 	 *
 	 * @return array
 	 */
-	private function getServiceClassesPreparedArray() : array {
+	private function getServiceClassesPreparedArray(): array
+	{
 		$output = [];
 
-		foreach ( $this->getServiceClassesWithAutowire() as $class => $dependencies ) {
-			if ( is_array( $dependencies ) ) {
+		foreach ($this->getServiceClassesWithAutowire() as $class => $dependencies) {
+			if (is_array($dependencies)) {
 				$output[ $class ] = $dependencies;
 				continue;
 			}
@@ -146,30 +156,33 @@ abstract class AbstractMain implements ServiceInterface {
 
 	/**
 	 * Implement PHP-DI.
+	 *
 	 * Build and return a DI container.
-	 * Wire all the dependencies automatically, based on the provided array of class => dependencies from the get_di_items().
+	 * Wire all the dependencies automatically, based on the provided array of
+	 * class => dependencies from the get_di_items().
 	 *
 	 * @param array $services Array of service.
 	 * @return Container
 	 *
 	 * @throws \Exception Exception thrown by the DI container.
 	 */
-	private function getDiContainer( array $services ) {
+	private function getDiContainer(array $services)
+	{
 		$definitions = [];
 
-		foreach ( $services as  $serviceKey => $serviceValues ) {
-			if ( gettype( $serviceValues ) !== 'array' ) {
+		foreach ($services as $serviceKey => $serviceValues) {
+			if (gettype($serviceValues) !== 'array') {
 				continue;
 			}
 
 			$autowire = new AutowireDefinitionHelper();
 
-			$definitions[ $serviceKey ] = $autowire->constructor( ...$this->getDiDependencies( $serviceValues ) );
+			$definitions[ $serviceKey ] = $autowire->constructor(...$this->getDiDependencies($serviceValues));
 		}
 
 		$builder = new ContainerBuilder();
 
-		return $builder->addDefinitions( $definitions )->build();
+		return $builder->addDefinitions($definitions)->build();
 	}
 
 	/**
@@ -180,11 +193,12 @@ abstract class AbstractMain implements ServiceInterface {
 	 *
 	 * @return array
 	 */
-	private function getDiDependencies( array $dependencies ) : array {
+	private function getDiDependencies(array $dependencies): array
+	{
 		return array_map(
-			function( $dependency ) {
-				if ( class_exists( $dependency ) ) {
-					return new Reference( $dependency );
+			function ($dependency) {
+				if (class_exists($dependency)) {
+					return new Reference($dependency);
 				}
 				return $dependency;
 			},
@@ -199,5 +213,5 @@ abstract class AbstractMain implements ServiceInterface {
 	 *
 	 * @return array<class-string, string|string[]> Array of fully qualified service class names.
 	 */
-	abstract protected function getServiceClasses() : array;
+	abstract protected function getServiceClasses(): array;
 }

--- a/src/Main/MainCli.php
+++ b/src/Main/MainCli.php
@@ -35,13 +35,7 @@ class MainCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the main class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Read the template contents, and replace the placeholders with provided variables.

--- a/src/Main/MainCli.php
+++ b/src/Main/MainCli.php
@@ -35,7 +35,13 @@ class MainCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the main class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Read the template contents, and replace the placeholders with provided variables.

--- a/src/Manifest/AbstractManifest.php
+++ b/src/Manifest/AbstractManifest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing an abstract class for holding Assets Manifest functionality.
  *
@@ -7,7 +8,7 @@
  * @package EightshiftLibs\Manifest
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Manifest;
 
@@ -18,7 +19,8 @@ use EightshiftLibs\Services\ServiceInterface;
 /**
  * Abstract class Manifest class.
  */
-abstract class AbstractManifest implements ServiceInterface, ManifestInterface {
+abstract class AbstractManifest implements ServiceInterface, ManifestInterface
+{
 
 	/**
 	 * Full data of manifest items.
@@ -35,21 +37,22 @@ abstract class AbstractManifest implements ServiceInterface, ManifestInterface {
 	 *
 	 * @return void Sets the manifest variable.
 	 */
-	public function setAssetsManifestRaw() : void {
+	public function setAssetsManifestRaw(): void
+	{
 		$path = $this->getManifestFilePath();
 
-		if ( ! file_exists( $path ) ) {
-			throw InvalidManifest::missingManifestException( $path );
+		if (! file_exists($path)) {
+			throw InvalidManifest::missingManifestException($path);
 		}
 
-		$data = json_decode( implode( ' ', (array) file( $path ) ), true );
+		$data = json_decode(implode(' ', (array) file($path)), true);
 
-		if ( empty( $data ) ) {
+		if (empty($data)) {
 			return;
 		}
 
 		$this->manifest = array_map(
-			function( $manifest_item ) {
+			function ($manifest_item) {
 				return "{$this->getAssetsManifestOutputPrefix()}{$manifest_item}";
 			},
 			$data
@@ -61,15 +64,17 @@ abstract class AbstractManifest implements ServiceInterface, ManifestInterface {
 	 *
 	 * @param string $key File name key you want to get from manifest.
 	 *
-	 * @throws InvalidManifest Throws error if manifest key is missing. Returned data from manifest and not global variable.
+	 * @throws InvalidManifest Throws error if manifest key is missing.
+	 *                         Returns data from manifest and not global variable.
 	 *
 	 * @return string Full path to asset.
 	 */
-	public function getAssetsManifestItem( string $key ) : string {
+	public function getAssetsManifestItem(string $key): string
+	{
 		$manifest = $this->manifest;
 
-		if ( ! isset( $manifest[ $key ] ) ) {
-			throw InvalidManifest::missingManifestItemException( $key );
+		if (! isset($manifest[ $key ])) {
+			throw InvalidManifest::missingManifestItemException($key);
 		}
 
 		return $manifest[ $key ];
@@ -80,14 +85,15 @@ abstract class AbstractManifest implements ServiceInterface, ManifestInterface {
 	 *
 	 * @return string
 	 */
-	abstract protected function getManifestFilePath() : string;
+	abstract protected function getManifestFilePath(): string;
 
 	/**
 	 * This method appends full site url to the relative manifest data item.
 	 *
 	 * @return string
 	 */
-	protected function getAssetsManifestOutputPrefix() : string {
+	protected function getAssetsManifestOutputPrefix(): string
+	{
 		return \site_url();
 	}
 }

--- a/src/Manifest/ManifestCli.php
+++ b/src/Manifest/ManifestCli.php
@@ -35,7 +35,13 @@ class ManifestCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generates manifest file
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Manifest/ManifestCli.php
+++ b/src/Manifest/ManifestCli.php
@@ -35,13 +35,7 @@ class ManifestCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generates manifest file
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Manifest/ManifestInterface.php
+++ b/src/Manifest/ManifestInterface.php
@@ -26,5 +26,5 @@ interface ManifestInterface
 	 *
 	 * @return string Full path to asset.
 	 */
-	public function getAssetsManifestItem(string $key ): string;
+	public function getAssetsManifestItem(string $key): string;
 }

--- a/src/Media/MediaCli.php
+++ b/src/Media/MediaCli.php
@@ -35,13 +35,7 @@ class MediaCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the Media class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Media/MediaCli.php
+++ b/src/Media/MediaCli.php
@@ -35,7 +35,13 @@ class MediaCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the Media class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Menu/AbstractMenu.php
+++ b/src/Menu/AbstractMenu.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * The Menu specific functionality.
  *
  * @package EightshiftLibs\Menu
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Menu;
 
@@ -15,14 +16,16 @@ use EightshiftLibs\Services\ServiceInterface;
 /**
  * Class Menu
  */
-abstract class AbstractMenu implements ServiceInterface, MenuPositionsInterface {
+abstract class AbstractMenu implements ServiceInterface, MenuPositionsInterface
+{
 
 	/**
 	 * Register All Menu positions
 	 *
 	 * @return void
 	 */
-	public function registerMenuPositions() {
+	public function registerMenuPositions()
+	{
 		\register_nav_menus(
 			$this->getMenuPositions()
 		);
@@ -33,28 +36,36 @@ abstract class AbstractMenu implements ServiceInterface, MenuPositionsInterface 
 	 *
 	 * @return array Of menu positions with name and slug.
 	 */
-	public function getMenuPositions() : array {
+	public function getMenuPositions(): array
+	{
 		return [];
 	}
 
 	/**
-	 * bemMenu returns an instance of the bemMenuWalker class with the following arguments
+	 * This method returns an instance of the bemMenuWalker class with the following arguments
 	 *
-	 * @param  string $location          This must be the same as what is set in wp-admin/settings/menus for menu location and registered in registerMenuPositions function.
+	 * @param  string $location          This must be the same as what is set in wp-admin/settings/menus
+	 *                                   for menu location and registered in registerMenuPositions function.
 	 * @param  string $cssClassPrefix    This string will prefix all of the menu's classes, BEM syntax friendly.
-	 * @param  string $cssClassModifiers Provide either a string or array of values to apply extra classes to the <ul> but not the <li's>.
+	 * @param  string $cssClassModifiers Provide either a string or array of values to apply extra classes
+	 *                                   to the <ul> but not the <li's>.
 	 * @param  bool   $echo              Echo the menu.
 	 *
 	 * @return string|false|void Menu output if $echo is false, false if there are no items or no menu was found.
 	 */
-	public static function bemMenu( string $location = 'main_menu', string $cssClassPrefix = 'main-menu', $cssClassModifiers = null, bool $echo = true ) {
+	public static function bemMenu(
+		string $location = 'main_menu',
+		string $cssClassPrefix = 'main-menu',
+		$cssClassModifiers = null,
+		bool $echo = true
+	) {
 
 		// Check to see if any css modifiers were supplied.
 		$modifiers = '';
-		if ( $cssClassModifiers ) {
-			if ( is_array( $cssClassModifiers ) ) {
-				$modifiers = implode( ' ', $cssClassModifiers );
-			} elseif ( is_string( $cssClassModifiers ) ) {
+		if ($cssClassModifiers) {
+			if (is_array($cssClassModifiers)) {
+				$modifiers = implode(' ', $cssClassModifiers);
+			} elseif (is_string($cssClassModifiers)) {
 				$modifiers = $cssClassModifiers;
 			}
 		}
@@ -64,13 +75,13 @@ abstract class AbstractMenu implements ServiceInterface, MenuPositionsInterface 
 			'container'      => false,
 			'items_wrap'     => '<ul class="' . $cssClassPrefix . ' ' . $modifiers . '">%3$s</ul>',
 			'echo'           => $echo,
-			'walker'         => new BemMenuWalker( $cssClassPrefix ),
+			'walker'         => new BemMenuWalker($cssClassPrefix),
 		];
 
-		if ( ! \has_nav_menu( $location ) ) {
+		if (! \has_nav_menu($location)) {
 			return '';
 		}
 
-		return \wp_nav_menu( $args );
+		return \wp_nav_menu($args);
 	}
 }

--- a/src/Menu/BemMenuWalker.php
+++ b/src/Menu/BemMenuWalker.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Custom Menu Walker specific functionality.
  * It provides BEM classes to menues.
@@ -6,7 +7,7 @@
  * @package EightshiftLibs\Menu
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Menu;
 
@@ -14,7 +15,8 @@ namespace EightshiftLibs\Menu;
  * Bem Menu Walker
  * Inserts some BEM naming sensibility into WordPress menus
  */
-class BemMenuWalker extends \Walker_Nav_Menu {
+class BemMenuWalker extends \Walker_Nav_Menu
+{
 	/**
 	 * CSS class prefix string - unique for a theme.
 	 *
@@ -34,7 +36,8 @@ class BemMenuWalker extends \Walker_Nav_Menu {
 	 *
 	 * @param string $cssClassPrefix load menu prefix for class.
 	 */
-	public function __construct( string $cssClassPrefix ) {
+	public function __construct(string $cssClassPrefix)
+	{
 
 		$this->cssClassPrefix = $cssClassPrefix;
 
@@ -63,15 +66,16 @@ class BemMenuWalker extends \Walker_Nav_Menu {
 	 *
 	 * @return void Parent Display element
 	 */
-	public function display_element( $element, &$children_elements, $max_depth, $depth = 0, $args, &$output ) {
+	public function display_element($element, &$children_elements, $max_depth, $depth = 0, $args, &$output) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps, PEAR.Functions.ValidDefaultValue.NotAtEnd
+	{
 
 		$id_field = $this->db_fields['id'];
 
-		if ( is_object( $args[0] ) ) {
-			$args[0]->has_children = ! empty( $children_elements[ $element->$id_field ] );
+		if (is_object($args[0])) {
+			$args[0]->has_children = ! empty($children_elements[ $element->$id_field ]);
 		}
 
-		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
+		parent::display_element($element, $children_elements, $max_depth, $depth, $args, $output);
 	}
 
 	/**
@@ -83,11 +87,12 @@ class BemMenuWalker extends \Walker_Nav_Menu {
 	 *
 	 * @return void
 	 */
-	public function start_lvl( &$output, $depth = 1, $args = [] ) {
+	public function start_lvl(&$output, $depth = 1, $args = []) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+	{
 
 		$real_depth = $depth + 1;
 
-		$indent = str_repeat( "\t", $real_depth );
+		$indent = str_repeat("\t", $real_depth);
 
 		$prefix = $this->cssClassPrefix;
 		$suffix = $this->itemCssClassSuffixes;
@@ -97,7 +102,7 @@ class BemMenuWalker extends \Walker_Nav_Menu {
 			$prefix . $suffix['sub_menu'] . '--' . $real_depth,
 		];
 
-		$classNames = implode( ' ', $classes );
+		$classNames = implode(' ', $classes);
 
 		// Add a ul wrapper to sub nav.
 		$output .= "\n" . $indent . '<ul class="' . $classNames . '">' . "\n";
@@ -114,19 +119,20 @@ class BemMenuWalker extends \Walker_Nav_Menu {
 	 *
 	 * @return void
 	 */
-	public function start_el( &$output, $item, $depth = 0, $args = [], $id = 0 ) {
+	public function start_el(&$output, $item, $depth = 0, $args = [], $id = 0) // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps
+	{
 
-		$indent = ( $depth > 0 ? str_repeat( '    ', $depth ) : '' ); // code indent.
+		$indent = ( $depth > 0 ? str_repeat('    ', $depth) : '' ); // code indent.
 
 		$prefix = $this->cssClassPrefix;
 		$suffix = $this->itemCssClassSuffixes;
 
 		$parent_class = $prefix . $suffix['parent_item'];
 
-		if ( ! empty( $item->classes ) ) {
+		if (! empty($item->classes)) {
 			$user_classes = array_map(
-				function( $className ) use ( $prefix ) {
-					if ( strpos( $className, 'js-' ) !== false ) {
+				function ($className) use ($prefix) {
+					if (strpos($className, 'js-') !== false) {
 						$output = $className;
 					} else {
 						$output = $prefix . '__item--' . $className;
@@ -141,16 +147,16 @@ class BemMenuWalker extends \Walker_Nav_Menu {
 		$item_classes = [
 			'item_class'            => 0 === $depth ? $prefix . $suffix['item'] : '',
 			'parent_class'          => $args->has_children ? $parent_class : '',
-			'active_page_class'     => in_array( 'current-menu-item', $item->classes, true ) ? $prefix . $suffix['active_item'] : '',
-			'active_parent_class'   => in_array( 'current-menu-parent', $item->classes, true ) ? $prefix . $suffix['parent_of_active_item'] : '',
-			'active_ancestor_class' => in_array( 'current-page-ancestor', $item->classes, true ) ? $prefix . $suffix['ancestor_of_active_item'] : '',
+			'active_page_class'     => in_array('current-menu-item', $item->classes, true) ? $prefix . $suffix['active_item'] : '',
+			'active_parent_class'   => in_array('current-menu-parent', $item->classes, true) ? $prefix . $suffix['parent_of_active_item'] : '',
+			'active_ancestor_class' => in_array('current-page-ancestor', $item->classes, true) ? $prefix . $suffix['ancestor_of_active_item'] : '',
 			'depth_class'           => $depth >= 1 ? $prefix . $suffix['sub_menu_item'] . ' ' . $prefix . $suffix['sub_menu'] . '--' . $depth . '__item' : '',
 			'item_id_class'         => $prefix . '__item--' . $item->object_id,
-			'user_class'            => ! empty( $user_classes ) ? implode( ' ', $user_classes ) : '',
+			'user_class'            => ! empty($user_classes) ? implode(' ', $user_classes) : '',
 		];
 
 		// Convert array to string excluding any empty values.
-		$class_string = implode( '  ', array_filter( $item_classes ) );
+		$class_string = implode('  ', array_filter($item_classes));
 
 		// Add the classes to the wrapping <li>.
 		$output .= $indent . '<li class="' . $class_string . '">';
@@ -161,7 +167,7 @@ class BemMenuWalker extends \Walker_Nav_Menu {
 			'depth_class' => $depth >= 1 ? $prefix . $suffix['sub_menu'] . $suffix['link'] . '  ' . $prefix . $suffix['sub_menu'] . '--' . $depth . $suffix['link'] : '',
 		];
 
-		$link_class_string = implode( '  ', array_filter( $link_classes ) );
+		$link_class_string = implode('  ', array_filter($link_classes));
 
 		$link_class_output = 'class="' . $link_class_string . ' "';
 
@@ -170,25 +176,24 @@ class BemMenuWalker extends \Walker_Nav_Menu {
 			'depth_class' => $depth >= 1 ? $prefix . $suffix['sub_menu'] . $suffix['link'] . '-text ' . $prefix . $suffix['sub_menu'] . '--' . $depth . $suffix['link'] . '-text' : '',
 		];
 
-		$link_text_class_string = implode( '  ', array_filter( $link_text_classes ) );
+		$link_text_class_string = implode('  ', array_filter($link_text_classes));
 		$link_text_class_output = 'class="' . $link_text_class_string . '"';
 
 		// link attributes.
-		$attributes  = ! empty( $item->attr_title ) ? ' title="' . esc_attr( $item->attr_title ) . '"' : '';
-		$attributes .= ! empty( $item->target ) ? ' target="' . esc_attr( $item->target ) . '"' : '';
-		$attributes .= ! empty( $item->xfn ) ? ' rel="' . esc_attr( $item->xfn ) . '"' : '';
-		$attributes .= ! empty( $item->url ) ? ' href="' . esc_attr( $item->url ) . '"' : '';
+		$attributes  = ! empty($item->attr_title) ? ' title="' . esc_attr($item->attr_title) . '"' : '';
+		$attributes .= ! empty($item->target) ? ' target="' . esc_attr($item->target) . '"' : '';
+		$attributes .= ! empty($item->xfn) ? ' rel="' . esc_attr($item->xfn) . '"' : '';
+		$attributes .= ! empty($item->url) ? ' href="' . esc_attr($item->url) . '"' : '';
 
 		// Create link markup.
 		$item_output  = $args->before;
 		$item_output .= '<a' . $attributes . ' ' . $link_class_output . '><span ' . $link_text_class_output . '>';
 		$item_output .= $args->link_before;
-		$item_output .= apply_filters( 'the_title', $item->title, $item->ID );
+		$item_output .= apply_filters('the_title', $item->title, $item->ID);
 		$item_output .= $args->link_after;
 		$item_output .= $args->after;
 		$item_output .= '</span></a>';
 
-		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+		$output .= apply_filters('walker_nav_menu_start_el', $item_output, $item, $depth, $args);
 	}
-
 }

--- a/src/Menu/MenuCli.php
+++ b/src/Menu/MenuCli.php
@@ -35,13 +35,7 @@ class MenuCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the Menu class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Menu/MenuCli.php
+++ b/src/Menu/MenuCli.php
@@ -35,7 +35,13 @@ class MenuCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the Menu class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();

--- a/src/ModifyAdminAppearance/AbstractModifyAdminAppearance.php
+++ b/src/ModifyAdminAppearance/AbstractModifyAdminAppearance.php
@@ -1,11 +1,12 @@
 <?php
+
 /**
  * Modify WordPress admin behavior
  *
  * @package EightshiftLibs\Admin
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace EightshiftLibs\Admin;
 
@@ -16,7 +17,8 @@ use EightshiftLibs\Services\ServiceInterface;
  *
  * Example: Change color based on environment, remove dashboard widgets etc.
  */
-abstract class AbstractModifyAdminAppearance implements ServiceInterface {
+abstract class AbstractModifyAdminAppearance implements ServiceInterface
+{
 
 	/**
 	 * List of admin color schemes.
@@ -34,7 +36,8 @@ abstract class AbstractModifyAdminAppearance implements ServiceInterface {
 	 *
 	 * @var array
 	 */
-	public function getColorSchemes() : array {
+	public function getColorSchemes(): array
+	{
 		return self::COLOR_SCHEMES;
 	}
 
@@ -45,10 +48,11 @@ abstract class AbstractModifyAdminAppearance implements ServiceInterface {
 	 *
 	 * @return string Modified color scheme.
 	 */
-	public function setAdminColor( string $env ) : string {
+	public function setAdminColor(string $env): string
+	{
 		$colors = $this->getColorSchemes();
 
-		if ( ! isset( $colors[ $env ] ) ) {
+		if (! isset($colors[ $env ])) {
 			return $colors['default'];
 		}
 

--- a/src/ModifyAdminAppearance/ModifyAdminAppearanceCli.php
+++ b/src/ModifyAdminAppearance/ModifyAdminAppearanceCli.php
@@ -35,7 +35,13 @@ class ModifyAdminAppearanceCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Create modify admin appearance class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$className = $this->getClassShortName();

--- a/src/ModifyAdminAppearance/ModifyAdminAppearanceCli.php
+++ b/src/ModifyAdminAppearance/ModifyAdminAppearanceCli.php
@@ -35,13 +35,7 @@ class ModifyAdminAppearanceCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Create modify admin appearance class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		$className = $this->getClassShortName();

--- a/src/Readme/ReadmeCli.php
+++ b/src/Readme/ReadmeCli.php
@@ -40,7 +40,7 @@ class ReadmeCli extends AbstractCli
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs(array $args ): array
+	public function getDevelopArgs(array $args): array
 	{
 		return [
 			'root' => $args[1] ?? './',
@@ -67,7 +67,13 @@ class ReadmeCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the Readme
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Get Props.

--- a/src/Readme/ReadmeCli.php
+++ b/src/Readme/ReadmeCli.php
@@ -67,13 +67,7 @@ class ReadmeCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the Readme
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Rest/CallableFieldInterface.php
+++ b/src/Rest/CallableFieldInterface.php
@@ -20,13 +20,15 @@ interface CallableFieldInterface
 	 * Method that returns rest response
 	 *
 	 * @param object|array $object     Post or custom post type object of the request.
-	 * @param string       $attr       Rest field/attr string identifier from the second parameter of your register_rest_field() declaration.
+	 * @param string       $attr       Rest field/attr string identifier from the second parameter
+	 *                                 of your register_rest_field() declaration.
 	 * @param object       $request    Full request payload - as a WP_REST_Request object.
-	 * @param string       $objectType The object type which the field is registered against. Typically first parameter of your register_rest_field() declaration.
+	 * @param string       $objectType The object type which the field is registered against.
+	 *                                 Typically first parameter of your register_rest_field() declaration.
 	 *
 	 * @return mixed If response generated an error, WP_Error, if response
 	 *               is already an instance, WP_HTTP_Response, otherwise
 	 *               returns a new WP_REST_Response instance.
 	 */
-	public function fieldCallback($object, string $attr, $request, string $objectType );
+	public function fieldCallback($object, string $attr, $request, string $objectType);
 }

--- a/src/Rest/CallableRouteInterface.php
+++ b/src/Rest/CallableRouteInterface.php
@@ -25,5 +25,5 @@ interface CallableRouteInterface
 	 *                                is already an instance, WP_HTTP_Response, otherwise
 	 *                                returns a new WP_REST_Response instance.
 	 */
-	public function routeCallback(\WP_REST_Request $request );
+	public function routeCallback(\WP_REST_Request $request);
 }

--- a/src/Rest/Fields/FieldCli.php
+++ b/src/Rest/Fields/FieldCli.php
@@ -74,13 +74,7 @@ class FieldCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generate the REST API field class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Rest/Fields/FieldCli.php
+++ b/src/Rest/Fields/FieldCli.php
@@ -40,7 +40,7 @@ class FieldCli extends AbstractCli
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs(array $args ): array
+	public function getDevelopArgs(array $args): array
 	{
 		return [
 			'field_name'  => $args[1] ?? 'title',
@@ -51,7 +51,7 @@ class FieldCli extends AbstractCli
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function getDoc(): array
 	{
@@ -74,7 +74,13 @@ class FieldCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generate the REST API field class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Get Props.
@@ -89,7 +95,7 @@ class FieldCli extends AbstractCli
 		$class = $this->getExampleTemplate(__DIR__, $this->getClassShortName());
 
 		// Replace stuff in file.
-		$class = $this->renameClassNameWithSufix($this->getClassShortName(), $className, $class);
+		$class = $this->renameClassNameWithSuffix($this->getClassShortName(), $className, $class);
 		$class = $this->renameNamespace($assocArgs, $class);
 		$class = $this->renameUse($assocArgs, $class);
 		$class = str_replace('example-post-type', $objectType, $class);

--- a/src/Rest/Fields/FieldExample.php
+++ b/src/Rest/Fields/FieldExample.php
@@ -31,7 +31,7 @@ class FieldExample extends AbstractField implements CallableFieldInterface
 	}
 
 	/**
-	 * Get the name of the field you awant to register or orverride.
+	 * Get the name of the field you want to register or override.
 	 *
 	 * @return string The attribute name.
 	 */
@@ -56,15 +56,17 @@ class FieldExample extends AbstractField implements CallableFieldInterface
 	 * Method that returns rest response
 	 *
 	 * @param object|array $object     Post or custom post type object of the request.
-	 * @param string       $attr       Rest field/attr string identifier from the second parameter of your register_rest_field() declaration.
+	 * @param string       $attr       Rest field/attr string identifier from the second parameter
+	 *                                 of your register_rest_field() declaration.
 	 * @param object       $request    Full request payload – as a WP_REST_Request object.
-	 * @param string       $objectType The object type which the field is registered against. Typically first parameter of your register_rest_field() declaration.
+	 * @param string       $objectType The object type which the field is registered against.
+	 *                                 Typically first parameter of your register_rest_field() declaration.
 	 *
 	 * @return mixed If response generated an error, WP_Error, if response
 	 *               is already an instance, WP_HTTP_Response, otherwise
 	 *               returns a new WP_REST_Response instance.
 	 */
-	public function fieldCallback($object, string $attr, $request, string $objectType )
+	public function fieldCallback($object, string $attr, $request, string $objectType)
 	{
 		return \rest_ensure_response('output data');
 	}

--- a/src/Rest/RouteInterface.php
+++ b/src/Rest/RouteInterface.php
@@ -31,10 +31,10 @@ interface RouteInterface
 	public const CREATABLE = 'POST';
 
 	/**
-   * Alias for PATCH transport method.
-   *
-   * @var string
-   */
+	 * Alias for PATCH transport method.
+	 *
+	 * @var string
+	 */
 	public const EDITABLE = 'PATCH';
 
 	/**

--- a/src/Rest/Routes/RouteCli.php
+++ b/src/Rest/Routes/RouteCli.php
@@ -85,13 +85,7 @@ class RouteCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Generates the REST Route class
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Rest/Routes/RouteCli.php
+++ b/src/Rest/Routes/RouteCli.php
@@ -51,7 +51,7 @@ class RouteCli extends AbstractCli
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs(array $args ): array
+	public function getDevelopArgs(array $args): array
 	{
 		return [
 			'endpoint_slug' => $args[1] ?? 'test',
@@ -62,7 +62,7 @@ class RouteCli extends AbstractCli
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function getDoc(): array
 	{
@@ -85,7 +85,13 @@ class RouteCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Generates the REST Route class
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Get Props.
@@ -100,7 +106,7 @@ class RouteCli extends AbstractCli
 		$class = $this->getExampleTemplate(__DIR__, $this->getClassShortName());
 
 		// Replace stuff in file.
-		$class = $this->renameClassNameWithSufix($this->getClassShortName(), $className, $class);
+		$class = $this->renameClassNameWithSuffix($this->getClassShortName(), $className, $class);
 		$class = $this->renameNamespace($assocArgs, $class);
 		$class = $this->renameUse($assocArgs, $class);
 		$class = str_replace('/example-route', "/{$endpointSlug}", $class);

--- a/src/Rest/Routes/RouteExample.php
+++ b/src/Rest/Routes/RouteExample.php
@@ -72,7 +72,7 @@ class RouteExample extends AbstractRoute implements CallableRouteInterface
 	 *                                is already an instance, WP_HTTP_Response, otherwise
 	 *                                returns a new WP_REST_Response instance.
 	 */
-	public function routeCallback(\WP_REST_Request $request ) // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClass
+	public function routeCallback(\WP_REST_Request $request)
 	{
 		return \rest_ensure_response();
 	}

--- a/src/Setup/Setup.php
+++ b/src/Setup/Setup.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
  *
  * @return void
  */
-function setup(string $projectRootPath, array $args = [], string $setupFile = 'setup.json' )
+function setup(string $projectRootPath, array $args = [], string $setupFile = 'setup.json')
 {
 
 	// Check if optional parameters exists.

--- a/src/Setup/SetupCli.php
+++ b/src/Setup/SetupCli.php
@@ -40,7 +40,7 @@ class SetupCli extends AbstractCli
 	 *
 	 * @return array
 	 */
-	public function getDevelopArgs(array $args ): array
+	public function getDevelopArgs(array $args): array
 	{
 		return [
 			'root' => $args[1] ?? './',
@@ -50,7 +50,7 @@ class SetupCli extends AbstractCli
 	/**
 	 * Get WPCLI command doc.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function getDoc(): array
 	{
@@ -67,7 +67,13 @@ class SetupCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	/**
+	 * Initializes setup.json
+	 *
+	 * @param array $args      Array of arguments form terminal.
+	 * @param array $assocArgs Array of associative arguments form terminal.
+	 */
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		// Get Props.

--- a/src/Setup/SetupCli.php
+++ b/src/Setup/SetupCli.php
@@ -67,13 +67,7 @@ class SetupCli extends AbstractCli
 		];
 	}
 
-	/**
-	 * Initializes setup.json
-	 *
-	 * @param array $args      Array of arguments form terminal.
-	 * @param array $assocArgs Array of associative arguments form terminal.
-	 */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		// Get Props.

--- a/src/Setup/UpdateCli.php
+++ b/src/Setup/UpdateCli.php
@@ -72,7 +72,7 @@ class UpdateCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs ) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
 	{
 
 		require $this->getLibsPath('src/Setup/Setup.php');

--- a/src/Setup/UpdateCli.php
+++ b/src/Setup/UpdateCli.php
@@ -72,7 +72,7 @@ class UpdateCli extends AbstractCli
 		];
 	}
 
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore Squiz.Commenting.FunctionComment.Missing, Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
 
 		require $this->getLibsPath('src/Setup/Setup.php');


### PR DESCRIPTION
This is the first pass of the new linter. I fixed all of the linting issues, plus added some exceptions in the `phpcs.xml.dist`.

After this, I'll go through the PHPStan and fix the issues. I've noticed some methods that should maybe be private, some docblocs are not correct, or the type hints are missing, etc.

There are a lot of changes, but it's the only way to test the standards. Let me know if you notice anything out of place, something that was broken during the `phpcbf`, or that I missed when manually fixing the rest of the issues.