### PR TITLE
Fix the autowiring issue

### DIFF
--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Main;
 
+use EightshiftLibs\Services\ServiceInterface;
+
 /**
  * The file that defines the autowiring process
  */
@@ -50,8 +52,13 @@ class Autowiring
 		foreach ($projectClasses as $projectClass) {
 			$reflClass = new \ReflectionClass($projectClass);
 
-			// Skip abstract classes, interfaces & traits.
-			if ($reflClass->isAbstract() || $reflClass->isInterface() || $reflClass->isTrait()) {
+			// Skip abstract classes, interfaces & traits, and non service classes.
+			if (
+				$reflClass->isAbstract() ||
+				$reflClass->isInterface() ||
+				$reflClass->isTrait() ||
+				!$reflClass->implementsInterface(ServiceInterface::class)
+			) {
 				continue;
 			}
 


### PR DESCRIPTION
Exclude the non-service classes from autowiring.

This should fix the bug I was experiencing on a client's site.

This is a temp fix without tests (we'll add those in 3.1.0).