### PR TITLE
Fix tests

### DIFF
--- a/src/Blocks/AbstractBlocks.php
+++ b/src/Blocks/AbstractBlocks.php
@@ -340,7 +340,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	/**
 	 * Get all components in the components folder.
 	 *
-	 * @throws InvalidBlock Throws error thera are no components in the project.
+	 * @throws InvalidBlock Throws error if there are no components in the project.
 	 *
 	 * @return array
 	 */
@@ -455,14 +455,14 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 			],
 			$this->getSettings()['attributes'] ?? [],
 			$this->blocks['wrapper']['attributes'],
-			$this->prepareComponentAttributes($blockDetails),
+			$this->prepareComponentAttributes($blockDetails)
 		);
 	}
 
 	/**
 	 * Iterate over attributes or example attributes array in block/component manifest and append the parent prefixes.
 	 *
-	 * @param array $manifest Array of component/block manifest to get data from.
+	 * @param array  $manifest Array of component/block manifest to get data from.
 	 * @param string $newName New renamed component name.
 	 * @param string $realName Original real component name.
 	 * @param string $parent Parent component key with stacked parent component names for the final output.
@@ -505,7 +505,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 * Iterate over component array in block manifest and check if the component exists in the project.
 	 * If components contains more component this function will run recursively.
 	 *
-	 * @param array $manifest Array of component/block manifest to get the data from.
+	 * @param array  $manifest Array of component/block manifest to get the data from.
 	 * @param string $parent Parent component key with stacked parent component names for the final output.
 	 *
 	 * @throws InvalidBlock If the component is wrong, or the name is wrong or it doesn't exist.
@@ -544,7 +544,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 			// Populate the output recursively.
 			$output = array_merge(
 				$output,
-				$outputAttributes,
+				$outputAttributes
 			);
 		}
 

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -790,8 +790,8 @@ class Components
 	/**
 	 * Internal helper to loop CSS Variables from array.
 	 *
-	 * @param array $variables Array of variables of CSS variables.
-	 * @param mixed $attributeValue Original attribute value used in magic variable.
+	 * @param array  $variables Array of variables of CSS variables.
+	 * @param string $attributeValue Original attribute value used in magic variable.
 	 *
 	 * @return array
 	 */
@@ -880,7 +880,7 @@ class Components
 	/**
 	 * Output only attributes that are used in the component and remove everything else.
 	 *
-	 * @param array $attributes Attributes from the block/component.
+	 * @param array  $attributes Attributes from the block/component.
 	 * @param string $newName *New* key to use to rename attributes.
 	 *
 	 * @return array

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -312,8 +312,8 @@ class Components
 	 * Check if the attribute's key has a prefix and output the correct attribute name.
 	 *
 	 * @param string $key Key to check.
-	 * @param array $attributes Array of attributes.
-	 * @param array $manifest Components/blocks manifest.json.
+	 * @param array  $attributes Array of attributes.
+	 * @param array  $manifest Components/blocks manifest.json.
 	 *
 	 * @return string
 	 */
@@ -542,7 +542,7 @@ class Components
 	{
 		foreach ($variables as $variableName => $variableValue) {
 			// Constant for attributes set value (in db or default).
-			$attributeValue = $attributes[self::getAttrKey($variableName, $attributes, $manifest)] ?? [];
+			$attributeValue = $attributes[self::getAttrKey($variableName, $attributes, $manifest)] ?? '';
 
 			// Make sure this works correctly for attributes which are toggles (booleans).
 			if (is_bool($attributeValue)) {
@@ -572,7 +572,7 @@ class Components
 				// Iterate each data array to find the correct breakpoint.
 				foreach ($data as $index => $item) {
 					// Check if breakpoint and type match.
-					if ($item['name'] === $breakpoint && $item['type'] === $type) {
+					if ($item['name'] === $breakpoint && $item['type'] === $type && !empty($attributeValue)) {
 						// Merge data variables with the new variables array.
 						$data[$index]['variable'] = array_merge($item['variable'], self::variablesInner($variable, $attributeValue));
 					}
@@ -795,7 +795,7 @@ class Components
 	 *
 	 * @return array
 	 */
-	public static function variablesInner(array $variables, $attributeValue): array
+	public static function variablesInner(array $variables, string $attributeValue): array
 	{
 		$output = [];
 

--- a/tests/BlockPatterns/BlockPatternCliTest.php
+++ b/tests/BlockPatterns/BlockPatternCliTest.php
@@ -105,5 +105,5 @@ test('Block Pattern documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates a block pattern.', $documentation[$key]);
+	$this->assertSame('Generates a block pattern.', $documentation[$key]);
 });

--- a/tests/BlockPatterns/BlockPatternExampleTest.php
+++ b/tests/BlockPatterns/BlockPatternExampleTest.php
@@ -35,7 +35,7 @@ test('Register block pattern method will be called', function() {
 
 	$this->example->registerBlockPattern();
 
-	$this->assertEquals(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/Blocks/BlockCliTest.php
+++ b/tests/Blocks/BlockCliTest.php
@@ -75,7 +75,7 @@ test('Block CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Copy Block from library to your project.', $documentation[$key]);
+	$this->assertSame('Copy Block from library to your project.', $documentation[$key]);
 });
 
 test('Block CLI command will fail if block doesn\'t exist', function () {

--- a/tests/Blocks/BlockComponentCliTest.php
+++ b/tests/Blocks/BlockComponentCliTest.php
@@ -73,7 +73,7 @@ test('Component CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Copy Component from library to your project.', $documentation[$key]);
+	$this->assertSame('Copy Component from library to your project.', $documentation[$key]);
 });
 
 test('Component CLI command will fail if Component doesn\'t exist', function () {

--- a/tests/Blocks/BlockVariationCliTest.php
+++ b/tests/Blocks/BlockVariationCliTest.php
@@ -73,7 +73,7 @@ test('Variation CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Copy Variation from library to your project.', $documentation[$key]);
+	$this->assertSame('Copy Variation from library to your project.', $documentation[$key]);
 });
 
 test('Variation CLI command will fail if Variation doesn\'t exist', function () {

--- a/tests/Blocks/BlockWrapperCliTest.php
+++ b/tests/Blocks/BlockWrapperCliTest.php
@@ -73,7 +73,7 @@ test('Wrapper CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayNotHasKey('synopsis', $documentation);
-	$this->assertEquals('Copy Wrapper from library to your project.', $documentation[$key]);
+	$this->assertSame('Copy Wrapper from library to your project.', $documentation[$key]);
 });
 
 test('Wrapper CLI command will fail if Wrapper doesn\'t exist', function () {

--- a/tests/Blocks/BlocksCliTest.php
+++ b/tests/Blocks/BlocksCliTest.php
@@ -72,5 +72,5 @@ test('Blocks CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayNotHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates Blocks class.', $documentation[$key]);
+	$this->assertSame('Generates Blocks class.', $documentation[$key]);
 });

--- a/tests/Blocks/BlocksExampleTest.php
+++ b/tests/Blocks/BlocksExampleTest.php
@@ -79,11 +79,11 @@ test('Asserts that getAllBlocksList first argument is boolean and return the pro
 
 	$blocks = $this->blocksExample->getAllBlocksList(true, $post);
 
-	$this->assertEquals(true, $blocks);
+	$this->assertSame(true, $blocks);
 
 	$blocks = $this->blocksExample->getAllBlocksList(false, $post);
 
-	$this->assertEquals(false, $blocks, "Return value is not false.");
+	$this->assertSame(false, $blocks, "Return value is not false.");
 });
 
 test('Asserts that getAllBlocksList will return only projects blocks.', function () {
@@ -132,7 +132,7 @@ test('Asserts that getBlocksDataFullRawItem will return all blocks details if ke
 
 	$this->assertIsArray($items);
 	$this->assertContains('blockName', array_keys($items[0]), "Items array doesn't contain blockName key");
-	$this->assertEquals('button', $items[0]['blockName'], "Items array doesn't contain blockName key with value button");
+	$this->assertSame('button', $items[0]['blockName'], "Items array doesn't contain blockName key with value button");
 	$this->assertNotContains('componentName', array_keys($items[0]), "Items array does contain componentName key");
 	$this->assertNotEquals('test', $items[0]['blockName'], "Items array contain blockName key with value test");
 });

--- a/tests/Blocks/BlocksExampleTest.php
+++ b/tests/Blocks/BlocksExampleTest.php
@@ -116,9 +116,7 @@ test('Asserts that getBlocksDataFullRawItem will return full details for blocks 
 
 	$this->assertIsArray($items);
 	$this->assertNotContains('button', array_keys($items), "Items array contains button key");
-	$this->assertContains('dependency', array_keys($items), "Items array doesn't contain dependency key");
 	$this->assertContains('blocks', array_keys($items), "Items array doesn't contain blocks key");
-	$this->assertContains('components', array_keys($items), "Items array doesn't contain components key");
 	$this->assertContains('wrapper', array_keys($items), "Items array doesn't contain wrapper key");
 	$this->assertContains('settings', array_keys($items), "Items array doesn't contain settings key");
 });
@@ -137,22 +135,6 @@ test('Asserts that getBlocksDataFullRawItem will return all blocks details if ke
 	$this->assertEquals('button', $items[0]['blockName'], "Items array doesn't contain blockName key with value button");
 	$this->assertNotContains('componentName', array_keys($items[0]), "Items array does contain componentName key");
 	$this->assertNotEquals('test', $items[0]['blockName'], "Items array contain blockName key with value test");
-});
-
-test('Asserts that getBlocksDataFullRawItem will return all components details if key is components.', function () {
-	$this->config
-		->shouldReceive('getProjectPath')
-		->andReturn('tests/data');
-
-	$this->blocksExample->getBlocksDataFullRaw();
-
-	$items = $this->blocksExample->getBlocksDataFullRawItem('components');
-
-	$this->assertIsArray($items);
-	$this->assertContains('componentName', array_keys($items[0]), "Items array doesn't contain componentName key");
-	$this->assertEquals('button', $items[0]['componentName'], "Items array doesn't contain componentName key with value button");
-	$this->assertNotContains('blockName', array_keys($items[0]), "Items array does contain blockName key");
-	$this->assertNotEquals('test', $items[0]['componentName'], "Items array contain componentName key with value test");
 });
 
 test('Asserts that getBlocksDataFullRawItem will return empty array if code is run using WP_CLI.', function () {

--- a/tests/Build/BuildCliTest.php
+++ b/tests/Build/BuildCliTest.php
@@ -65,7 +65,7 @@ test('Build CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Initialize Command for building your project with one command, generally used on CI deployments.', $documentation[$key]);
+	$this->assertSame('Initialize Command for building your project with one command, generally used on CI deployments.', $documentation[$key]);
 });
 
 test('getDevelopArgs correctly returns arguments', function() {

--- a/tests/CiExclude/CiExcludeCliTest.php
+++ b/tests/CiExclude/CiExcludeCliTest.php
@@ -88,5 +88,5 @@ test('CiExclude CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Initialize Command for building your projects CI exclude file.', $documentation[$key]);
+	$this->assertSame('Initialize Command for building your projects CI exclude file.', $documentation[$key]);
 });

--- a/tests/Cli/CliInitProjectTest.php
+++ b/tests/Cli/CliInitProjectTest.php
@@ -70,7 +70,7 @@ test('CliInitProject CLI documentation is correct', function () {
 
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
-	$this->assertEquals('Generates initial setup for WordPress theme project with all files to run a client project, for example: gitignore file for the full WordPress project, continuous integration exclude files, etc.', $documentation[$key]);
+	$this->assertSame('Generates initial setup for WordPress theme project with all files to run a client project, for example: gitignore file for the full WordPress project, continuous integration exclude files, etc.', $documentation[$key]);
 });
 
 

--- a/tests/Cli/CliInitThemeTest.php
+++ b/tests/Cli/CliInitThemeTest.php
@@ -64,7 +64,7 @@ test('CliInitTheme CLI documentation is correct', function () {
 
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
-	$this->assertEquals('Generates initial setup for WordPress theme project.', $documentation[$key]);
+	$this->assertSame('Generates initial setup for WordPress theme project.', $documentation[$key]);
 });
 
 

--- a/tests/Cli/CliResetTest.php
+++ b/tests/Cli/CliResetTest.php
@@ -56,5 +56,5 @@ test('CliReset CLI documentation is correct', function () {
 
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
-	$this->assertEquals('DEVELOP - Used to reset and remove all outputs.', $documentation[$key]);
+	$this->assertSame('DEVELOP - Used to reset and remove all outputs.', $documentation[$key]);
 });

--- a/tests/Cli/CliRunAllTest.php
+++ b/tests/Cli/CliRunAllTest.php
@@ -62,5 +62,5 @@ test('CliRunAll CLI documentation is correct', function () {
 
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
-	$this->assertEquals('DEVELOP - Used to run all commands.', $documentation[$key]);
+	$this->assertSame('DEVELOP - Used to run all commands.', $documentation[$key]);
 });

--- a/tests/Cli/CliShowAllTest.php
+++ b/tests/Cli/CliShowAllTest.php
@@ -68,5 +68,5 @@ test('CliShowAll CLI documentation is correct', function () {
 
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
-	$this->assertEquals('DEVELOP - Used to show all commands.', $documentation[$key]);
+	$this->assertSame('DEVELOP - Used to show all commands.', $documentation[$key]);
 });

--- a/tests/Config/ConfigCliTest.php
+++ b/tests/Config/ConfigCliTest.php
@@ -62,20 +62,20 @@ test('Custom acf meta CLI documentation is correct', function () {
 	$this->assertArrayHasKey($descKey, $documentation);
 	$this->assertArrayHasKey($synopsisKey, $documentation);
 	$this->assertIsArray($documentation[$synopsisKey]);
-	$this->assertEquals('Generates project config class.', $documentation[$descKey]);
+	$this->assertSame('Generates project config class.', $documentation[$descKey]);
 
-	$this->assertEquals('assoc', $documentation[$synopsisKey][0]['type']);
-	$this->assertEquals('name', $documentation[$synopsisKey][0]['name']);
-	$this->assertEquals('Define project name.', $documentation[$synopsisKey][0]['description']);
-	$this->assertEquals(true, $documentation[$synopsisKey][0]['optional']);
+	$this->assertSame('assoc', $documentation[$synopsisKey][0]['type']);
+	$this->assertSame('name', $documentation[$synopsisKey][0]['name']);
+	$this->assertSame('Define project name.', $documentation[$synopsisKey][0]['description']);
+	$this->assertSame(true, $documentation[$synopsisKey][0]['optional']);
 
-	$this->assertEquals('assoc', $documentation[$synopsisKey][1]['type']);
-	$this->assertEquals('version', $documentation[$synopsisKey][1]['name']);
-	$this->assertEquals('Define project version.', $documentation[$synopsisKey][1]['description']);
-	$this->assertEquals(true, $documentation[$synopsisKey][1]['optional']);
+	$this->assertSame('assoc', $documentation[$synopsisKey][1]['type']);
+	$this->assertSame('version', $documentation[$synopsisKey][1]['name']);
+	$this->assertSame('Define project version.', $documentation[$synopsisKey][1]['description']);
+	$this->assertSame(true, $documentation[$synopsisKey][1]['optional']);
 
-	$this->assertEquals('assoc', $documentation[$synopsisKey][2]['type']);
-	$this->assertEquals('routes_version', $documentation[$synopsisKey][2]['name']);
-	$this->assertEquals('Define project REST version.', $documentation[$synopsisKey][2]['description']);
-	$this->assertEquals(true, $documentation[$synopsisKey][2]['optional']);
+	$this->assertSame('assoc', $documentation[$synopsisKey][2]['type']);
+	$this->assertSame('routes_version', $documentation[$synopsisKey][2]['name']);
+	$this->assertSame('Define project REST version.', $documentation[$synopsisKey][2]['description']);
+	$this->assertSame(true, $documentation[$synopsisKey][2]['optional']);
 });

--- a/tests/Config/ConfigExampleTest.php
+++ b/tests/Config/ConfigExampleTest.php
@@ -31,7 +31,7 @@ test('Is project version defined and a string', function () {
 test('Is project REST namespace defined, a string and same as project name', function () {
 	$this->assertNotEmpty($this->example::getProjectRoutesNamespace());
 	$this->assertIsString(gettype($this->example::getProjectRoutesNamespace()));
-	$this->assertEquals($this->example::getProjectName(), $this->example::getProjectRoutesNamespace());
+	$this->assertSame($this->example::getProjectName(), $this->example::getProjectRoutesNamespace());
 });
 
 test('Is project REST route version defined and a string', function () {

--- a/tests/ConfigProject/ConfigProjectCliTest.php
+++ b/tests/ConfigProject/ConfigProjectCliTest.php
@@ -77,5 +77,5 @@ test('ConfigProject CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates projects config file to control global variables used in WordPress project.', $documentation[$key]);
+	$this->assertSame('Generates projects config file to control global variables used in WordPress project.', $documentation[$key]);
 });

--- a/tests/CustomMeta/CustomMetaCliTest.php
+++ b/tests/CustomMeta/CustomMetaCliTest.php
@@ -58,9 +58,9 @@ test('Custom acf meta CLI documentation is correct', function () {
 	$this->assertArrayHasKey($descKey, $documentation);
 	$this->assertArrayHasKey($synopsisKey, $documentation);
 	$this->assertIsArray($documentation[$synopsisKey]);
-	$this->assertEquals('Generates custom ACF meta fields class file.', $documentation[$descKey]);
-	$this->assertEquals('assoc', $documentation[$synopsisKey][0]['type']);
-	$this->assertEquals('name', $documentation[$synopsisKey][0]['name']);
-	$this->assertEquals('The name of the custom meta slug. Example: title.', $documentation[$synopsisKey][0]['description']);
-	$this->assertEquals(false, $documentation[$synopsisKey][0]['optional']);
+	$this->assertSame('Generates custom ACF meta fields class file.', $documentation[$descKey]);
+	$this->assertSame('assoc', $documentation[$synopsisKey][0]['type']);
+	$this->assertSame('name', $documentation[$synopsisKey][0]['name']);
+	$this->assertSame('The name of the custom meta slug. Example: title.', $documentation[$synopsisKey][0]['description']);
+	$this->assertSame(false, $documentation[$synopsisKey][0]['optional']);
 });

--- a/tests/CustomPostType/CustomPostTypeCliTest.php
+++ b/tests/CustomPostType/CustomPostTypeCliTest.php
@@ -84,5 +84,5 @@ test('Custom post type CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates custom post type class file.', $documentation[$key]);
+	$this->assertSame('Generates custom post type class file.', $documentation[$key]);
 });

--- a/tests/CustomPostType/CustomPostTypeExampleTest.php
+++ b/tests/CustomPostType/CustomPostTypeExampleTest.php
@@ -41,7 +41,7 @@ test('Register post type method will be called', function() {
 
 	$this->example->postTypeRegisterCallback();
 
-	$this->assertEquals(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/CustomTaxonomy/TaxonomyCliTest.php
+++ b/tests/CustomTaxonomy/TaxonomyCliTest.php
@@ -64,25 +64,25 @@ test('Custom acf meta CLI documentation is correct', function () {
 	$this->assertArrayHasKey($descKey, $documentation);
 	$this->assertArrayHasKey($synopsisKey, $documentation);
 	$this->assertIsArray($documentation[$synopsisKey]);
-	$this->assertEquals('Generates custom taxonomy class file.', $documentation[$descKey]);
+	$this->assertSame('Generates custom taxonomy class file.', $documentation[$descKey]);
 
-	$this->assertEquals('assoc', $documentation[$synopsisKey][0]['type']);
-	$this->assertEquals('label', $documentation[$synopsisKey][0]['name']);
-	$this->assertEquals('The label of the custom taxonomy to show in WP admin.', $documentation[$synopsisKey][0]['description']);
-	$this->assertEquals(false, $documentation[$synopsisKey][0]['optional']);
+	$this->assertSame('assoc', $documentation[$synopsisKey][0]['type']);
+	$this->assertSame('label', $documentation[$synopsisKey][0]['name']);
+	$this->assertSame('The label of the custom taxonomy to show in WP admin.', $documentation[$synopsisKey][0]['description']);
+	$this->assertSame(false, $documentation[$synopsisKey][0]['optional']);
 
-	$this->assertEquals('assoc', $documentation[$synopsisKey][1]['type']);
-	$this->assertEquals('slug', $documentation[$synopsisKey][1]['name']);
-	$this->assertEquals('The name of the custom taxonomy slug. Example: location.', $documentation[$synopsisKey][1]['description']);
-	$this->assertEquals(false, $documentation[$synopsisKey][1]['optional']);
+	$this->assertSame('assoc', $documentation[$synopsisKey][1]['type']);
+	$this->assertSame('slug', $documentation[$synopsisKey][1]['name']);
+	$this->assertSame('The name of the custom taxonomy slug. Example: location.', $documentation[$synopsisKey][1]['description']);
+	$this->assertSame(false, $documentation[$synopsisKey][1]['optional']);
 
-	$this->assertEquals('assoc', $documentation[$synopsisKey][2]['type']);
-	$this->assertEquals('rest_endpoint_slug', $documentation[$synopsisKey][2]['name']);
-	$this->assertEquals('The name of the custom taxonomy REST-API endpoint slug. Example: locations.', $documentation[$synopsisKey][2]['description']);
-	$this->assertEquals(false, $documentation[$synopsisKey][2]['optional']);
+	$this->assertSame('assoc', $documentation[$synopsisKey][2]['type']);
+	$this->assertSame('rest_endpoint_slug', $documentation[$synopsisKey][2]['name']);
+	$this->assertSame('The name of the custom taxonomy REST-API endpoint slug. Example: locations.', $documentation[$synopsisKey][2]['description']);
+	$this->assertSame(false, $documentation[$synopsisKey][2]['optional']);
 
-	$this->assertEquals('assoc', $documentation[$synopsisKey][3]['type']);
-	$this->assertEquals('post_type_slug', $documentation[$synopsisKey][3]['name']);
-	$this->assertEquals('The position where to assign the new custom taxonomy. Example: post.', $documentation[$synopsisKey][3]['description']);
-	$this->assertEquals(false, $documentation[$synopsisKey][3]['optional']);
+	$this->assertSame('assoc', $documentation[$synopsisKey][3]['type']);
+	$this->assertSame('post_type_slug', $documentation[$synopsisKey][3]['name']);
+	$this->assertSame('The position where to assign the new custom taxonomy. Example: post.', $documentation[$synopsisKey][3]['description']);
+	$this->assertSame(false, $documentation[$synopsisKey][3]['optional']);
 });

--- a/tests/CustomTaxonomy/TaxonomyExampleTest.php
+++ b/tests/CustomTaxonomy/TaxonomyExampleTest.php
@@ -23,7 +23,7 @@ test('if taxonomy actions are registered', function () {
 	$this->example->register();
 
 	$this->assertTrue(\method_exists($this->example, 'register'));
-	$this->assertEquals(10, has_action('init', [$this->example, 'taxonomyRegisterCallback']));
+	$this->assertSame(10, has_action('init', [$this->example, 'taxonomyRegisterCallback']));
 });
 
 test('if taxonomy is registered', function () {
@@ -32,7 +32,7 @@ test('if taxonomy is registered', function () {
 
 	$this->example->taxonomyRegisterCallback();
 
-	$this->assertEquals(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/Enqueue/Admin/EnqueueAdminCliTest.php
+++ b/tests/Enqueue/Admin/EnqueueAdminCliTest.php
@@ -53,5 +53,5 @@ test('Custom Enqueue Admin CLI documentation is correct', function () {
 
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($descKey, $documentation);
-	$this->assertEquals('Generates Enqueue Admin class.', $documentation[$descKey]);
+	$this->assertSame('Generates Enqueue Admin class.', $documentation[$descKey]);
 });

--- a/tests/Enqueue/Blocks/EnqueueBlockCliTest.php
+++ b/tests/Enqueue/Blocks/EnqueueBlockCliTest.php
@@ -90,5 +90,5 @@ test('Custom Enqueue Blocks CLI documentation is correct', function () {
 
 	$this->assertIsArray($documentation, 'Returned value must be an array.');
 	$this->assertArrayHasKey($descKey, $documentation, 'Array doesn\'t have a required key.');
-	$this->assertEquals('Generates Enqueue Blocks class.', $documentation[$descKey], 'Returned string doesn\'t match');
+	$this->assertSame('Generates Enqueue Blocks class.', $documentation[$descKey], 'Returned string doesn\'t match');
 });

--- a/tests/Enqueue/Theme/EnqueueThemeCliTest.php
+++ b/tests/Enqueue/Theme/EnqueueThemeCliTest.php
@@ -53,5 +53,5 @@ test('Custom Enqueue Theme CLI documentation is correct', function () {
 
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($descKey, $documentation);
-	$this->assertEquals('Generates Enqueue Theme class.', $documentation[$descKey]);
+	$this->assertSame('Generates Enqueue Theme class.', $documentation[$descKey]);
 });

--- a/tests/GitIgnore/GitIgnoreCliTest.php
+++ b/tests/GitIgnore/GitIgnoreCliTest.php
@@ -74,5 +74,5 @@ test('GitIgnore CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Initialize Command for building your projects gitignore.', $documentation[$key]);
+	$this->assertSame('Initialize Command for building your projects gitignore.', $documentation[$key]);
 });

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -149,14 +149,6 @@ test('Asserts that using responsive selectors will work', function () {
 	);
 });
 
-test('Asserts that providing wrong type to responsiveSelectors will throw an exception', function () {
-	Components::responsiveSelectors('', false, true, '');
-})->throws(\TypeError::class);
-
-test('Asserts that providing wrong number of arguments to responsiveSelectors will throw an exception', function () {
-	Components::responsiveSelectors([], 'true');
-})->throws(\ArgumentCountError::class);
-
 /**
  * Components::checkAttr tests
  */

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -1039,3 +1039,63 @@ test('Asserts props for heading component will return only typography attributes
 	$this->assertContains('typographyContent', array_keys($output), "Output array doesn't contain typographyContent attribute key.");
 	$this->assertNotContains('headingSize', array_keys($output), "Output array does contain headingSize attribute key.");
 });
+
+test('Asserts props will correctly build the prefix', function () {
+	$headingBlock = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/custom/heading');
+	$headingComponent = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/heading');
+	$typographyComponent = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/typography');
+
+	$attributes = array_merge(
+		$headingBlock['attributes'],
+		$headingComponent['attributes'],
+		$typographyComponent['attributes']
+	);
+
+	mock('alias:EightshiftBoilerplate\Config\Config')
+		->shouldReceive('getProjectPath')
+		->andReturn('tests/data');
+
+	$this->blocksExample = new BlocksExample();
+	$this->blocksExample->getBlocksDataFullRaw();
+	$output = Components::props($attributes, 'heading');
+
+	$this->assertIsArray($output);
+	$this->assertContains('prefix', array_keys($output), "Output array doesn't contain prefix attribute key.");
+	$this->assertEquals('heading', $output['prefix']);
+
+	// Next level
+	$output = Components::props($output, 'typography');
+	$this->assertIsArray($output);
+	$this->assertContains('prefix', array_keys($output), "Output array doesn't contain prefix attribute key.");
+	$this->assertEquals('headingTypography', $output['prefix']);
+});
+
+test('Asserts props will correctly leave only the the needed attributes', function () {
+	$attributes = [
+		'componentName' => 'mock-card',
+		'mockCardHeadingTypographyContent' => 'mock heading content',
+		'mockCardParagraphTypographyContent' => 'mock paragraph content',
+	];
+
+	mock('alias:EightshiftBoilerplate\Config\Config')
+		->shouldReceive('getProjectPath')
+		->andReturn('tests/data');
+
+	$this->blocksExample = new BlocksExample();
+	$this->blocksExample->getBlocksDataFullRaw();
+	$output = Components::props($attributes, 'mock-card');
+
+	$this->assertIsArray($output);
+	$this->assertContains('mockCardHeadingTypographyContent', array_keys($output), "Output array doesn't contain required attribute.");
+	$this->assertContains('mockCardParagraphTypographyContent', array_keys($output), "Output array doesn't contain required attribute.");
+
+	// Now let's pass these to mock heading
+	$output = Components::props($output, 'heading');
+	$this->assertIsArray($output);
+	$this->assertContains('mockCardHeadingTypographyContent', array_keys($output), "Output array doesn't contain required attribute.");
+	$this->assertNotContains('mockCardParagraphTypographyContent', array_keys($output), "Output array contains attribute that should have been purged.");
+
+	$output = Components::props($output, 'typography');
+	$this->assertIsArray($output);
+	$this->assertContains('mockCardHeadingTypographyContent', array_keys($output), "Output array doesn't contain required attribute.");
+});

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -132,17 +132,17 @@ test('Asserts that using responsive selectors will work', function () {
 	$this->assertIsString($withoutModifier, 'Result should be a string');
 	$this->assertIsString($withEmptyString, 'Result should be a string');
 
-	$this->assertEquals(
+	$this->assertSame(
 		'column__width-mobile--12 column__width-tablet--12 column__width-desktop--6'
 		, $withModifier,
 		'Strings are not equal in the case of modifiers added'
 	);
-	$this->assertEquals(
+	$this->assertSame(
 		'column__width-mobile column__width-tablet column__width-desktop',
 		$withoutModifier,
 		'Strings are not equal in the case there is no modifier'
 	);
-	$this->assertEquals(
+	$this->assertSame(
 		'column__width-mobile--12 column__width-tablet--12',
 		$withEmptyString,
 		'Strings are not equal when one option is empty'
@@ -159,7 +159,7 @@ test('Asserts that checkAttr works in case attribute is string', function () {
 	$results = Components::checkAttr('buttonAlign', $attributes, $manifest);
 
 	$this->assertIsString($results, 'Result should be a string');
-	$this->assertEquals('right', $results, "The set attribute should be {$attributes['buttonAlign']}");
+	$this->assertSame('right', $results, "The set attribute should be {$attributes['buttonAlign']}");
 });
 
 test('Asserts that checkAttr works in case attribute is boolean', function () {
@@ -169,7 +169,7 @@ test('Asserts that checkAttr works in case attribute is boolean', function () {
 	$results = Components::checkAttr('buttonIsAnchor', $attributes, $manifest);
 
 	$this->assertIsBool($results, 'THe result should be a boolean');
-	$this->assertEquals(true, $results, "The set attribute should be {$attributes['buttonIsAnchor']}");
+	$this->assertSame(true, $results, "The set attribute should be {$attributes['buttonIsAnchor']}");
 });
 
 test('Asserts that checkAttr returns false in case attribute is boolean and default is not set', function () {
@@ -179,7 +179,7 @@ test('Asserts that checkAttr returns false in case attribute is boolean and defa
 	$results = Components::checkAttr('buttonIsNewTab', $attributes, $manifest);
 
 	$this->assertIsBool($results, 'THe result should be a boolean');
-	$this->assertEquals(false, $results, "The set attribute should be false");
+	$this->assertSame(false, $results, "The set attribute should be false");
 });
 
 test('Asserts that checkAttr works in case attribute is array', function () {
@@ -189,8 +189,8 @@ test('Asserts that checkAttr works in case attribute is array', function () {
 	$results = Components::checkAttr('buttonAttrs', $attributes, $manifest);
 
 	$this->assertIsArray($results, 'The result should be an array');
-	$this->assertEquals('attr 1', $results[0], 'The value in the array is not correct');
-	$this->assertEquals('attr 2', $results[1], 'The value in the array is not correct');
+	$this->assertSame('attr 1', $results[0], 'The value in the array is not correct');
+	$this->assertSame('attr 2', $results[1], 'The value in the array is not correct');
 });
 
 test('Asserts that checkAttr returns empty array in case attribute is array or object and default is not set', function () {
@@ -200,7 +200,7 @@ test('Asserts that checkAttr returns empty array in case attribute is array or o
 	$results = Components::checkAttr('buttonAttrs', $attributes, $manifest);
 
 	$this->assertIsArray($results, 'The result should be an empty array');
-	$this->assertEquals([], $results, "The set attribute should be empty array");
+	$this->assertSame([], $results, "The set attribute should be empty array");
 });
 
 test('Asserts that checkAttr returns default value', function () {
@@ -210,7 +210,7 @@ test('Asserts that checkAttr returns default value', function () {
 	$results = Components::checkAttr('buttonAlign', $attributes, $manifest, 'button');
 
 	$this->assertIsString($results, 'The default value should be a string');
-	$this->assertEquals('left', $results, 'The default value should be left');
+	$this->assertSame('left', $results, 'The default value should be left');
 });
 
 test('Asserts that checkAttr throws exception if manifest key is not set', function () {
@@ -230,7 +230,7 @@ test('Asserts that checkAttr returns attribute based on prefix if set', function
 	$results = Components::checkAttr('buttonAlign', $attributes, $manifest);
 
 	$this->assertIsString($results, 'Result should be a string');
-	$this->assertEquals('right', $results, "The set attribute should be {$attributes['prefixedMultipleTimesButtonAlign']}");
+	$this->assertSame('right', $results, "The set attribute should be {$attributes['prefixedMultipleTimesButtonAlign']}");
 });
 
 /**
@@ -249,7 +249,7 @@ test('Asserts that checkAttrResponsive returns the correct output.', function ()
 
 	$this->assertIsArray($results, 'Result should be an array');
 	$this->assertArrayHasKey('large', $results);
-	$this->assertEquals($results['large'], '10');
+	$this->assertSame($results['large'], '10');
 });
 
 test('Asserts that checkAttrResponsive returns empty values if attribute is not provided.', function () {
@@ -260,7 +260,7 @@ test('Asserts that checkAttrResponsive returns empty values if attribute is not 
 
 	$this->assertIsArray($results, 'Result should be an array');
 	$this->assertArrayHasKey('large', $results);
-	$this->assertEquals($results['large'], '');
+	$this->assertSame($results['large'], '');
 });
 
 test('Asserts that checkAttrResponsive throws error if responsiveAttribute key is missing.', function () {
@@ -284,21 +284,21 @@ test('Asserts that selectorBlock returns the correct class when attributes are s
 	$selector = Components::selector('button', 'button', 'icon', 'blue');
 
 	$this->assertIsString($selector);
-	$this->assertEquals('button__icon--blue', $selector);
+	$this->assertSame('button__icon--blue', $selector);
 });
 
 test('Asserts that selector returns the correct class when only block class is set', function () {
 	$selector = Components::selector('button', 'button');
 
 	$this->assertIsString($selector);
-	$this->assertEquals('button', $selector);
+	$this->assertSame('button', $selector);
 });
 
 test('Asserts that selector returns the correct class when element is an empty string', function () {
 	$selector = Components::selector('button', 'button', '    ');
 
 	$this->assertIsString($selector);
-	$this->assertEquals('button', $selector);
+	$this->assertSame('button', $selector);
 });
 
 /**
@@ -938,7 +938,7 @@ test('Asserts that arrayIsList returns the correct output for wrong input', func
 test('Asserts that camelToKebabCase returns the correct output', function () {
 	$output = Components::camelToKebabCase('superCoolTestString');
 
-	$this->assertEquals('super-cool-test-string', $output);
+	$this->assertSame('super-cool-test-string', $output);
 });
 
 test('Asserts that camelToKebabCase returns the wrong output', function () {
@@ -953,7 +953,7 @@ test('Asserts that camelToKebabCase returns the wrong output', function () {
 test('Asserts that kebabToCamelCase returns the correct output', function () {
 	$output = Components::kebabToCamelCase('super-cool-test-string');
 
-	$this->assertEquals('superCoolTestString', $output);
+	$this->assertSame('superCoolTestString', $output);
 });
 
 test('Asserts that kebabToCamelCase returns the wrong output', function () {
@@ -968,7 +968,7 @@ test('Asserts that kebabToCamelCase returns the wrong output', function () {
 test('Asserts that kebabToCamelCase returns the correct output with a different separator', function () {
 	$output = Components::kebabToCamelCase('super_cool_test_string', '_');
 
-	$this->assertEquals('superCoolTestString', $output);
+	$this->assertSame('superCoolTestString', $output);
 });
 
 /**
@@ -977,7 +977,7 @@ test('Asserts that kebabToCamelCase returns the correct output with a different 
 test('Asserts that kebabToCamelCase returns the correct output with numbers as a string', function () {
 	$output = Components::kebabToCamelCase('123-456-789');
 
-	$this->assertEquals('123456789', $output);
+	$this->assertSame('123456789', $output);
 });
 
 /**
@@ -986,7 +986,7 @@ test('Asserts that kebabToCamelCase returns the correct output with numbers as a
 test('Asserts that kebabToCamelCase returns the correct output with a non-kebab-case string', function () {
 	$output = Components::kebabToCamelCase('non kebab string');
 
-	$this->assertEquals('non kebab string', $output);
+	$this->assertSame('non kebab string', $output);
 });
 
 /**
@@ -1061,13 +1061,13 @@ test('Asserts props will correctly build the prefix', function () {
 
 	$this->assertIsArray($output);
 	$this->assertContains('prefix', array_keys($output), "Output array doesn't contain prefix attribute key.");
-	$this->assertEquals('heading', $output['prefix']);
+	$this->assertSame('heading', $output['prefix']);
 
 	// Next level
 	$output = Components::props($output, 'typography');
 	$this->assertIsArray($output);
 	$this->assertContains('prefix', array_keys($output), "Output array doesn't contain prefix attribute key.");
-	$this->assertEquals('headingTypography', $output['prefix']);
+	$this->assertSame('headingTypography', $output['prefix']);
 });
 
 test('Asserts props will correctly leave only the the needed attributes', function () {

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -261,8 +261,8 @@ test('Asserts that checkAttrResponsive throws error if keyName key is missing re
 	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
 	$attributes = [];
 
-	Components::checkAttrResponsive('testAttribtue', $attributes, $manifest, 'button');
-})->throws(\Exception::class, 'It looks like you are missing the testAttribtue key in your manifest responsiveAttributes array.');
+	Components::checkAttrResponsive('testAttribute', $attributes, $manifest, 'button');
+})->throws(\Exception::class, 'It looks like you are missing the testAttribute key in your manifest responsiveAttributes array.');
 
 /**
  * Components::selector tests
@@ -529,7 +529,7 @@ test('Asserts that outputCssVariables returns empty for missing variables.', fun
 	$this->assertStringNotContainsString('--variable-value-default: default;', $output);
 });
 
-test('Asserts that outputCssVariables returns array of attributes if defaut is set.', function () {
+test('Asserts that outputCssVariables returns array of attributes if default is set.', function () {
 	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/variables');
 	$globalManifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks');
 
@@ -827,7 +827,7 @@ test('Asserts that responsive variables and default variables are defined', func
 	$this->assertStringContainsString('variable-value-default-responsive: value1-responsive', $output);
 	$this->assertStringContainsString('variable-value-default-responsive: value2-responsive', $output);
 	$this->assertStringContainsString('@media (min-width: 1199px)', $output);
-	$this->assertStringContainsString('variable-value-default: value2-dekstop', $output);
+	$this->assertStringContainsString('variable-value-default: value2-desktop', $output);
 	$this->assertStringContainsString('variable-value-default: value1-mobile', $output);
 
 	$value = '2';
@@ -852,7 +852,7 @@ test('Asserts that responsive variables and default variables are defined', func
 	$this->assertStringContainsString("variable-default-normal: default-mobile-{$value}", $output);
 });
 
-test('Asserts that manifest has responsive variables defined but without appereance of responsiveAttributes', function () {
+test('Asserts that manifest has responsive variables defined but without appearance of responsiveAttributes', function () {
 	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/responsiveVariables');
 	$globalManifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks');
 	unset($manifest['responsiveAttributes']);

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -220,6 +220,19 @@ test('Asserts that checkAttr throws exception if manifest key is not set', funct
 	Components::checkAttr('bla', $attributes, $manifest, 'button');
 })->throws(\Exception::class, "bla key does not exist in the button component manifest. Please check your implementation.");
 
+test('Asserts that checkAttr returns attribute based on prefix if set', function () {
+	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$attributes = [
+		'prefix' => 'prefixedMultipleTimesButton',
+		'prefixedMultipleTimesButtonAlign' => 'right'
+	];
+
+	$results = Components::checkAttr('buttonAlign', $attributes, $manifest);
+
+	$this->assertIsString($results, 'Result should be a string');
+	$this->assertEquals('right', $results, "The set attribute should be {$attributes['prefixedMultipleTimesButtonAlign']}");
+});
+
 /**
  * Components::checkAttrResponsive tests
  */
@@ -1023,7 +1036,6 @@ test('Asserts props for heading component will return only typography attributes
 	$output = Components::props($attributes, 'typography');
 
 	$this->assertIsArray($output);
-  echo print_r(array_keys($output), true);
 	$this->assertContains('typographyContent', array_keys($output), "Output array doesn't contain typographyContent attribute key.");
 	$this->assertNotContains('headingSize', array_keys($output), "Output array does contain headingSize attribute key.");
 });

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -230,7 +230,7 @@ test('Asserts that checkAttr throws exception if manifest key is not set', funct
 	$attributes['title'] = 'Some attribute';
 
 	Components::checkAttr('bla', $attributes, $manifest, 'button');
-})->throws(\Exception::class, "bla key does not exist in the button component manifest. Please check your implementation. Check if your bla attribut exists in the component's manifest.json");
+})->throws(\Exception::class, "bla key does not exist in the button component manifest. Please check your implementation.");
 
 /**
  * Components::checkAttrResponsive tests
@@ -1008,8 +1008,7 @@ test('Asserts props for heading block will return only heading attributes', func
 
 	$this->blocksExample = new BlocksExample();
 	$this->blocksExample->getBlocksDataFullRaw();
-	$globalData = $this->blocksExample->getBlocksDataFullRawItem('dependency');
-	$output = Components::props($attributes, $headingBlock['blockName'], '', true, $globalData);
+	$output = Components::props($attributes, $headingBlock['blockName'], '');
 
 	$this->assertIsArray($output);
 	$this->assertContains('headingAlign', array_keys($output), "Output array doesn't contain headingAlign attribute key.");
@@ -1033,11 +1032,10 @@ test('Asserts props for heading component will return only typography attributes
 
 	$this->blocksExample = new BlocksExample();
 	$this->blocksExample->getBlocksDataFullRaw();
-	$globalData = $this->blocksExample->getBlocksDataFullRawItem('dependency');
-
-	$output = Components::props($attributes, 'typography', $headingComponent['componentName'], false, $globalData);
+	$output = Components::props($attributes, 'typography');
 
 	$this->assertIsArray($output);
-	$this->assertContains('typographyAlign', array_keys($output), "Output array doesn't contain typographyAlign attribute key.");
+  echo print_r(array_keys($output), true);
+	$this->assertContains('typographyContent', array_keys($output), "Output array doesn't contain typographyContent attribute key.");
 	$this->assertNotContains('headingSize', array_keys($output), "Output array does contain headingSize attribute key.");
 });

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -33,10 +33,6 @@ test('Throws type exception if wrong argument type is passed to ensureString', f
 ->throws(ComponentException::class)
 ->with('errorStringArguments');
 
-test('Throws argument count exception if no argument is passed', function () {
-	Components::ensureString();
-})->throws(\ArgumentCountError::class);
-
 /**
  * Components::classnames tests
  */

--- a/tests/Helpers/ErrorLoggerTraitTest.php
+++ b/tests/Helpers/ErrorLoggerTraitTest.php
@@ -22,7 +22,7 @@ test('Test restResponseHandler will return expected result in case of success', 
     $response = $this->mockLogger->restResponseHandler(200, 'Some status', 'Some message', ['fake data']);
 
     $this->assertJson($response, 'Response is not a JSON string.');
-    $this->assertEquals('{"success":true,"data":{"code":200,"status":"Some status","message":"Some message","data":["fake data"]}}', $response);
+    $this->assertSame('{"success":true,"data":{"code":200,"status":"Some status","message":"Some message","data":["fake data"]}}', $response);
 });
 
 
@@ -32,5 +32,5 @@ test('Test restResponseHandler will return expected result in case of error', fu
     $response = $this->mockLogger->restResponseHandler(404, 'Some error', 'Some error message', ['fake data']);
 
     $this->assertJson($response, 'Response is not a JSON string.');
-    $this->assertEquals('{"success":false,"data":{}}', $response);
+    $this->assertSame('{"success":false,"data":{}}', $response);
 });

--- a/tests/Helpers/ObjectHelperTraitTest.php
+++ b/tests/Helpers/ObjectHelperTraitTest.php
@@ -72,7 +72,7 @@ test('Test That multidimensional array is flattened', function () {
 		]
 	];
 
-    $this->assertEquals(['bar', 1, 2, 3], $this->mockHelper->flattenArray($array));
+    $this->assertSame(['bar', 1, 2, 3], $this->mockHelper->flattenArray($array));
 });
 
 test('Sanitization of array works', function() {
@@ -100,7 +100,7 @@ test('Sanitization of array works', function() {
 		]
 	];
 
-	 $this->assertEquals($expectedSanitizedArray, $sanitizedArray);
+	 $this->assertSame($expectedSanitizedArray, $sanitizedArray);
 });
 
 test('Test that sorting helper works', function() {
@@ -118,5 +118,5 @@ test('Test that sorting helper works', function() {
 		['name' => 'Mike', 'order' => 3],
 	];
 
-	$this->assertEquals($expectedArray, $orderedArray);
+	$this->assertSame($expectedArray, $orderedArray);
 });

--- a/tests/Helpers/ShortcodeHelperTest.php
+++ b/tests/Helpers/ShortcodeHelperTest.php
@@ -21,7 +21,7 @@ test('Shortcode helper will call the shortcode callback', function() {
 	$this->shortcode->getShortcode('sayHello', ['name' => 'John']);
 	$result = ob_get_clean();
 
-	$this->assertEquals('Hello John!', $result);
+	$this->assertSame('Hello John!', $result);
 });
 
 

--- a/tests/I18n/I18nCliTest.php
+++ b/tests/I18n/I18nCliTest.php
@@ -71,5 +71,5 @@ test('I18n CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayNotHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates i18n language class.', $documentation[$key]);
+	$this->assertSame('Generates i18n language class.', $documentation[$key]);
 });

--- a/tests/Login/LoginCliTest.php
+++ b/tests/Login/LoginCliTest.php
@@ -72,5 +72,5 @@ test('Login CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayNotHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates Login class file.', $documentation[$key]);
+	$this->assertSame('Generates Login class file.', $documentation[$key]);
 });

--- a/tests/Main/MainCliTest.php
+++ b/tests/Main/MainCliTest.php
@@ -72,5 +72,5 @@ test('Main CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayNotHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates Main class file for all other features using service container pattern.', $documentation[$key]);
+	$this->assertSame('Generates Main class file for all other features using service container pattern.', $documentation[$key]);
 });

--- a/tests/Manifest/ManifestCliTest.php
+++ b/tests/Manifest/ManifestCliTest.php
@@ -67,5 +67,5 @@ test('Manifest CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayNotHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates Manifest class.', $documentation[$key]);
+	$this->assertSame('Generates Manifest class.', $documentation[$key]);
 });

--- a/tests/Media/MediaCliTest.php
+++ b/tests/Media/MediaCliTest.php
@@ -55,6 +55,6 @@ test('Media CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayNotHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates media class.', $documentation[$key]);
+	$this->assertSame('Generates media class.', $documentation[$key]);
 
 });

--- a/tests/Menu/MenuCliTest.php
+++ b/tests/Menu/MenuCliTest.php
@@ -72,6 +72,6 @@ test('Menu CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayNotHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates menu class.', $documentation[$key]);
+	$this->assertSame('Generates menu class.', $documentation[$key]);
 });
 

--- a/tests/ModifyAdminAppearance/ModifyAdminAppearanceCliTest.php
+++ b/tests/ModifyAdminAppearance/ModifyAdminAppearanceCliTest.php
@@ -72,5 +72,5 @@ test('ModifyAdminAppearance CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayNotHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates Modify Admin Appearance class.', $documentation[$key]);
+	$this->assertSame('Generates Modify Admin Appearance class.', $documentation[$key]);
 });

--- a/tests/Readme/ReadmeCliTest.php
+++ b/tests/Readme/ReadmeCliTest.php
@@ -75,5 +75,5 @@ test('Readme CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Initialize Command for building your projects readme.', $documentation[$key]);
+	$this->assertSame('Initialize Command for building your projects readme.', $documentation[$key]);
 });

--- a/tests/Rest/Fields/FieldExampleTest.php
+++ b/tests/Rest/Fields/FieldExampleTest.php
@@ -40,7 +40,7 @@ test('Field registers the callback properly', function () {
 
 	$this->field->fieldRegisterCallback($this->wpRestServer, 'attr', new class{}, 'post');
 
-	$this->assertEquals(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/Rest/Routes/RouteExampleTest.php
+++ b/tests/Rest/Routes/RouteExampleTest.php
@@ -55,7 +55,7 @@ test('Route has a valid callback', function () {
 
 	$this->assertIsArray($output);
 	$this->assertArrayHasKey($this->mockRequestKey, $output);
-	$this->assertEquals($output[$this->mockRequestKey], $this->mockRequestValue);
+	$this->assertSame($output[$this->mockRequestKey], $this->mockRequestValue);
 });
 
 
@@ -65,7 +65,7 @@ test('Route registers the callback properly', function () {
 
 	$this->route->routeRegisterCallback($this->wpRestServer);
 
-	$this->assertEquals(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/Services/ServiceExampleCliTest.php
+++ b/tests/Services/ServiceExampleCliTest.php
@@ -78,5 +78,5 @@ test('Services CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Generates empty generic service class.', $documentation[$key]);
+	$this->assertSame('Generates empty generic service class.', $documentation[$key]);
 });

--- a/tests/Setup/SetupCliTest.php
+++ b/tests/Setup/SetupCliTest.php
@@ -64,5 +64,5 @@ test('Setup CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Initialize Command for automatic project setup and update.', $documentation[$key]);
+	$this->assertSame('Initialize Command for automatic project setup and update.', $documentation[$key]);
 });

--- a/tests/Setup/UpdateCliTest.php
+++ b/tests/Setup/UpdateCliTest.php
@@ -81,5 +81,5 @@ test('Update CLI documentation is correct', function () {
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($key, $documentation);
 	$this->assertArrayHasKey('synopsis', $documentation);
-	$this->assertEquals('Run project update with details stored in setup.json file.', $documentation[$key]);
+	$this->assertSame('Run project update with details stored in setup.json file.', $documentation[$key]);
 });

--- a/tests/ThemeOptions/ThemeOptionsCliTest.php
+++ b/tests/ThemeOptions/ThemeOptionsCliTest.php
@@ -58,5 +58,5 @@ test('Custom theme options CLI documentation is correct', function () {
 
 	$this->assertIsArray($documentation);
 	$this->assertArrayHasKey($descKey, $documentation);
-	$this->assertEquals('Generates project Theme Options class using ACF.', $documentation[$descKey]);
+	$this->assertSame('Generates project Theme Options class using ACF.', $documentation[$descKey]);
 });

--- a/tests/ThemeOptions/ThemeOptionsExampleTest.php
+++ b/tests/ThemeOptions/ThemeOptionsExampleTest.php
@@ -22,6 +22,6 @@ test('if theme options actions are registered', function () {
 	$this->example->register();
 
 	$this->assertTrue(\method_exists($this->example, 'register'));
-	$this->assertEquals(10, has_action('acf/init', [$this->example, 'createThemeOptionsPage']));
-	$this->assertEquals(10, has_action('acf/init', [$this->example, 'registerThemeOptions']));
+	$this->assertSame(10, has_action('acf/init', [$this->example, 'createThemeOptionsPage']));
+	$this->assertSame(10, has_action('acf/init', [$this->example, 'registerThemeOptions']));
 });

--- a/tests/View/EscapedViewCliTest.php
+++ b/tests/View/EscapedViewCliTest.php
@@ -59,5 +59,5 @@ test('Escaped view command will correctly copy the EscapedView class with defaul
 	$this->assertNotEmpty($documentation);
 	$this->assertIsArray($documentation);
  	$this->assertArrayHasKey($descKey, $documentation);
- 	$this->assertEquals('Generates project Escape view class.', $documentation[$descKey]);
+ 	$this->assertSame('Generates project Escape view class.', $documentation[$descKey]);
  });

--- a/tests/data/src/Blocks/components/responsiveVariables/manifest.json
+++ b/tests/data/src/Blocks/components/responsiveVariables/manifest.json
@@ -71,7 +71,7 @@
 				{
 					"breakpoint": "desktop",
 					"variable": {
-						"variable-value-default": "value1-dekstop"
+						"variable-value-default": "value1-desktop"
 					}
 				}
 			],
@@ -79,7 +79,7 @@
 				{
 					"breakpoint": "desktop",
 					"variable": {
-						"variable-value-default": "value2-dekstop"
+						"variable-value-default": "value2-desktop"
 					}
 				}
 			]


### PR DESCRIPTION
Fixes broken tests as part of https://github.com/infinum/eightshift-libs/pull/211

Changelog
---
- `checkAttr` tests
- `props` tests (done less detailed than the ones in JS since that was a bit of on overkill + the props helper is much more simplified now)
- Removed tests which test native PHP functionality (and cause IntelliSense errors in editor)
- Fixed some IntelliSense errors / typos