### PR TITLE
Fix global varible name for Shortcode class

### DIFF
--- a/src/Helpers/Shortcode.php
+++ b/src/Helpers/Shortcode.php
@@ -30,12 +30,12 @@ class Shortcode
 	 */
 	public static function getShortcode(string $tag, array $attr = [], $content = null)
 	{
-		global $shortcode_tags;
+		global $shortcode_tags; // phpcs:ignore Squiz.NamingConventions.ValidVariableName.NotCamelCaps
 
-		if (!isset($shortcode_tags[$tag])) {
+		if (!isset($shortcode_tags[$tag])) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.NotCamelCaps
 			return false;
 		}
 
-		return \call_user_func($shortcode_tags[$tag], $attr, $content, $tag);
+		return \call_user_func($shortcode_tags[$tag], $attr, $content, $tag); // phpcs:ignore Squiz.NamingConventions.ValidVariableName.NotCamelCaps
 	}
 }

--- a/src/Helpers/Shortcode.php
+++ b/src/Helpers/Shortcode.php
@@ -30,12 +30,12 @@ class Shortcode
 	 */
 	public static function getShortcode(string $tag, array $attr = [], $content = null)
 	{
-		global $shortcodeTags;
+		global $shortcode_tags;
 
-		if (!isset($shortcodeTags[$tag])) {
+		if (!isset($shortcode_tags[$tag])) {
 			return false;
 		}
 
-		return \call_user_func($shortcodeTags[$tag], $attr, $content, $tag);
+		return \call_user_func($shortcode_tags[$tag], $attr, $content, $tag);
 	}
 }


### PR DESCRIPTION
Variable was written in `camelCase`