### PR TITLE
Setup tests

### DIFF
--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -793,7 +793,7 @@ abstract class AbstractCli implements CliInterface
 	{
 		$output = dirname(__DIR__, 8);
 
-		if ($isDev) {
+		if ($isDev || getenv('TEST') !== false) {
 			$output = dirname(__DIR__, 2);
 		}
 

--- a/src/Setup/SetupCli.php
+++ b/src/Setup/SetupCli.php
@@ -17,6 +17,7 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class SetupCli extends AbstractCli
 {
+	public const SETUP_CLI_COMMAND_NAME = 'init_setup';
 
 	/**
 	 * Output dir relative path.
@@ -32,7 +33,7 @@ class SetupCli extends AbstractCli
 	 */
 	public function getCommandName(): string
 	{
-		return 'init_setup';
+		return self::SETUP_CLI_COMMAND_NAME;
 	}
 
 	/**

--- a/src/Setup/UpdateCli.php
+++ b/src/Setup/UpdateCli.php
@@ -18,6 +18,7 @@ use WP_CLI\ExitException;
  */
 class UpdateCli extends AbstractCli
 {
+	public const COMMAND_NAME = 'run_update';
 
 	/**
 	 * Get WPCLI command name
@@ -26,7 +27,7 @@ class UpdateCli extends AbstractCli
 	 */
 	public function getCommandName(): string
 	{
-		return 'run_update';
+		return self::COMMAND_NAME;
 	}
 
 	/**
@@ -75,7 +76,13 @@ class UpdateCli extends AbstractCli
 
 	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
-		require $this->getLibsPath('src/Setup/Setup.php');
+		require_once $this->getLibsPath('src/Setup/Setup.php');
+
+		$setupFilename = 'setup.json';
+
+		if (getenv('TEST') !== false) {
+			$setupFilename = $this->getProjectConfigRootPath() . '/cliOutput/setup.json';
+		}
 
 		try {
 			setup(
@@ -86,7 +93,8 @@ class UpdateCli extends AbstractCli
 					'skip_plugins_core' => $assocArgs['skip_plugins_core'] ?? false,
 					'skip_plugins_github' => $assocArgs['skip_plugins_github'] ?? false,
 					'skip_themes' => $assocArgs['skip_themes'] ?? false,
-				]
+				],
+				$setupFilename
 			);
 		} catch (ExitException $e) {
 			exit("{$e->getCode()}: {$e->getMessage()}");

--- a/tests/Setup/SetupCliTest.php
+++ b/tests/Setup/SetupCliTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit\Setup;
+
+use EightshiftLibs\Setup\SetupCli;
+
+use function Tests\deleteCliOutput;
+
+/**
+ * Mock before tests.
+ */
+beforeEach(function () {
+    $wpCliMock = \Mockery::mock('alias:WP_CLI');
+
+	$wpCliMock
+		->shouldReceive('success')
+		->andReturnArg(0);
+
+	$wpCliMock
+		->shouldReceive('error')
+		->andReturnArg(0);
+
+	$this->setup = new SetupCli('boilerplate');
+});
+
+/**
+ * Cleanup after tests.
+ */
+afterEach(function () {
+	$output = dirname(__FILE__, 3) . '/cliOutput';
+
+	deleteCliOutput($output);
+});
+
+test('Setup CLI command will correctly copy the Setup class with defaults', function () {
+	$setup = $this->setup;
+	$setup([], $setup->getDevelopArgs([]));
+
+	// Check the output dir if the generated method is correctly generated.
+	$generatedFile = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/setup.json');
+	$this->assertStringContainsString('twentytwentyone', $generatedFile);
+	$this->assertStringNotContainsString('random string', $generatedFile);
+});
+
+test('Setup CLI command will correctly copy the Setup class with set parameters', function () {
+	$setup = $this->setup;
+	$setup([], [
+		'root' => 'test',
+	]);
+
+	// Check the output dir if the generated method is correctly generated.
+	$generatedFile = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/test/setup.json');
+	$this->assertStringContainsString('twentytwentyone', $generatedFile);
+	$this->assertStringNotContainsString('random string', $generatedFile);
+});
+
+test('Setup CLI documentation is correct', function () {
+	$setup = $this->setup;
+
+	$documentation = $setup->getDoc();
+
+	$key = 'shortdesc';
+
+	$this->assertIsArray($documentation);
+	$this->assertArrayHasKey($key, $documentation);
+	$this->assertArrayHasKey('synopsis', $documentation);
+	$this->assertEquals('Initialize Command for automatic project setup and update.', $documentation[$key]);
+});

--- a/tests/Setup/SetupCliTest.php
+++ b/tests/Setup/SetupCliTest.php
@@ -10,7 +10,7 @@ use function Tests\deleteCliOutput;
  * Mock before tests.
  */
 beforeEach(function () {
-    $wpCliMock = \Mockery::mock('alias:WP_CLI');
+	$wpCliMock = \Mockery::mock('alias:WP_CLI');
 
 	$wpCliMock
 		->shouldReceive('success')

--- a/tests/Setup/UpdateCliTest.php
+++ b/tests/Setup/UpdateCliTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Unit\Setup;
+
+use EightshiftLibs\Setup\UpdateCli;
+use Throwable;
+use WP_CLI\ExitException;
+
+use function Tests\deleteCliOutput;
+
+/**
+ * Mock before tests.
+ */
+beforeEach(function () {
+    $wpCliMock = \Mockery::mock('alias:WP_CLI');
+
+	$wpCliMock
+		->shouldReceive('success')
+		->andReturnArg(0);
+
+	$wpCliMock
+		->shouldReceive('error')
+		->andReturnArg(0);
+
+	$wpCliMock
+		->shouldReceive('runcommand')
+		->andReturnArg(0);
+
+	$wpCliMock
+		->shouldReceive('log')
+		->andReturnArg(0);
+
+	$this->update = new UpdateCli('boilerplate');
+});
+
+/**
+ * Cleanup after tests.
+ */
+afterEach(function () {
+	$output = dirname(__FILE__, 3) . '/cliOutput';
+
+	deleteCliOutput($output);
+});
+
+test('Update CLI command will correctly run the update with defaults', function () {
+	// Create cliOutput folder ...
+	$outputDir = dirname(__FILE__, 3) . '/cliOutput';
+
+	if (!is_dir($outputDir)) {
+		mkdir($outputDir, 0755, true);
+	}
+
+	// ... so you can copy the example setup.json inside
+	copy(dirname(__FILE__, 3) . '/src/Setup/setup.json', dirname(__FILE__, 3) . '/cliOutput/setup.json');
+
+	// Check if an exception occured
+	$exceptionOccured = false;
+
+	$update = $this->update;
+	$update([], []);
+});
+
+test('Update CLI command will correctly throw an exception if setup.json does not exist or has the wrong filename', function () {
+	$update = $this->update;
+	$update([], []);
+})->throws(\Exception::class);
+
+test('Update CLI documentation is correct', function () {
+	$update = $this->update;
+
+	$documentation = $update->getDoc();
+
+	$key = 'shortdesc';
+
+	$this->assertIsArray($documentation);
+	$this->assertArrayHasKey($key, $documentation);
+	$this->assertArrayHasKey('synopsis', $documentation);
+	$this->assertEquals('Run project update with details stored in setup.json file.', $documentation[$key]);
+});

--- a/tests/Setup/UpdateCliTest.php
+++ b/tests/Setup/UpdateCliTest.php
@@ -12,7 +12,7 @@ use function Tests\deleteCliOutput;
  * Mock before tests.
  */
 beforeEach(function () {
-    $wpCliMock = \Mockery::mock('alias:WP_CLI');
+	$wpCliMock = \Mockery::mock('alias:WP_CLI');
 
 	$wpCliMock
 		->shouldReceive('success')
@@ -56,8 +56,14 @@ test('Update CLI command will correctly run the update with defaults', function 
 	// Check if an exception occured
 	$exceptionOccured = false;
 
-	$update = $this->update;
-	$update([], []);
+	try {
+		$update = $this->update;
+		$update([], []);
+	} catch (\Throwable $th) {
+		$exceptionOccured = true;
+	}
+
+	$this->assertFalse($exceptionOccured);
 });
 
 test('Update CLI command will correctly throw an exception if setup.json does not exist or has the wrong filename', function () {


### PR DESCRIPTION
This took way more than I hoped it would, ran into some weird issues and path brainf##ks, but all is good now 😄 

Changelog:
- `AbstractCli` wasn't detecting the test environment correctly, added the condition that makes it work now
- extracted command name to a const in `SetupCli` and `UpdateCli`
- added check in `UpdateCli` to detect if we're in a test environment and make it point to `setup.json` in `cliOutput` instead of libs root folder
- added tests for `SetupCli` and `UpdateCli`