### PR TITLE
Fix plugin install for GitHub plugins

### DIFF
--- a/src/Cli/CliHelpers.php
+++ b/src/Cli/CliHelpers.php
@@ -63,4 +63,23 @@ trait CliHelpers
 	{
 		return lcfirst(str_replace($separator, '', ucwords(mb_strtolower($string), $separator)));
 	}
+
+	/**
+	 * Returns the name of the github plugin without slashes. For example converts "infinum/eightshift-forms" to "eightshift-forms"
+	 *
+	 * @param string $name Name of the github package.
+	 * @return string
+	 */
+	public static function getGithubPluginName(string $name): string
+	{
+
+		// If the plugin doesn't have a namespace, we're good, just return it.
+		if (strpos($name, '/') === false) {
+			return $name;
+		}
+
+		$splitName = explode('/', $name);
+
+		return $splitName[count($splitName) - 1];
+	}
 }

--- a/src/Setup/Setup.php
+++ b/src/Setup/Setup.php
@@ -87,8 +87,13 @@ function setup(string $projectRootPath, array $args = [], string $setupFile = 's
 				// Install github plugins.
 				if (!empty($pluginsGithub)) {
 					foreach ($pluginsGithub as $name => $version) {
-						WP_CLI::runcommand("plugin install https://github.com/{$name}/releases/download/{$version}/release.zip --force");
+						$shortName = CliHelpers::getGithubPluginName($name);
+						$filePath = getcwd() . "/{$shortName}.zip";
+						$releaseZip = file_get_contents("https://github.com/{$name}/releases/download/{$version}/release.zip");
+						file_put_contents($filePath, $releaseZip);
+						WP_CLI::runcommand("plugin install {$filePath} --force");
 						WP_CLI::log('--------------------------------------------------');
+						unlink($filePath);
 					}
 				} else {
 					WP_CLI::warning('No Github plugins are defined. Skipping.');

--- a/src/Setup/Setup.php
+++ b/src/Setup/Setup.php
@@ -89,8 +89,8 @@ function setup(string $projectRootPath, array $args = [], string $setupFile = 's
 					foreach ($pluginsGithub as $name => $version) {
 						$shortName = CliHelpers::getGithubPluginName($name);
 						$filePath = getcwd() . "/{$shortName}.zip";
-						$releaseZip = file_get_contents("https://github.com/{$name}/releases/download/{$version}/release.zip");
-						file_put_contents($filePath, $releaseZip);
+						$releaseZip = file_get_contents("https://github.com/{$name}/releases/download/{$version}/release.zip"); // phpcs:ignore WordPress.WP.AlternativeFunctions
+						file_put_contents($filePath, $releaseZip); // phpcs:ignore WordPress.WP.AlternativeFunctions
 						WP_CLI::runcommand("plugin install {$filePath} --force");
 						WP_CLI::log('--------------------------------------------------');
 						unlink($filePath);

--- a/src/Setup/setup.json
+++ b/src/Setup/setup.json
@@ -10,7 +10,7 @@
       "contact-form-7": "5.1.8"
     },
     "github": {
-      "infinum/eightshift-gdpr": "1.0.1"
+      "infinum/eightshift-forms": "0.2.2"
     }
   },
   "themes": {

--- a/tests/Cli/CliHelpersTest.php
+++ b/tests/Cli/CliHelpersTest.php
@@ -81,3 +81,18 @@ test('Return wrong case - kebab-case to camelCase', function ($input, $output) {
 	$this->assertIsString($case);
 	$this->assertNotSame($case, $output);
 })->with('kebabToCamelCaseCheckWrong');
+
+test('Return correct name - getGithubPluginName', function ($input, $output) {
+	$case = CliHelpers::getGithubPluginName($input);
+
+	$this->assertIsString($case);
+	$this->assertSame($case, $output);
+})->with('getGithubPluginNameCorrect');
+
+test('Return wrong name - getGithubPluginName', function ($input, $output) {
+	$case = CliHelpers::getGithubPluginName($input);
+
+	$this->assertIsString($case);
+	$this->assertNotSame($case, $output);
+})->with('getGithubPluginNameWrong');
+

--- a/tests/Datasets/Arguments.php
+++ b/tests/Datasets/Arguments.php
@@ -209,3 +209,17 @@ dataset('kebabToCamelCaseCheckWrong', [
 	['ba-ba-ba', 'BaBaBa'],
 	['lib-c', 'libc'],
 ]);
+
+dataset('getGithubPluginNameCorrect', [
+	['some-plugin-name', 'some-plugin-name'],
+	['infinum/some-plugin-name', 'some-plugin-name'],
+	['simple', 'simple'],
+	['infinum/simple', 'simple'],
+	['infinum/something-else/simple', 'simple'],
+]);
+
+dataset('getGithubPluginNameWrong', [
+	['infinum/some-plugin-name', 'infinum/some-plugin-name'],
+	['infinum/something-else/simple', 'infinum/something-else'],
+	['infinum/something-else/simple', 'something-else/simple'],
+]);

--- a/tests/Setup/UpdateCliTest.php
+++ b/tests/Setup/UpdateCliTest.php
@@ -63,7 +63,7 @@ test('Update CLI command will correctly run the update with defaults', function 
 		$exceptionOccurred = true;
 	}
 
-	$this->assertFalse($exceptionOccurred);
+	$this->assertFalse($exceptionOccurred, ! empty($th) ? $th->getMessage() : 'Unknown error');
 });
 
 test('Update CLI command will correctly throw an exception if setup.json does not exist or has the wrong filename', function () {


### PR DESCRIPTION
Because of the way `wp plugin install` works with remote zips (it appends a random hash at the end of the file after unzipping) and you can't change the name of the archive, we need to do it like this:

1. Download `release.zip` from a repo and save it as the correct plugin name (for example: `eightshift-forms.zip`)
2. Install from the local file and delete afterwards