### PR TITLE
Allowed more attributes on buttons

### DIFF
--- a/src/View/AbstractEscapedView.php
+++ b/src/View/AbstractEscapedView.php
@@ -149,7 +149,10 @@ abstract class AbstractEscapedView implements ServiceInterface
 			'allowfullscreen' => true,
 		],
 		'button' => [
-			'onClick' => true,
+      'class' => true,
+      'id' => true,
+			'type' => true,
+      'onClick' => true,
 		],
 	];
 

--- a/src/View/AbstractEscapedView.php
+++ b/src/View/AbstractEscapedView.php
@@ -149,10 +149,10 @@ abstract class AbstractEscapedView implements ServiceInterface
 			'allowfullscreen' => true,
 		],
 		'button' => [
-      'class' => true,
-      'id' => true,
+			'class' => true,
+			'id' => true,
 			'type' => true,
-      'onClick' => true,
+			'onClick' => true,
 		],
 	];
 


### PR DESCRIPTION
Allowed class, id and type attributes to buttons rendered by `Components::render` while extending `AbstractEscapedView` class

This broke the hamburger and drawer components as hamburger button didn't have class attribute.