### PR TITLE
Feature/render helper

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -210,7 +210,7 @@ class Components
 			$manifestKey = $manifest['attributes'][$key] ?? null;
 
 			if ($manifestKey === null) {
-				throw new \Exception("{$key} key does not exist in the {$componentName} component. Please check your implementation. Check if your {$key} attributes exists in the components manifest.json");
+				throw new \Exception("{$key} key does not exist in the {$componentName} component. Please check your implementation. Check if your {$key} attribut exists in the component's manifest.json");
 			}
 
 			$defaultType = $manifestKey['type'];

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -74,13 +74,13 @@ class Components
 	 * @param array  $attributes Array of attributes that's implicitly passed to component.
 	 * @param string $parentPath If parent path is provides it will be appended to the file location.
 	 *                            If not get_template_directory_uri() will be used as a default parent path.
-	 * @param bool   $useParentDefaults If true the helper will fetch component manifest and merge default attributes in the original attributes list.
+	 * @param bool   $useComponentDefaults If true the helper will fetch component manifest and merge default attributes in the original attributes list.
 	 *
 	 * @throws \Exception When we're unable to find the component by $component.
 	 *
 	 * @return string
 	 */
-	public static function render(string $component, array $attributes = [], string $parentPath = '', bool $useParentDefaults = false)
+	public static function render(string $component, array $attributes = [], string $parentPath = '', bool $useComponentDefaults = false)
 	{
 		if (empty($parentPath)) {
 			$parentPath = \get_template_directory();
@@ -90,13 +90,13 @@ class Components
 		if (strpos($component, '.php') !== false) {
 			$componentPath = "{$parentPath}/$component";
 
-			if ($useParentDefaults) {
+			if ($useComponentDefaults) {
 				$manifest = self::getManifest($parentPath);
 			}
 		} else {
 			$componentPath = "{$parentPath}/src/Blocks/components/{$component}/{$component}.php";
 
-			if ($useParentDefaults) {
+			if ($useComponentDefaults) {
 				$manifest = self::getManifest("{$parentPath}/src/Blocks/components/{$component}");
 			}
 		}
@@ -105,7 +105,7 @@ class Components
 			ComponentException::throwUnableToLocateComponent($componentPath);
 		}
 
-		if ($useParentDefaults && isset($manifest['attributes'])) {
+		if ($useComponentDefaults && isset($manifest['attributes'])) {
 			$defaultAttributes = [];
 			foreach ($manifest['attributes'] as $itemKey => $itemValue) {
 				if (isset($itemValue['default'])) {
@@ -121,7 +121,7 @@ class Components
 		// Wrap component with parent BEM selector if parent's class is provided. Used
 		// for setting specific styles for components rendered inside other components.
 		if (isset($attributes['parentClass'])) {
-			echo "<div class=\"{$attributes['parentClass']}__{$component}\">"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			printf('<div class="%s">', \esc_attr("{$attributes['parentClass']}__{$component}"));
 		}
 
 		require $componentPath;

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -74,12 +74,13 @@ class Components
 	 * @param array  $attributes Array of attributes that's implicitly passed to component.
 	 * @param string $parentPath If parent path is provides it will be appended to the file location.
 	 *                            If not get_template_directory_uri() will be used as a default parent path.
+	 * @param bool $useParentDefaults If true the helper will fetch component manifest and merge default attributes in the original attributes list.
 	 *
 	 * @throws \Exception When we're unable to find the component by $component.
 	 *
 	 * @return string
 	 */
-	public static function render(string $component, array $attributes = [], string $parentPath = '')
+	public static function render(string $component, array $attributes = [], string $parentPath = '', bool $useParentDefaults = false)
 	{
 		if (empty($parentPath)) {
 			$parentPath = \get_template_directory();
@@ -88,12 +89,31 @@ class Components
 		// Detect if user passed component name or path.
 		if (strpos($component, '.php') !== false) {
 			$componentPath = "{$parentPath}/$component";
+
+			if ($useParentDefaults) {
+				$manifest = self::getManifest($parentPath);
+			}
 		} else {
 			$componentPath = "{$parentPath}/src/Blocks/components/{$component}/{$component}.php";
+
+			if ($useParentDefaults) {
+				$manifest = self::getManifest("{$parentPath}/src/Blocks/components/{$component}");
+			}
 		}
 
 		if (!file_exists($componentPath)) {
 			ComponentException::throwUnableToLocateComponent($componentPath);
+		}
+
+		if ($useParentDefaults && isset($manifest['attributes'])) {
+			$defaultAttributes = [];
+			foreach($manifest['attributes'] as $itemKey => $itemValue) {
+				if (isset($itemValue['default'])) {
+					$defaultAttributes[$itemKey] = $itemValue['default'];
+				}
+			}
+
+			$attributes = array_merge($defaultAttributes, $attributes);
 		}
 
 		ob_start();
@@ -101,7 +121,7 @@ class Components
 		// Wrap component with parent BEM selector if parent's class is provided. Used
 		// for setting specific styles for components rendered inside other components.
 		if (isset($attributes['parentClass'])) {
-			echo \wp_kses_post("<div class=\"{$attributes['parentClass']}__{$component}\">");
+			echo "<div class=\"{$attributes['parentClass']}__{$component}\">";
 		}
 
 		require $componentPath;
@@ -190,7 +210,7 @@ class Components
 			$manifestKey = $manifest['attributes'][$key] ?? null;
 
 			if ($manifestKey === null) {
-				throw new \Exception("{$key} key does not exist in the {$componentName} component. Please check your implementation.");
+				throw new \Exception("{$key} key does not exist in the {$componentName} component. Please check your implementation. Check if your {$key} attributes exists in the components manifest.json");
 			}
 
 			$defaultType = $manifestKey['type'];

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -74,7 +74,7 @@ class Components
 	 * @param array  $attributes Array of attributes that's implicitly passed to component.
 	 * @param string $parentPath If parent path is provides it will be appended to the file location.
 	 *                            If not get_template_directory_uri() will be used as a default parent path.
-	 * @param bool $useParentDefaults If true the helper will fetch component manifest and merge default attributes in the original attributes list.
+	 * @param bool   $useParentDefaults If true the helper will fetch component manifest and merge default attributes in the original attributes list.
 	 *
 	 * @throws \Exception When we're unable to find the component by $component.
 	 *
@@ -107,7 +107,7 @@ class Components
 
 		if ($useParentDefaults && isset($manifest['attributes'])) {
 			$defaultAttributes = [];
-			foreach($manifest['attributes'] as $itemKey => $itemValue) {
+			foreach ($manifest['attributes'] as $itemKey => $itemValue) {
 				if (isset($itemValue['default'])) {
 					$defaultAttributes[$itemKey] = $itemValue['default'];
 				}
@@ -121,7 +121,7 @@ class Components
 		// Wrap component with parent BEM selector if parent's class is provided. Used
 		// for setting specific styles for components rendered inside other components.
 		if (isset($attributes['parentClass'])) {
-			echo "<div class=\"{$attributes['parentClass']}__{$component}\">";
+			echo "<div class=\"{$attributes['parentClass']}__{$component}\">"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 		require $componentPath;


### PR DESCRIPTION
I have found out that when you want to use component in a different component the is smart, for example use heading component for single article, you have to provide attribute for the headingContent. You expect to have all default attributes from the component but this is not happening out of the box. So you must map all the default components manually.

Now you can provide 4th key as `true` and this will happen automatically. 

Before:
```php
echo \wp_kses_post(
	Components::render(
		'card-review-alternative',
		[
			'headingColor' => $cardReviewAlternativeManifest['attributes']['headingColor']['default'],
			'headingSize' => $cardReviewAlternativeManifest['attributes']['headingSize']['default'],
			'headingWeight' => $cardReviewAlternativeManifest['attributes']['headingWeight']['default'],
			/* translators: %s will be replaced with the number of rating. */
			'headingContent' => sprintf(__('Rated %s/5', 'Tvornica'), $rating),

			'ratingAmount' => $rating,

			'paragraphContent' => \get_field(ReviewAcfMeta::FIELD_REVIEW_KEY, $review->ID),
			'paragraphSize' => $cardReviewAlternativeManifest['attributes']['paragraphSize']['default'],

			'linkContent' => __('Read the reviews', 'Tvornica'),
			'linkUrl' => "#reviews",
			'linkSize' => $cardReviewAlternativeManifest['attributes']['linkSize']['default'],
			'linkColor' => $cardReviewAlternativeManifest['attributes']['linkColor']['default'],
			'linkIsUppercase' => $cardReviewAlternativeManifest['attributes']['linkIsUppercase']['default'],
			'linkUseArrow' => $cardReviewAlternativeManifest['attributes']['linkUseArrow']['default'],

			'blockClass' => $componentClass
		],
	)
);
```

now:
```php
echo \wp_kses_post(
	Components::render(
		'card-review-alternative',
		[
			/* translators: %s will be replaced with the number of rating. */
			'headingContent' => sprintf(__('Rated %s/5', 'Tvornica'), $rating),

			'ratingAmount' => $rating,

			'paragraphContent' => \get_field(ReviewAcfMeta::FIELD_REVIEW_KEY, $review->ID),

			'linkContent' => __('Read the reviews', 'Tvornica'),
			'linkUrl' => "#reviews",

			'blockClass' => $componentClass
		],
	),
	'',
	true
);
```

All the default components will be inherited from the called component