### PR TITLE
Output attributes which can be set as 0

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -781,7 +781,7 @@ class Components
 			// If value contains magic variable swap that variable with original attribute value.
 			if (strpos($variableValue, '%value%') !== false) {
 				// Bailout if magic variable is empty.
-				if (empty($attributeValue)) {
+				if (empty($attributeValue) && $attributeValue !== 0) {
 					continue;
 				}
 

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -780,11 +780,6 @@ class Components
 
 			// If value contains magic variable swap that variable with original attribute value.
 			if (strpos($variableValue, '%value%') !== false) {
-				// Bailout if magic variable is empty.
-				if (empty($attributeValue) && $attributeValue !== 0) {
-					continue;
-				}
-
 				$variableValue = str_replace('%value%', $attributeValue, $variableValue);
 			}
 


### PR DESCRIPTION
This fixes a bug where some attributes (like wrapper spacing attributes) won't be outputted as CSS variables if they're set to 0.

This is especially problematic if you have something like the following structure in editor:

```
group         // wrapper-spacing-top == 20
    heading
    paragraph // wrapper-spacing-top == 0
```

Because `paragraph` will inherit the `wrapper-spacing-top: 20` css variable from group block.

