### PR TITLE
Remove debugging if not development setup

### DIFF
--- a/src/ConfigProject/ConfigProjectExample.php
+++ b/src/ConfigProject/ConfigProjectExample.php
@@ -32,12 +32,14 @@ define('AUTOSAVE_INTERVAL', 240);
 // Disable automatic updating of plugins.
 define('AUTOMATIC_UPDATER_DISABLED', true);
 
-// Environment based setup.
-if (WP_ENVIRONMENT_TYPE === 'development' || WP_ENVIRONMENT_TYPE === 'local') {
+if (WP_ENVIRONMENT_TYPE !== 'production') {
 	// Enable debug and error logging.
 	define('WP_DEBUG', true);
 	define('WP_DEBUG_LOG', true);
+}
 
+// Environment based setup.
+if (WP_ENVIRONMENT_TYPE === 'development' || WP_ENVIRONMENT_TYPE === 'local') {
 	// Enable direct upload from admin.
 	define('FS_METHOD', 'direct');
 

--- a/src/ConfigProject/ConfigProjectExample.php
+++ b/src/ConfigProject/ConfigProjectExample.php
@@ -32,12 +32,12 @@ define('AUTOSAVE_INTERVAL', 240);
 // Disable automatic updating of plugins.
 define('AUTOMATIC_UPDATER_DISABLED', true);
 
-// Enable debug and error logging.
-define('WP_DEBUG', true);
-define('WP_DEBUG_LOG', true);
-
 // Environment based setup.
 if (WP_ENVIRONMENT_TYPE === 'development' || WP_ENVIRONMENT_TYPE === 'local') {
+	// Enable debug and error logging.
+	define('WP_DEBUG', true);
+	define('WP_DEBUG_LOG', true);
+
 	// Enable direct upload from admin.
 	define('FS_METHOD', 'direct');
 


### PR DESCRIPTION
I think we should not have debugging turned on when in production or staging.