### PR TITLE
Allow meta and link to be rendered with wp_kses_post

### DIFF
--- a/src/View/AbstractEscapedView.php
+++ b/src/View/AbstractEscapedView.php
@@ -149,10 +149,10 @@ abstract class AbstractEscapedView implements ServiceInterface
 			'allowfullscreen' => true,
 		],
 		'button' => [
-      'class' => true,
-      'id' => true,
+			'class' => true,
+			'id' => true,
 			'type' => true,
-      'onClick' => true,
+			'onClick' => true,
 		],
 	];
 
@@ -167,6 +167,22 @@ abstract class AbstractEscapedView implements ServiceInterface
 			'frameborder' => true,
 			'allow' => true,
 			'allowfullscreen' => true,
+		],
+	];
+
+	/**
+	 * Tags that are allowed to be rendered in head.
+	 */
+	public const HEAD = [
+		'meta' => [
+			'content' => true,
+			'name' => true,
+			'charset' => true,
+			'http-equiv' => true,
+		],
+		'link' => [
+			'rel' => true,
+			'href' => true,
 		],
 	];
 }


### PR DESCRIPTION
If we output the custom head component, almost everything will be escaped.
Adding meta and link elements to this filter fixes the head component