### PR TITLE
Remove readme command from the setup theme script

### DIFF
--- a/src/Cli/CliInitTheme.php
+++ b/src/Cli/CliInitTheme.php
@@ -41,7 +41,6 @@ class CliInitTheme extends AbstractCli
 		EnqueueThemeCli::class,
 		MenuCli::class,
 		BlocksCli::class,
-		ReadmeCli::class,
 	];
 
 	/**


### PR DESCRIPTION
When using the npx command, the readme gets pulled from the boilerplate, and the setup script fails with readme already exists.