### PR TITLE
Minor setup fixes

### DIFF
--- a/src/Blocks/BlocksCli.php
+++ b/src/Blocks/BlocksCli.php
@@ -42,7 +42,6 @@ class BlocksCli extends AbstractCli
 		'heading',
 		'image',
 		'layout-three-columns',
-		'link',
 		'lists',
 		'logo',
 		'menu',
@@ -63,7 +62,6 @@ class BlocksCli extends AbstractCli
 		'group',
 		'heading',
 		'image',
-		'link',
 		'lists',
 		'paragraph',
 	];

--- a/src/Blocks/BlocksExample.php
+++ b/src/Blocks/BlocksExample.php
@@ -78,12 +78,12 @@ class BlocksExample extends AbstractBlocks
 	/**
 	 * Set props helper to a proper values to be used in blocks/components.
 	 *
-	 * @param array  $attributes Object of attributes from block/component.
-	 * @param string $realName Old key to use, generally this is the name of the block/component.
-	 * @param string $newName New key to use to rename attributes.
-	 * @param bool   $isBlock Check if helper is used on block or component.
+	 * @param array<mixed> $attributes Object of attributes from block/component.
+	 * @param string       $realName Old key to use, generally this is the name of the block/component.
+	 * @param string       $newName New key to use to rename attributes.
+	 * @param bool         $isBlock Check if helper is used on block or component.
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public static function props(array $attributes, string $realName, string $newName = '', bool $isBlock = false): array
 	{
@@ -102,7 +102,7 @@ class BlocksExample extends AbstractBlocks
 			\esc_html__('Blocks', 'eightshift-libs'),
 			self::REUSABLE_BLOCKS_CAPABILITY,
 			'edit.php?post_type=wp_block',
-			'',
+			'', // @phpstan-ignore-line
 			'dashicons-editor-table',
 			4
 		);

--- a/src/CustomPostType/PostTypeCli.php
+++ b/src/CustomPostType/PostTypeCli.php
@@ -109,7 +109,7 @@ class PostTypeCli extends AbstractCli
 		$rewriteUrl = $this->prepareSlug($assocArgs['rewrite_url']);
 		$restEndpointSlug = $this->prepareSlug($assocArgs['rest_endpoint_slug']);
 		$capability = $assocArgs['capability'] ?? '';
-		$menuPosition = $assocArgs['menu_position'] ? (string)$assocArgs['menu_position'] : '';
+		$menuPosition = isset($assocArgs['menu_position']) ? (string)$assocArgs['menu_position'] : '';
 		$menuIcon = $assocArgs['menu_icon'] ?? '';
 
 		// Get full class name.

--- a/src/CustomPostType/PostTypeCli.php
+++ b/src/CustomPostType/PostTypeCli.php
@@ -109,7 +109,7 @@ class PostTypeCli extends AbstractCli
 		$rewriteUrl = $this->prepareSlug($assocArgs['rewrite_url']);
 		$restEndpointSlug = $this->prepareSlug($assocArgs['rest_endpoint_slug']);
 		$capability = $assocArgs['capability'] ?? '';
-		$menuPosition = isset($assocArgs['menu_position']) ? (string)$assocArgs['menu_position'] : '';
+		$menuPosition = (string) ($assocArgs['menu_position'] ?? '');
 		$menuIcon = $assocArgs['menu_icon'] ?? '';
 
 		// Get full class name.

--- a/src/CustomPostType/PostTypeExample.php
+++ b/src/CustomPostType/PostTypeExample.php
@@ -73,7 +73,7 @@ class PostTypeExample extends AbstractPostType
 	/**
 	 * Get the arguments that configure the Projects custom post type.
 	 *
-	 * @return array Array of arguments.
+	 * @return array<mixed> Array of arguments.
 	 */
 	protected function getPostTypeArguments(): array
 	{

--- a/src/CustomTaxonomy/TaxonomyExample.php
+++ b/src/CustomTaxonomy/TaxonomyExample.php
@@ -45,7 +45,7 @@ class TaxonomyExample extends AbstractTaxonomy
 	/**
 	 * Get the post type slug(s) that use the taxonomy.
 	 *
-	 * @return string|array Custom post type slug or an array of slugs.
+	 * @return string|array<string> Custom post type slug or an array of slugs.
 	 */
 	protected function getPostTypeSlug()
 	{
@@ -55,7 +55,7 @@ class TaxonomyExample extends AbstractTaxonomy
 	/**
 	 * Get the arguments that configure the custom taxonomy.
 	 *
-	 * @return array Array of arguments.
+	 * @return array<mixed> Array of arguments.
 	 */
 	protected function getTaxonomyArguments(): array
 	{


### PR DESCRIPTION
Changelog
---
* Fix phpstan errors that pop up after certain classes / blocks are generated
* Fix broken setup using latest libs (`release/3.1.0`) / frontend libs (`develop`) because of missing `link` component / block
* Fixed a warning during `wp boilerplate create_post_type` if `menu_position` parameter is not provided

#153, #152 (which this PR was supposed to fix) seem to already be fixed, the text domain is properly set, for example this is one I just created in my test theme (same thing for CPT):

```php
	/**
	 * Get the arguments that configure the custom taxonomy.
	 *
	 * @return array Array of arguments.
	 */
	protected function getTaxonomyArguments(): array
	{
		return [
			'hierarchical' => true,
			'label' => \esc_html__('Some Taxonomy', 'boilerplate301'),
			'show_ui' => true,
			'show_admin_column' => true,
			'show_in_nav_menus' => false,
			'public' => true,
			'show_in_rest' => true,
			'query_var' => true,
			'rest_base' => static::REST_API_ENDPOINT_SLUG,
			'rewrite' => [
				'hierarchical' => true,
				'with_front' => false,
			],
		];
	}
```