### PR TITLE
Custom taxonomy wrong doc comment fix

### DIFF
--- a/src/CustomTaxonomy/TaxonomyCli.php
+++ b/src/CustomTaxonomy/TaxonomyCli.php
@@ -102,6 +102,7 @@ class TaxonomyCli extends AbstractCli
 			->searchReplaceString('example-endpoint-slug', $restEndpointSlug)
 			->searchReplaceString("'post'", "'{$postTypeSlug}'")
 			->searchReplaceString('Example Name', $label)
+			->searchReplaceString('Blog_Taxonomy', $className)
 			->outputWrite(static::OUTPUT_DIR, $className, $assocArgs);
 	}
 }

--- a/tests/CustomTaxonomy/TaxonomyCliTest.php
+++ b/tests/CustomTaxonomy/TaxonomyCliTest.php
@@ -40,6 +40,7 @@ test('Custom taxonomy CLI command will correctly copy the Taxonomy class', funct
 	// Check the output dir if the generated method is correctly generated.
 	$generatedTaxonomy = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/CustomTaxonomy/LocationTaxonomy.php');
 
+	$this->assertStringContainsString('The LocationTaxonomy specific functionality.', $generatedTaxonomy);
 	$this->assertStringContainsString('class LocationTaxonomy extends AbstractTaxonomy', $generatedTaxonomy);
 	$this->assertStringContainsString('getTaxonomySlug', $generatedTaxonomy);
 	$this->assertStringContainsString('getPostTypeSlug', $generatedTaxonomy);


### PR DESCRIPTION
When generating a custom taxonomy, the doc comment of the generated file always had
> The Blog_Taxonomy specific functionality.
as a doc comment.

This PR corrects it to include the class name, aka
> The `$className` specific functionality.