### PR TITLE
Fix correct boolean handling when outputting css variables

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -464,6 +464,11 @@ class Components
 			// Constant for attributes set value (in db or default).
 			$attributeValue = $attributes[$variableName] ?? [];
 
+			// Make sure this works correctly for attributes which are toggles (booleans).
+			if (is_bool($attributeValue)) {
+				$attributeValue = $attributeValue ? 'true' : 'false';
+			}
+
 			// If type default or value.
 			if (!self::arrayIsList($variableValue)) {
 				$variableValue = $variableValue[$attributeValue] ?? [];

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -661,6 +661,26 @@ test('Asserts that outputCssVariables returns empty globalManifest is not set.',
 	$this->assertStringNotContainsString('--variable-value-default: default;', $output);
 });
 
+test('Asserts that outputCssVariables returns variable for attributes which expect booleans.', function () {
+	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/variables');
+	$globalManifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks');
+
+	$attributes = [
+		'variableBool' => true,
+	];
+
+	$output = Components::outputCssVariables(
+		$attributes,
+		$manifest,
+		'uniqueString',
+		$globalManifest
+	);
+
+	$this->assertIsString($output);
+	$this->assertStringContainsString('<style>', $output);
+	$this->assertStringContainsString('--variable-created-by-boolean: any-value;', $output);
+});
+
 /**
  * Components::getUnique tests
  */

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -678,7 +678,22 @@ test('Asserts that outputCssVariables returns variable for attributes which expe
 
 	$this->assertIsString($output);
 	$this->assertStringContainsString('<style>', $output);
-	$this->assertStringContainsString('--variable-created-by-boolean: any-value;', $output);
+	$this->assertStringContainsString('--variable-created-by-boolean: value-when-true;', $output);
+
+	$attributes = [
+		'variableBool' => false,
+	];
+
+	$output = Components::outputCssVariables(
+		$attributes,
+		$manifest,
+		'uniqueString',
+		$globalManifest
+	);
+
+	$this->assertIsString($output);
+	$this->assertStringContainsString('<style>', $output);
+	$this->assertStringContainsString('--variable-created-by-boolean: value-when-false;', $output);
 });
 
 /**

--- a/tests/data/src/Blocks/components/variables/manifest.json
+++ b/tests/data/src/Blocks/components/variables/manifest.json
@@ -70,7 +70,14 @@
 			"true": [
 				{
 					"variable": {
-						"variable-created-by-boolean": "any-value"
+						"variable-created-by-boolean": "value-when-true"
+					}
+				}
+			],
+			"false": [
+				{
+					"variable": {
+						"variable-created-by-boolean": "value-when-false"
 					}
 				}
 			]

--- a/tests/data/src/Blocks/components/variables/manifest.json
+++ b/tests/data/src/Blocks/components/variables/manifest.json
@@ -17,6 +17,10 @@
 		"variableMissing": {
 			"type": "string"
 		},
+		"variableBool": {
+			"type": "boolean",
+			"default": true
+		},
 		"variablesWithDefault": {
 			"type": "string",
 			"default": "value"
@@ -62,6 +66,15 @@
 				}
 			}
 		],
+		"variableBool": {
+			"true": [
+				{
+					"variable": {
+						"variable-created-by-boolean": "any-value"
+					}
+				}
+			]
+		},
 
 		"variableValue": {
 			"value1": [


### PR DESCRIPTION
This fix ensures these kinds of variables are properly handled on front (in PHP).

```json
		"typographyUppercase": {
			"true": [
				{
					"variable": {
						"typography-uppercase": "uppercase"
					}
				}
			]
		},
```