### PR TITLE
Autowiring fixes + tests

### DIFF
--- a/src/Exception/InvalidAutowireDependency.php
+++ b/src/Exception/InvalidAutowireDependency.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * File containing the failure exception class when trying to inject interface based dependencies into a class (using autowiring) but
+ * failing to provide the correct variable name by which we can find a class to inject.
+ *
+ * @package EightshiftLibs\Exception
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftLibs\Exception;
+
+/**
+ * Class Component_Exception.
+ */
+final class InvalidAutowireDependency extends \InvalidArgumentException implements GeneralExceptionInterface
+{
+
+	/**
+	 * Throws exception if we cant guess the class to inject.
+	 *
+	 * @param string $className Class name we're looking for.
+	 * @param string $interfaceName Class we're looking for needs to implement this.
+	 * @return static
+	 */
+	public static function throwUnableToFindClass(string $className, string $interfaceName)
+	{
+		return new static(
+			sprintf(
+				/* translators: %s is replaced with the className and interfaceName. */
+				"Unable to find \"%s\" class that implements %s (looking in \$filenameIndex). When injecting Interface dependencies, please make sure your variable name in __construct() matches the filename of a class implementing that interface (otherwise we dont know which class to inject). Alternatively you can define the dependency tree manually for this class using \$main->getServiceClasses(). See https://infinum.github.io/eightshift-docs/docs/basics/autowiring#what-if-my-class-has-an-interface-parameter-inside-the-constructor-method",
+				$className,
+				$interfaceName
+			)
+		);
+	}
+
+	/**
+	 * Throws exception if we cant guess the class to inject because we found more than 1 with same name that implement $interfaceName.
+	 *
+	 * @param string $className Class name we're looking for.
+	 * @param string $interfaceName Class we're looking for needs to implement this.
+	 * @return static
+	 */
+	public static function throwMoreThanOneClassFound(string $className, string $interfaceName)
+	{
+		return new static(
+			sprintf(
+				/* translators: %s is replaced with the className and interfaceName. */
+				"Found more than 1 class called \"%s\" that implements %s interface. Please make sure you dont have more than 1 class with the same name implementing the same interface. Alternatively you can manually defined dependencies for the class that uses %s interface as a dependency. See: https://infinum.github.io/eightshift-docs/docs/basics/autowiring#what-if-my-class-has-an-interface-parameter-inside-the-constructor-method",
+				$className,
+				$interfaceName,
+				$interfaceName
+			)
+		);
+	}
+
+	/**
+	 * Throws exception if we find a primitive dependency on a class that's not been manually built.
+	 *
+	 * @param string $className Class name we're looking for.
+	 * @return static
+	 */
+	public static function throwPrimitiveDependencyFound(string $className)
+	{
+		return new static(
+			sprintf(
+				/* translators: %s is replaced with the className and interfaceName. */
+				"Found a primitive dependency for %s. Autowire is unable to figure out what value needs to be injected here. Please define the dependency tree for this class manually using \$main->getServiceClasses(). See: https://infinum.github.io/eightshift-docs/docs/basics/autowiring#what-if-my-class-has-a-primitive-parameter-string-int-etc-inside-a-constructor-method",
+				$className
+			)
+		);
+	}
+}

--- a/src/Exception/NonPsr4CompliantClass.php
+++ b/src/Exception/NonPsr4CompliantClass.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * File containing the failure exception class when trying to autowire a class that's not PSR-4 compliant
+ *
+ * @package EightshiftLibs\Exception
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftLibs\Exception;
+
+/**
+ * Class Component_Exception.
+ */
+final class NonPsr4CompliantClass extends \InvalidArgumentException implements GeneralExceptionInterface
+{
+
+	/**
+	 * Throws exception if class has non psr-4 compliant namespace.
+	 *
+	 * @param string $className Class name we're looking for.
+	 * @return static
+	 */
+	public static function throwInvalidNamespace(string $className)
+	{
+		return new static(
+			sprintf(
+				/* translators: %s is replaced with the className. */
+				'Unable to autowire %s. Please check if the namespace is PSR-4 compliant (i.e. it needs to match the folder structure). See: https://www.php-fig.org/psr/psr-4/#3-examples',
+				$className
+			)
+		);
+	}
+}

--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -105,7 +105,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 */
 	private function getServiceClassesWithAutowire(): array
 	{
-		return array_merge($this->buildServiceClasses(), $this->getServiceClasses());
+		return $this->buildServiceClasses($this->getServiceClasses());
 	}
 
 	/**

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Main;
 
+use EightshiftLibs\Services\ServiceInterface;
+
 /**
  * The file that defines the autowiring process
  */
@@ -56,8 +58,13 @@ class Autowiring
 				continue;
 			}
 
-			// Skip abstract classes, interfaces & traits.
-			if ($reflClass->isAbstract() || $reflClass->isInterface() || $reflClass->isTrait()) {
+			// Skip abstract classes, interfaces & traits, and non service classes.
+			if (
+				$reflClass->isAbstract() ||
+				$reflClass->isInterface() ||
+				$reflClass->isTrait() ||
+				!$reflClass->implementsInterface(ServiceInterface::class)
+			) {
 				continue;
 			}
 

--- a/tests/Datasets/Autowiring/Deep/Deeper/ServiceNoDependenciesDeep.php
+++ b/tests/Datasets/Autowiring/Deep/Deeper/ServiceNoDependenciesDeep.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MockAutowiring\Deep\Deeper;
+namespace Tests\Datasets\Autowiring\Deep\Deeper;
 
 use EightshiftLibs\Services\ServiceInterface;
 

--- a/tests/Datasets/Autowiring/Deep/Deeper/ServiceNoDependenciesDeep.php
+++ b/tests/Datasets/Autowiring/Deep/Deeper/ServiceNoDependenciesDeep.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MockAutowiring\Deep\Deeper;
+
+use EightshiftLibs\Services\ServiceInterface;
+
+class ServiceNoDependenciesDeep implements ServiceInterface
+{
+	/**
+	 * Registers service.
+   *
+	 * @return void
+	 */
+	public function register(): void
+	{
+	}
+}

--- a/tests/Datasets/Autowiring/Dependencies/ClassDepWithNoDependencies.php
+++ b/tests/Datasets/Autowiring/Dependencies/ClassDepWithNoDependencies.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Dependencies;
+
+class ClassDepWithNoDependencies
+{
+}

--- a/tests/Datasets/Autowiring/Dependencies/ClassImplementingInterfaceDependency.php
+++ b/tests/Datasets/Autowiring/Dependencies/ClassImplementingInterfaceDependency.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Dependencies;
+
+class ClassImplementingInterfaceDependency implements InterfaceDependency
+{
+}

--- a/tests/Datasets/Autowiring/Dependencies/ClassWithDependency.php
+++ b/tests/Datasets/Autowiring/Dependencies/ClassWithDependency.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Dependencies;
+
+class ClassWithDependency
+{
+  public function __construct(ClassDepWithNoDependencies $classDepWithNoDependencies) {
+    $this->classDepWithNoDependencies = $classDepWithNoDependencies;
+  }
+}

--- a/tests/Datasets/Autowiring/Dependencies/InterfaceDependency.php
+++ b/tests/Datasets/Autowiring/Dependencies/InterfaceDependency.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Dependencies;
+
+interface InterfaceDependency
+{
+}

--- a/tests/Datasets/Autowiring/Dependencies/SubNamespace1/SomeClass.php
+++ b/tests/Datasets/Autowiring/Dependencies/SubNamespace1/SomeClass.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Dependencies\SubNamespace1;
+
+use Tests\Datasets\Autowiring\Dependencies\InterfaceDependency;
+
+class SomeClass implements InterfaceDependency
+{
+}

--- a/tests/Datasets/Autowiring/Dependencies/SubNamespace2/SomeClass.php
+++ b/tests/Datasets/Autowiring/Dependencies/SubNamespace2/SomeClass.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Dependencies\SubNamespace2;
+
+use Tests\Datasets\Autowiring\Dependencies\InterfaceDependency;
+
+class SomeClass implements InterfaceDependency
+{
+}

--- a/tests/Datasets/Autowiring/NonServices/SomeFactory.php
+++ b/tests/Datasets/Autowiring/NonServices/SomeFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MockAutowiring\NonServices;
+
+/**
+ * Some class that should not be autowired.
+ */
+class SomeFactory
+{
+}

--- a/tests/Datasets/Autowiring/NonServices/SomeFactory.php
+++ b/tests/Datasets/Autowiring/NonServices/SomeFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MockAutowiring\NonServices;
+namespace Tests\Datasets\Autowiring\NonServices;
 
 /**
  * Some class that should not be autowired.

--- a/tests/Datasets/Autowiring/Other/MockAbstractClass.php
+++ b/tests/Datasets/Autowiring/Other/MockAbstractClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Other;
+
+abstract class MockAbstractClass
+{
+}

--- a/tests/Datasets/Autowiring/Other/MockTrait.php
+++ b/tests/Datasets/Autowiring/Other/MockTrait.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Other;
+
+trait MockTrait
+{
+}

--- a/tests/Datasets/Autowiring/Services/ServiceNoDependencies.php
+++ b/tests/Datasets/Autowiring/Services/ServiceNoDependencies.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MockAutowiring\Services;
+
+use EightshiftLibs\Services\ServiceInterface;
+
+class ServiceNoDependencies implements ServiceInterface
+{
+	/**
+	 * Registers service.
+   *
+	 * @return void
+	 */
+	public function register(): void
+	{
+	}
+}

--- a/tests/Datasets/Autowiring/Services/ServiceWithClassDep.php
+++ b/tests/Datasets/Autowiring/Services/ServiceWithClassDep.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Services;
+
+use EightshiftLibs\Services\ServiceInterface;
+use Tests\Datasets\Autowiring\Dependencies\ClassDepWithNoDependencies;
+
+class ServiceWithClassDep implements ServiceInterface
+{
+
+	public function __construct(ClassDepWithNoDependencies $classDepWithNoDependencies) {
+		$this->classDepWithNoDependencies = $classDepWithNoDependencies;
+	}
+
+	/**
+	 * Registers service.
+   *
+	 * @return void
+	 */
+	public function register(): void
+	{
+	}
+}

--- a/tests/Datasets/Autowiring/Services/ServiceWithDeepClassDep.php
+++ b/tests/Datasets/Autowiring/Services/ServiceWithDeepClassDep.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Services;
+
+use EightshiftLibs\Services\ServiceInterface;
+use Tests\Datasets\Autowiring\Dependencies\ClassWithDependency;
+
+class ServiceWithDeepClassDep implements ServiceInterface
+{
+
+	public function __construct(ClassWithDependency $classWithDependency) {
+		$this->classWithDependency = $classWithDependency;
+	}
+
+	/**
+	 * Registers service.
+   *
+	 * @return void
+	 */
+	public function register(): void
+	{
+	}
+}

--- a/tests/Datasets/Autowiring/Services/ServiceWithInterfaceDep.php
+++ b/tests/Datasets/Autowiring/Services/ServiceWithInterfaceDep.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Services;
+
+use EightshiftLibs\Services\ServiceInterface;
+use Tests\Datasets\Autowiring\Dependencies\InterfaceDependency;
+
+class ServiceWithInterfaceDep implements ServiceInterface
+{
+	public function __construct(InterfaceDependency $classImplementingInterfaceDependency) {
+		$this->classImplementingInterfaceDependency = $classImplementingInterfaceDependency;
+	}
+
+	/**
+	 * Registers service.
+   *
+	 * @return void
+	 */
+	public function register(): void
+	{
+	}
+}

--- a/tests/Datasets/Autowiring/Services/ServiceWithInterfaceDepMoreThanOneClassFound.php
+++ b/tests/Datasets/Autowiring/Services/ServiceWithInterfaceDepMoreThanOneClassFound.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Services;
+
+use EightshiftLibs\Services\ServiceInterface;
+use Tests\Datasets\Autowiring\Dependencies\InterfaceDependency;
+
+class ServiceWithInterfaceDepMoreThanOneClassFound implements ServiceInterface
+{
+	public function __construct(InterfaceDependency $someClass) {
+		$this->someClass = $someClass;
+	}
+
+	/**
+	 * Registers service.
+   *
+	 * @return void
+	 */
+	public function register(): void
+	{
+	}
+}

--- a/tests/Datasets/Autowiring/Services/ServiceWithInterfaceDepWrongName.php
+++ b/tests/Datasets/Autowiring/Services/ServiceWithInterfaceDepWrongName.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Services;
+
+use EightshiftLibs\Services\ServiceInterface;
+use Tests\Datasets\Autowiring\Dependencies\InterfaceDependency;
+
+class ServiceWithInterfaceDepWrongName implements ServiceInterface
+{
+	public function __construct(InterfaceDependency $incorrectVariableName) {
+		$this->incorrectVariableName = $incorrectVariableName;
+	}
+
+	/**
+	 * Registers service.
+   *
+	 * @return void
+	 */
+	public function register(): void
+	{
+	}
+}

--- a/tests/Datasets/Autowiring/Services/ServiceWithMultipleDeps.php
+++ b/tests/Datasets/Autowiring/Services/ServiceWithMultipleDeps.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Services;
+
+use EightshiftLibs\Services\ServiceInterface;
+use Tests\Datasets\Autowiring\Dependencies\ClassDepWithNoDependencies;
+use Tests\Datasets\Autowiring\Dependencies\InterfaceDependency;
+
+class ServiceWithMultipleDeps implements ServiceInterface
+{
+	public function __construct(InterfaceDependency $classImplementingInterfaceDependency, ClassDepWithNoDependencies $classDepWithNoDependencies) {
+		$this->classImplementingInterfaceDependency = $classImplementingInterfaceDependency;
+		$this->classDepWithNoDependencies = $classDepWithNoDependencies;
+	}
+
+	/**
+	 * Registers service.
+   *
+	 * @return void
+	 */
+	public function register(): void
+	{
+	}
+}

--- a/tests/Datasets/Autowiring/Services/ServiceWithPrimitiveDep.php
+++ b/tests/Datasets/Autowiring/Services/ServiceWithPrimitiveDep.php
@@ -6,8 +6,12 @@ namespace Tests\Datasets\Autowiring\Services;
 
 use EightshiftLibs\Services\ServiceInterface;
 
-class ServiceNoDependencies implements ServiceInterface
+class ServiceWithPrimitiveDep implements ServiceInterface
 {
+	public function __construct(string $something) {
+		$this->something = $something;
+	}
+
 	/**
 	 * Registers service.
    *

--- a/tests/Datasets/Autowiring/Services/ServiceWithPrimitiveDepHasDefault.php
+++ b/tests/Datasets/Autowiring/Services/ServiceWithPrimitiveDepHasDefault.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Services;
+
+use EightshiftLibs\Services\ServiceInterface;
+
+class ServiceWithPrimitiveDepHasDefault implements ServiceInterface
+{
+	public function __construct(string $something = 'default') {
+		$this->something = $something;
+	}
+
+	/**
+	 * Registers service.
+   *
+	 * @return void
+	 */
+	public function register(): void
+	{
+	}
+}

--- a/tests/Datasets/Autowiring/invalid/ServiceWithInvalidNamespace.php
+++ b/tests/Datasets/Autowiring/invalid/ServiceWithInvalidNamespace.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Datasets\Autowiring\Invalid\DoesNotExist;
+
+use EightshiftLibs\Services\ServiceInterface;
+
+if ( ! class_exists( ServiceWithInvalidNamespace::class ) ) {
+	class ServiceWithInvalidNamespace implements ServiceInterface
+	{
+		/**
+		 * Registers service.
+		 *
+		 * @return void
+		 */
+		public function register(): void
+		{
+		}
+	}
+}

--- a/tests/Main/AutowiringTest.php
+++ b/tests/Main/AutowiringTest.php
@@ -147,3 +147,19 @@ test('Autowiring does not throw exceptions on blocks', function () {
 test('Autowiring throws exception on primitive deps which are not manually configured', function () {
 	$this->main->buildServiceClasses($this->manualDepsNoPrimitive, true);
 })->throws(InvalidAutowireDependency::class);
+
+test('buildServiceClasses includes all manually defined dependency trees', function () {
+	$dependencyTree = $this->main->buildServiceClasses($this->manuallyDefinedDependencies, true);
+	$this->assertArrayHasKey(ServiceWithInterfaceDepWrongName::class, $dependencyTree);
+	$this->assertArrayHasKey(ServiceWithInterfaceDepMoreThanOneClassFound::class, $dependencyTree);
+	$this->assertArrayHasKey(ServiceWithPrimitiveDep::class, $dependencyTree);
+	$this->assertArrayHasKey(ServiceWithPrimitiveDepHasDefault::class, $dependencyTree);
+	$this->assertIsArray($dependencyTree[ServiceWithInterfaceDepWrongName::class]);
+	$this->assertIsArray($dependencyTree[ServiceWithInterfaceDepMoreThanOneClassFound::class]);
+	$this->assertIsArray($dependencyTree[ServiceWithPrimitiveDep::class]);
+	$this->assertIsArray($dependencyTree[ServiceWithPrimitiveDepHasDefault::class]);
+	$this->assertContains(ClassImplementingInterfaceDependency::class, $dependencyTree[ServiceWithInterfaceDepWrongName::class] );
+	$this->assertContains(SomeClass::class, $dependencyTree[ServiceWithInterfaceDepMoreThanOneClassFound::class] );
+	$this->assertContains('some string', $dependencyTree[ServiceWithPrimitiveDep::class] );
+	$this->assertContains('some string', $dependencyTree[ServiceWithPrimitiveDepHasDefault::class] );
+});

--- a/tests/Main/AutowiringTest.php
+++ b/tests/Main/AutowiringTest.php
@@ -146,4 +146,4 @@ test('Autowiring does not throw exceptions on blocks', function () {
 
 test('Autowiring throws exception on primitive deps which are not manually configured', function () {
 	$this->main->buildServiceClasses($this->manualDepsNoPrimitive, true);
-})->throws(\Exception::class);
+})->throws(InvalidAutowireDependency::class);

--- a/tests/Main/AutowiringTest.php
+++ b/tests/Main/AutowiringTest.php
@@ -4,72 +4,121 @@ namespace Tests\Unit\Autowiring;
 
 use Brain\Monkey;
 use EightshiftBoilerplate\Main\MainExample;
-use MockAutowiring\Services\ServiceNoDependencies;
-use MockAutowiring\Deep\Deeper\ServiceNoDependenciesDeep;
-use MockAutowiring\NonServices\SomeFactory;
-
-use function Tests\setupMocks;
+use Tests\Datasets\Autowiring\Services\ServiceNoDependencies;
+use Tests\Datasets\Autowiring\Deep\Deeper\ServiceNoDependenciesDeep;
+use Tests\Datasets\Autowiring\Dependencies\ClassDepWithNoDependencies;
+use Tests\Datasets\Autowiring\Dependencies\ClassImplementingInterfaceDependency;
+use Tests\Datasets\Autowiring\Dependencies\ClassWithDependency;
+use Tests\Datasets\Autowiring\NonServices\SomeFactory;
+use Tests\Datasets\Autowiring\Services\ServiceWithClassDep;
+use Tests\Datasets\Autowiring\Services\ServiceWithDeepClassDep;
+use Tests\Datasets\Autowiring\Services\ServiceWithInterfaceDep;
+use Tests\Datasets\Autowiring\Services\ServiceWithMultipleDeps;
+use Tests\Datasets\Autowiring\Services\ServiceWithPrimitiveDep;
 
 beforeEach(function() {
-	Monkey\setUp();
-	setupMocks();
 
 	$this->main = new MainExample([
-		'MockAutowiring\\' => [
+		'Tests\\Datasets\\Autowiring\\' => [
 			dirname( __FILE__, 2 ) . '/Datasets/Autowiring',
 		],
-	], 'MockAutowiring');
-});
-
-afterEach(function() {
-	Monkey\tearDown();
+	], 'Tests\Datasets\Autowiring');
 });
 
 test('Building service classes works', function () {
-	// $dependencyTree = $this->main->buildServiceClasses();
-	// $this->assertIsArray($dependencyTree);
-	// $this->assertGreaterThan(0, count($dependencyTree));
+	$dependencyTree = $this->main->buildServiceClasses([], true);
+	$this->assertIsArray($dependencyTree);
+	$this->assertGreaterThan(0, count($dependencyTree));
 });
 
 test('Service classes are correctly included in the list', function () {
-	$dependencyTree = $this->main->buildServiceClasses();
+	$dependencyTree = $this->main->buildServiceClasses([], true);
 	$this->assertIsArray($dependencyTree);
 	$this->assertContains(ServiceNoDependencies::class, $dependencyTree);
 	$this->assertContains(ServiceNoDependenciesDeep::class, $dependencyTree);
 });
 
 test('Non-service classes are NOT auto-wired', function () {
-	$dependencyTree = $this->main->buildServiceClasses();
-	echo print_r($dependencyTree);
+	$dependencyTree = $this->main->buildServiceClasses([], true);
 	$this->assertIsArray($dependencyTree);
 	$this->assertNotContains(SomeFactory::class, $dependencyTree);
 });
 
 test('Service classes with class dependencies are properly auto-wired', function () {
-	// $dependencyTree = $this->main->buildServiceClasses();
-	// $this->assertIsArray($dependencyTree);
-	$this->assertTrue(true);
+	$dependencyTree = $this->main->buildServiceClasses([], true);
+	$this->assertIsArray($dependencyTree);
+
+	// Service with 1 level deep dependency tree.
+	$this->assertArrayHasKey(ServiceWithClassDep::class, $dependencyTree, 'Is service with single class dependency auto-wired?');
+	$this->assertContains(ClassDepWithNoDependencies::class, $dependencyTree[ServiceWithClassDep::class], 'Is service class dependency in the array of dependencies?');
+
+	// Service with 2 levels deep dependency tree.
+	$this->assertArrayHasKey(ServiceWithDeepClassDep::class, $dependencyTree, 'Is service with single class dependency (which has its own dependency) auto-wired?');
+	$this->assertContains(ClassWithDependency::class, $dependencyTree[ServiceWithDeepClassDep::class], 'Is service class dependency in the array of dependencies?');
+	$this->assertArrayHasKey(ClassWithDependency::class, $dependencyTree, 'Is the lvl 1 class dependency auto-wired?');
+	$this->assertContains(ClassDepWithNoDependencies::class, $dependencyTree[ClassWithDependency::class], 'Is the lvl 2 class dependency auto-wired?');
 });
 
 test('Service classes with interface dependencies are properly auto-wired', function () {
-	// $dependencyTree = $this->main->buildServiceClasses();
-	// $this->assertIsArray($dependencyTree);
-	$this->assertTrue(true);
+	$dependencyTree = $this->main->buildServiceClasses([], true);
+	$this->assertIsArray($dependencyTree);
+	$this->assertArrayHasKey(ServiceWithInterfaceDep::class, $dependencyTree, 'Is service with single interface dependency auto-wired?');
+	$this->assertContains(ClassImplementingInterfaceDependency::class, $dependencyTree[ServiceWithInterfaceDep::class], 'Is service class dependency in the array of dependencies?');
 });
 
-test('Service classes with a mix of class / interface dependencies are properly auto-wired', function () {
-	// $dependencyTree = $this->main->buildServiceClasses();
-	// $this->assertIsArray($dependencyTree);
-	$this->assertTrue(true);
+test('Service classes with multiple dependencies are properly auto-wired', function () {
+	$dependencyTree = $this->main->buildServiceClasses([], true);
+	$this->assertIsArray($dependencyTree);
+	$this->assertArrayHasKey(ServiceWithMultipleDeps::class, $dependencyTree, 'Is service with 2 dependencies auto-wired?');
+	$this->assertContains(ClassImplementingInterfaceDependency::class, $dependencyTree[ServiceWithMultipleDeps::class], 'Is interface-based class dependency in the array of dependencies?');
+	$this->assertContains(ClassDepWithNoDependencies::class, $dependencyTree[ServiceWithMultipleDeps::class], 'Is class dependency in the array of dependencies?');
 });
 
 test('Service classes with primitive dependencies are NOT auto-wired', function () {
-	// $dependencyTree = $this->main->buildServiceClasses();
-	// $this->assertIsArray($dependencyTree);
+	$dependencyTree = $this->main->buildServiceClasses([], true);
+	$this->assertIsArray($dependencyTree);
+	$this->assertNotContains(ServiceWithPrimitiveDep::class, $dependencyTree);
+});
+
+test('Service classes with interface dependencies using un-guessable variable names are NOT auto-wired', function () {
+	$dependencyTree = $this->main->buildServiceClasses([], true);
+	$this->assertIsArray($dependencyTree);
 	$this->assertTrue(true);
 });
 
 test('Services with Invalid namespace (non PSR-4 compliant) will not be auto-wired / included', function () {
+	$this->assertTrue(true);
+
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	// $this->assertNotContains(ServiceWithInvalidNamespace::class, $dependencyTree);
+});
+
+test('Autowiring shouldnt touch abstract classses, interfaces and traits', function () {
+	$this->assertTrue(true);
+
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	// $this->assertNotContains(ServiceWithInvalidNamespace::class, $dependencyTree);
+});
+
+test('Autowiring doesn\t throw exceptions on blocks', function () {
+	$this->assertTrue(true);
+
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	// $this->assertNotContains(ServiceWithInvalidNamespace::class, $dependencyTree);
+});
+
+test('Autowiring throws exception on primitive deps which arent manually configured', function () {
+	$this->assertTrue(true);
+
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	// $this->assertNotContains(ServiceWithInvalidNamespace::class, $dependencyTree);
+});
+
+test('Autowiring doesnt throw exception on primitive deps which have defaults', function () {
 	$this->assertTrue(true);
 
 	// $dependencyTree = $this->main->buildServiceClasses();

--- a/tests/Main/AutowiringTest.php
+++ b/tests/Main/AutowiringTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Autowiring;
+
+use Brain\Monkey;
+use EightshiftBoilerplate\Main\MainExample;
+use MockAutowiring\Services\ServiceNoDependencies;
+use MockAutowiring\Deep\Deeper\ServiceNoDependenciesDeep;
+use MockAutowiring\NonServices\SomeFactory;
+
+use function Tests\setupMocks;
+
+beforeEach(function() {
+	Monkey\setUp();
+	setupMocks();
+
+	$this->main = new MainExample([
+		'MockAutowiring\\' => [
+			dirname( __FILE__, 2 ) . '/Datasets/Autowiring',
+		],
+	], 'MockAutowiring');
+});
+
+afterEach(function() {
+	Monkey\tearDown();
+});
+
+test('Building service classes works', function () {
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	// $this->assertGreaterThan(0, count($dependencyTree));
+});
+
+test('Service classes are correctly included in the list', function () {
+	$dependencyTree = $this->main->buildServiceClasses();
+	$this->assertIsArray($dependencyTree);
+	$this->assertContains(ServiceNoDependencies::class, $dependencyTree);
+	$this->assertContains(ServiceNoDependenciesDeep::class, $dependencyTree);
+});
+
+test('Non-service classes are NOT auto-wired', function () {
+	$dependencyTree = $this->main->buildServiceClasses();
+	echo print_r($dependencyTree);
+	$this->assertIsArray($dependencyTree);
+	$this->assertNotContains(SomeFactory::class, $dependencyTree);
+});
+
+test('Service classes with class dependencies are properly auto-wired', function () {
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	$this->assertTrue(true);
+});
+
+test('Service classes with interface dependencies are properly auto-wired', function () {
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	$this->assertTrue(true);
+});
+
+test('Service classes with a mix of class / interface dependencies are properly auto-wired', function () {
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	$this->assertTrue(true);
+});
+
+test('Service classes with primitive dependencies are NOT auto-wired', function () {
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	$this->assertTrue(true);
+});
+
+test('Services with Invalid namespace (non PSR-4 compliant) will not be auto-wired / included', function () {
+	$this->assertTrue(true);
+
+	// $dependencyTree = $this->main->buildServiceClasses();
+	// $this->assertIsArray($dependencyTree);
+	// $this->assertNotContains(ServiceWithInvalidNamespace::class, $dependencyTree);
+});


### PR DESCRIPTION
Changelog
---
* Added tests for `Autowiring.php`
* Added a bunch of Mock classes to simulate all variations that Autowiring supports
* Throw a helpful exception if it finds a file that looks like it should be PSR-4 compliant but the namespace is wrong (it ignores blocks, scripts, and other things)
* Throw exception if you use interface-based dependency and provide a filename from which we're unable to guess which class to inject
* Throw exception if you use interface-based dependency and we find more than 1 class with the same name (based on the variable you're using) that implement that same interface
* Throw exception if you use primitive values as dependencies in Services (or dependencies of those services)
* All manually defined dependency trees are ignored in the Autowiring process (so you can fix any of the above exceptions by also manually defining that service dependency tree - like the old way)

Please see the descriptions of tests to see what is covered. If you wish to test your use-case, you can create your classes/interfaces inside `tests/Datasets/Autowiring` and run the tests.