### PR TITLE
Kebab-case to camel case helper

### DIFF
--- a/src/Cli/CliHelpers.php
+++ b/src/Cli/CliHelpers.php
@@ -50,4 +50,17 @@ trait CliHelpers
 		$output = str_replace('_', '-', $output);
 		return str_replace('--', '-', $output);
 	}
+
+	/**
+	 * Convert string from kebab to camel case
+	 *
+	 * @param string $string    String to convert.
+	 * @param string $separator Separator to use for conversion.
+	 *
+	 * @return string
+	 */
+	public static function kebabToCamelCase(string $string, string $separator = '-'): string
+	{
+		return lcfirst(str_replace($separator, '', ucwords(mb_strtolower($string), $separator)));
+	}
 }

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -699,7 +699,7 @@ class Components
 	 */
 	public static function kebabToCamelCase(string $string, string $separator = '-'): string
 	{
-		return lcfirst(str_replace($separator, '', ucwords($string, $separator)));
+		return lcfirst(str_replace($separator, '', ucwords(mb_strtolower($string), $separator)));
 	}
 
 	/**

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -690,6 +690,19 @@ class Components
 	}
 
 	/**
+	 * Convert string from kebab to camel case
+	 *
+	 * @param string $string    String to convert.
+	 * @param string $separator Separator to use for conversion.
+	 *
+	 * @return string
+	 */
+	public static function kebabToCamelCase(string $string, string $separator = '-'): string
+	{
+		return lcfirst(str_replace($separator, '', ucwords($string, $separator)));
+	}
+
+	/**
 	 * Check if provided array is associative or sequential. Will return true if array is sequential.
 	 *
 	 * @param array $array Array to check.

--- a/tests/Cli/CliHelpersTest.php
+++ b/tests/Cli/CliHelpersTest.php
@@ -54,16 +54,30 @@ afterEach(function () {
 	Monkey\tearDown();
 });
 
-test('Return correct case', function($input, $output) {
+test('Return correct case - camelCase to kebab-case', function ($input, $output) {
 	$case = CliHelpers::camelCaseToKebabCase($input);
 
 	$this->assertIsString($case);
 	$this->assertSame($case, $output);
-})->with('caseCheckCorrect');
+})->with('camelToKebabCaseCheckCorrect');
 
-test('Return wrong case', function($input, $output) {
+test('Return wrong case - camelCase to kebab-case', function ($input, $output) {
 	$case = CliHelpers::camelCaseToKebabCase($input);
 
 	$this->assertIsString($case);
 	$this->assertNotSame($case, $output);
-})->with('caseCheckWrong');
+})->with('camelToKebabCaseCheckWrong');
+
+test('Return correct case - kebab-case to camelCase', function ($input, $output) {
+	$case = CliHelpers::kebabToCamelCase($input);
+
+	$this->assertIsString($case);
+	$this->assertSame($case, $output);
+})->with('kebabToCamelCaseCheckCorrect');
+
+test('Return wrong case - kebab-case to camelCase', function ($input, $output) {
+	$case = CliHelpers::kebabToCamelCase($input);
+
+	$this->assertIsString($case);
+	$this->assertNotSame($case, $output);
+})->with('kebabToCamelCaseCheckWrong');

--- a/tests/Datasets/Arguments.php
+++ b/tests/Datasets/Arguments.php
@@ -125,7 +125,7 @@ dataset('arrayIsListCorrect', [[
 	['0' => 'a', '1' => 'b', '2' => 'c'],
 ]]);
 
-dataset('caseCheckCorrect', [
+dataset('camelToKebabCaseCheckCorrect', [
 	['simpleTest', 'simple-test'],
 	['easy', 'easy'],
 	['HTML', 'html'],
@@ -148,7 +148,7 @@ dataset('caseCheckCorrect', [
 	['libC', 'lib-c'],
 ]);
 
-dataset('caseCheckWrong', [
+dataset('camelToKebabCaseCheckWrong', [
 	['simpleTest', 'simpleTest'],
 	['HTML', 'HTML'],
 	['simpleXML', 'simpleXML'],
@@ -167,4 +167,45 @@ dataset('caseCheckWrong', [
 	['aBaBaB', 'aBaBaB'],
 	['BaBaBa', 'BaBaBa'],
 	['libC', 'libC'],
+]);
+
+dataset('kebabToCamelCaseCheckCorrect', [
+	['simple-test', 'simpleTest'],
+	['easy', 'easy'],
+	['HTML', 'html'],
+	['simple-xml', 'simpleXml'],
+	['pdf-load', 'pdfLoad'],
+	['start-middle-last', 'startMiddleLast'],
+	['start-MIDDLE-last', 'startMiddleLast'],
+	['a-string', 'aString'],
+	['some4-numbers234', 'some4Numbers234'],
+	['test123-string', 'test123String'],
+	['test123 456', 'test123 456'],
+	['hello-world', 'helloWorld'],
+	['-hello-world-', 'helloWorld'],
+	['hello-world', 'helloWorld'],
+	['hello-world', 'helloWorld'],
+	['hello-world-foo', 'helloWorldFoo'],
+	['my-html-fi-le', 'myHtmlFiLe'],
+	['a-ba-ba-b', 'aBaBaB'],
+	['ba-ba-ba', 'baBaBa'],
+	['lib-c', 'libC'],
+]);
+
+dataset('kebabToCamelCaseCheckWrong', [
+	['simple-test', 'simpletest'],
+	['HTML', 'HTML'],
+	['simple-xml', 'simpleXML'],
+	['pdf-load', 'PDFLoad'],
+	['start-MIDDLE-last', 'startMIDDLElast'],
+	['a-string', 'AString'],
+	['some4-numbers234', 'Some4Numbers234'],
+	['test123-string', 'Test123String'],
+	['-hello-world-', 'HelloWorld'],
+	['hello-world-foo', 'HelloWorldFoo'],
+	['hello-world', 'HelloWorld'],
+	['my-html-fi-le', 'MyHtmlFiLe'],
+	['a-ba-ba-b', 'ABaBaB'],
+	['ba-ba-ba', 'BaBaBa'],
+	['lib-c', 'libc'],
 ]);

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -754,6 +754,33 @@ test('Asserts that kebabToCamelCase returns the wrong output', function () {
 });
 
 /**
+ * Components::kebabToCamelCase tests
+ */
+test('Asserts that kebabToCamelCase returns the correct output with a different separator', function () {
+	$output = Components::kebabToCamelCase('super_cool_test_string', '_');
+
+	$this->assertEquals('superCoolTestString', $output);
+});
+
+/**
+ * Components::kebabToCamelCase tests
+ */
+test('Asserts that kebabToCamelCase returns the correct output with numbers as a string', function () {
+	$output = Components::kebabToCamelCase('123-456-789');
+
+	$this->assertEquals('123456789', $output);
+});
+
+/**
+ * Components::kebabToCamelCase tests
+ */
+test('Asserts that kebabToCamelCase returns the correct output with a non-kebab-case string', function () {
+	$output = Components::kebabToCamelCase('non kebab string');
+
+	$this->assertEquals('non kebab string', $output);
+});
+
+/**
  * Components::props tests
  */
 test('Asserts props for heading block will return only heading attributes', function () {

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -739,6 +739,21 @@ test('Asserts that camelToKebabCase returns the wrong output', function () {
 });
 
 /**
+ * Components::kebabToCamelCase tests
+ */
+test('Asserts that kebabToCamelCase returns the correct output', function () {
+	$output = Components::kebabToCamelCase('super-cool-test-string');
+
+	$this->assertEquals('superCoolTestString', $output);
+});
+
+test('Asserts that kebabToCamelCase returns the wrong output', function () {
+	$output = Components::kebabToCamelCase('super-cool-test-string-goc');
+
+	$this->assertNotEquals('super_CoolTest-String goc', $output);
+});
+
+/**
  * Components::props tests
  */
 test('Asserts props for heading block will return only heading attributes', function () {


### PR DESCRIPTION
Adds a kebab-to-camelCase helper (and a corresponding test) for cases when you need camelCased things (e.g. using the `Blocks::props` with a component that has a `-` in the name).