### PR TITLE
Trim before output

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -110,7 +110,7 @@ class Components
 			echo '</div>';
 		}
 
-		return (string)ob_get_clean();
+		return trim((string) ob_get_clean());
 	}
 
 	/**


### PR DESCRIPTION
As @volfkarlo can probably testify, without `trim()`, `Components::render()` might make your life miserable as having a component's PHP part defined as:

```php
?>

<div>...</div>
```

and 

```php
?>
<div>...</div>
```

Is not the same (the first one will leave a newline in output - potentially breaking your layout).