### PR TITLE
Acf theme options fix

### DIFF
--- a/src/ThemeOptions/ThemeOptionsExample.php
+++ b/src/ThemeOptions/ThemeOptionsExample.php
@@ -74,7 +74,30 @@ class ThemeOptionsExample implements ServiceInterface
 	public function registerThemeOptions(): void
 	{
 		if (function_exists('acf_add_options_page')) {
-			acf_add_local_field_group();
+			acf_add_local_field_group(
+				array(
+					'key' => 'group_5fcab51c7138c',
+					'title' => 'Theme Options',
+					'fields' => [],
+					'location' => [
+						[
+							[
+								'param' => 'options_page',
+								'operator' => '==',
+								'value' => static::THEME_OPTIONS_SLUG,
+							],
+						],
+					],
+					'menu_order' => 20,
+					'position' => 'normal',
+					'style' => 'default',
+					'label_placement' => 'top',
+					'instruction_placement' => 'label',
+					'hide_on_screen' => '',
+					'active' => true,
+					'description' => '',
+				)
+			);
 		}
 	}
 }

--- a/src/ThemeOptions/ThemeOptionsExample.php
+++ b/src/ThemeOptions/ThemeOptionsExample.php
@@ -75,9 +75,9 @@ class ThemeOptionsExample implements ServiceInterface
 	{
 		if (function_exists('acf_add_options_page')) {
 			acf_add_local_field_group(
-				array(
+				[
 					'key' => 'group_5fcab51c7138c',
-					'title' => 'Theme Options',
+					'title' => esc_html__('Theme Options', 'eightshift-libs'),
 					'fields' => [],
 					'location' => [
 						[
@@ -96,7 +96,7 @@ class ThemeOptionsExample implements ServiceInterface
 					'hide_on_screen' => '',
 					'active' => true,
 					'description' => '',
-				)
+				]
 			);
 		}
 	}

--- a/src/ThemeOptions/ThemeOptionsExample.php
+++ b/src/ThemeOptions/ThemeOptionsExample.php
@@ -28,7 +28,7 @@ class ThemeOptionsExample implements ServiceInterface
 	/**
 	 * Theme Options ACF Capability Name.
 	 */
-	public const THEME_OPTIONS_CAPABILITY = 'manage_acf_theme_options';
+	public const THEME_OPTIONS_CAPABILITY = 'edit_theme_options';
 
 	/**
 	 * Register all the hooks


### PR DESCRIPTION
There was an error while adding the Theme Options class.
The error was caused because of the wrong `THEME_OPTIONS_CAPABILITY` and there was no value inside `acf_add_local_field_group`.

I've changed the capability and added an example placeholder field.