### PR TITLE
Add admin menus cli

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,9 +5,17 @@
 # https://blog.madewithlove.be/post/gitattributes/
 #
 /.github export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
 /docs export-ignore
 /documentation export-ignore
 /CODE_OF_CONDUCT.md export-ignore
+/tests export-ignore
+/package.json export-ignore
+/patchwork.json export-ignore
+/phpcs.xml.dist export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/src/AdminMenus/AbstractAdminMenu.php
+++ b/src/AdminMenus/AbstractAdminMenu.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * File that holds base abstract class for admin menus generation.
+ *
+ * @package EightshiftLibs\BlockPatterns
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftLibs\AdminMenus;
+
+use EightshiftLibs\Helpers\Components;
+use EightshiftLibs\Services\ServiceInterface;
+use EightshiftLibs\Blocks\RenderableBlockInterface;
+
+/**
+ * Abstract class AbstractAdminMenu class.
+ *
+ * Class responsible for creating admin menus, separately from CPT admin menus.
+ */
+abstract class AbstractAdminMenu implements ServiceInterface, RenderableBlockInterface
+{
+
+	/**
+	 * Register all the hooks
+	 *
+	 * @return void
+	 */
+	public function register(): void
+	{
+		\add_action(
+			'admin_menu',
+			function () {
+				\add_menu_page(
+					$this->getTitle(),
+					$this->getMenuTitle(),
+					$this->getCapability(),
+					$this->getMenuSlug(),
+					[$this, 'processAdminMenu'],
+					$this->getIcon(),
+					$this->getPosition()
+				);
+			}
+		);
+	}
+
+	/**
+	 * Process the admin menu attributes and prepare rendering.
+	 *
+	 * The echo doesn't need to be escaped since it's escaped
+	 * in the render method.
+	 *
+	 * @param array|string $attr Attributes as passed to the admin menu.
+	 *
+	 * @return void The rendered content needs to be echoed.
+	 * @throws \Exception Exception in case the component is missing.
+	 */
+	public function processAdminMenu($attr): void
+	{
+		$attr = $this->processAttributes($attr);
+
+		$attr['adminMenuSlug'] = $this->getMenuSlug();
+		$attr['nonceField'] = $this->renderNonce();
+
+		echo $this->render((array)$attr); // phpcs:ignore
+	}
+
+	/**
+	 * Render the current view.
+	 *
+	 * @param array  $attributes Array of attributes passed to the view.
+	 * @param string $innerBlockContent Not used here.
+	 *
+	 * @return string Rendered HTML.
+	 * @throws \Exception On missing attributes OR missing template.
+	 */
+	public function render(array $attributes = [], string $innerBlockContent = ''): string
+	{
+		try {
+			return Components::render($this->getViewComponent(), $attributes);
+		} catch (\Exception $exception) { // To do: once new libs are released, replace with ComponentException.
+			// Don't let exceptions bubble up. Just render the exception message into the admin menu.
+			return sprintf(
+				'<pre>%s</pre>',
+				$exception->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Get the title to use for the admin page.
+	 *
+	 * @return string The text to be displayed in the title tags of the page when the menu is selected.
+	 */
+	abstract protected function getTitle(): string;
+
+	/**
+	 * Get the menu title to use for the admin menu.
+	 *
+	 * @return string The text to be used for the menu.
+	 */
+	abstract protected function getMenuTitle(): string;
+
+	/**
+	 * Get the capability required for this menu to be displayed.
+	 *
+	 * @return string The capability required for this menu to be displayed to the user.
+	 */
+	abstract protected function getCapability(): string;
+
+	/**
+	 * Get the menu slug.
+	 *
+	 * @return string The slug name to refer to this menu by.
+	 *                Should be unique for this menu page and only include lowercase alphanumeric,
+	 *                dashes, and underscores characters to be compatible with sanitize_key().
+	 */
+	abstract protected function getMenuSlug(): string;
+
+	/**
+	 * Get the view component that will render correct view.
+	 *
+	 * @return string View uri.
+	 */
+	abstract protected function getViewComponent(): string;
+
+	/**
+	 * Process the admin menu attributes.
+	 *
+	 * @param array|string $attr Raw admin menu attributes passed into the
+	 *                           admin menu function.
+	 *
+	 * @return array Processed admin menu attributes.
+	 */
+	abstract protected function processAttributes($attr): array;
+
+	/**
+	 * Render the nonce.
+	 *
+	 * @return string|false Hidden field with a nonce.
+	 */
+	protected function renderNonce()
+	{
+		ob_start();
+
+		\wp_nonce_field(
+			$this->getNonceAction(),
+			$this->getNonceName()
+		);
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Get the action of the nonce to use.
+	 *
+	 * @return string Action of the nonce.
+	 */
+	protected function getNonceAction(): string
+	{
+		return "{$this->getMenuSlug()}_action";
+	}
+
+	/**
+	 * Get the name of the nonce to use.
+	 *
+	 * @return string Name of the nonce.
+	 */
+	protected function getNonceName(): string
+	{
+		return "{$this->getMenuSlug()}_nonce";
+	}
+
+	/**
+	 * Get the URL to the icon to be used for this menu
+	 *
+	 * @return string The URL to the icon to be used for this menu.
+	 *                * Pass a base64-encoded SVG using a data URI, which will be colored to match
+	 *                  the color scheme. This should begin with 'data:image/svg+xml;base64,'.
+	 *                * Pass the name of a Dashicons helper class to use a font icon,
+	 *                  e.g. 'dashicons-chart-pie'.
+	 *                * Pass 'none' to leave div.wp-menu-image empty so an icon can be added via CSS.
+	 */
+	protected function getIcon(): string
+	{
+		return 'none';
+	}
+
+	/**
+	 * Get the position of the menu.
+	 *
+	 * @return int Number that indicates the position of the menu.
+	 * 5   - below Posts
+	 * 10  - below Media
+	 * 15  - below Links
+	 * 20  - below Pages
+	 * 25  - below comments
+	 * 60  - below first separator
+	 * 65  - below Plugins
+	 * 70  - below Users
+	 * 75  - below Tools
+	 * 80  - below Settings
+	 * 100 - below second separator
+	 */
+	protected function getPosition(): int
+	{
+		return 100;
+	}
+}

--- a/src/AdminMenus/AbstractAdminSubMenu.php
+++ b/src/AdminMenus/AbstractAdminSubMenu.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * File that holds base abstract class for admin sub menus generation.
+ *
+ * @package EightshiftLibs\BlockPatterns
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftLibs\AdminMenus;
+
+/**
+ * Abstract class AbstractAdminSubMenu class.
+ *
+ * Class responsible for creating admin sub menus.
+ */
+abstract class AbstractAdminSubMenu extends AbstractAdminMenu
+{
+
+	/**
+	 * Register all the hooks
+	 *
+	 * @return void
+	 */
+	public function register(): void
+	{
+		\add_action(
+			'admin_menu',
+			function () {
+				\add_submenu_page(
+					$this->getParentMenu(),
+					$this->getTitle(),
+					$this->getMenuTitle(),
+					$this->getCapability(),
+					$this->getMenuSlug(),
+					[$this, 'processAdminSubmenu']
+				);
+			}
+		);
+	}
+
+	/**
+	 * Process the admin submenu attributes and prepare rendering.
+	 *
+	 * The echo doesn't need to be escaped since it's escaped
+	 * in the render method.
+	 *
+	 * @param array|string $attr Attributes as passed to the admin menu.
+	 *
+	 * @return void The rendered content needs to be echoed.
+	 * @throws \Exception Exception in case the component is missing.
+	 */
+	public function processAdminSubmenu($attr): void
+	{
+		$attr = $this->processAttributes($attr);
+
+		$attr['adminMenuSlug'] = $this->getMenuSlug();
+		$attr['nonceField'] = $this->renderNonce();
+
+		echo $this->render((array)$attr); // phpcs:ignore
+	}
+
+	/**
+	 * Get the slug of the parent menu.
+	 *
+	 * @return string The slug name for the parent menu (or the file name of a standard WordPress admin page.
+	 */
+	abstract protected function getParentMenu(): string;
+}

--- a/src/AdminMenus/AdminMenuCli.php
+++ b/src/AdminMenus/AdminMenuCli.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Class that registers WPCLI command for Admin menu creation.
+ *
+ * @package EightshiftLibs\CustomPostType
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftLibs\AdminMenus;
+
+use EightshiftLibs\Cli\AbstractCli;
+
+/**
+ * Class AdminMenuCli
+ */
+class AdminMenuCli extends AbstractCli
+{
+
+	/**
+	 * Output dir relative path.
+	 *
+	 * @var string
+	 */
+	public const OUTPUT_DIR = 'src/AdminMenus';
+
+	/**
+	 * Define default develop props.
+	 *
+	 * @param array $args WPCLI eval-file arguments.
+	 *
+	 * @return array
+	 */
+	public function getDevelopArgs(array $args): array
+	{
+		return [
+			'tile' => $args[1] ?? 'Admin Title',
+			'menu_title' => $args[2] ?? 'Admin Title',
+			'capability' => $args[3] ?? 'edit_posts',
+			'menu_slug' => $args[4] ?? 'admin_title',
+			'menu_icon' => $args[5] ?? 'dashicons-admin-generic',
+			'menu_position' => $args[6] ?? 100,
+		];
+	}
+
+	/**
+	 * Get WPCLI command doc.
+	 *
+	 * @return array
+	 */
+	public function getDoc(): array
+	{
+		return [
+			'shortdesc' => 'Generates admin menu class file.',
+			'synopsis' => [
+				[
+					'type' => 'assoc',
+					'name' => 'tile',
+					'description' => 'The text to be displayed in the title tags of the page when the menu is selected.',
+					'optional' => false,
+				],
+				[
+					'type' => 'assoc',
+					'name' => 'menu_title',
+					'description' => 'The text to be used for the menu.',
+					'optional' => false,
+				],
+				[
+					'type' => 'assoc',
+					'name' => 'capability',
+					'description' => 'The capability required for this menu to be displayed to the user.',
+					'optional' => false,
+				],
+				[
+					'type' => 'assoc',
+					'name' => 'menu_slug',
+					'description' => 'The slug name to refer to this menu by. Should be unique for this menu page and only include lowercase alphanumeric, dashes, and underscores characters to be compatible with sanitize_key().',
+					'optional' => false,
+				],
+				[
+					'type' => 'assoc',
+					'name' => 'menu_icon',
+					'description' => 'The default menu icon for the admin menu. Example: dashicons-admin-generic.',
+					'optional' => true,
+				],
+				[
+					'type' => 'assoc',
+					'name' => 'menu_position',
+					'description' => 'The default menu position. Example: 20.',
+					'optional' => true,
+				],
+			],
+		];
+	}
+
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	{
+		// Get Arguments.
+		$tile = $assocArgs['tile'];
+		$menuTitle = $assocArgs['menu_title'];
+		$capability = $assocArgs['capability'];
+		$menuSlug = $this->prepareSlug($assocArgs['menu_slug']);
+		$menuIcon = $assocArgs['menu_icon'] ?? '';
+		$menuPosition = (string)($assocArgs['menu_position'] ?? '');
+
+		// Get full class name.
+		$className = $this->getFileName($menuSlug);
+		$className = $className . $this->getClassShortName();
+
+		// Read the template contents, and replace the placeholders with provided variables.
+		$class = $this->getExampleTemplate(__DIR__, $this->getClassShortName())
+			->renameClassNameWithPrefix($this->getClassShortName(), $className)
+			->renameNamespace($assocArgs)
+			->renameUse($assocArgs)
+			->renameTextDomain($assocArgs)
+			->searchReplaceString('Admin Title', $tile)
+			->searchReplaceString('Admin Menu Title', $menuTitle)
+			->searchReplaceString("'edit_posts'", "'{$capability}'")
+			->searchReplaceString('example-menu-slug', $menuSlug);
+
+		if (!empty($menuPosition)) {
+			$class->searchReplaceString('100', $menuPosition);
+		}
+
+		if (!empty($menuIcon)) {
+			$class->searchReplaceString('dashicons-admin-generic', $menuIcon);
+		}
+
+		// Output final class to new file/folder and finish.
+		$class->outputWrite(static::OUTPUT_DIR, $className, $assocArgs);
+	}
+}

--- a/src/AdminMenus/AdminMenuExample.php
+++ b/src/AdminMenus/AdminMenuExample.php
@@ -13,7 +13,7 @@ namespace EightshiftBoilerplate\AdminMenus;
 use EightshiftLibs\AdminMenus\AbstractAdminMenu;
 
 /**
- * BlockPatternExample class.
+ * AdminMenuExample class.
  */
 class AdminMenuExample extends AbstractAdminMenu
 {

--- a/src/AdminMenus/AdminMenuExample.php
+++ b/src/AdminMenus/AdminMenuExample.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * File that holds class for admin menu example.
+ *
+ * @package EightshiftLibs\AdminMenus
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftBoilerplate\AdminMenus;
+
+use EightshiftLibs\AdminMenus\AbstractAdminMenu;
+
+/**
+ * BlockPatternExample class.
+ */
+class AdminMenuExample extends AbstractAdminMenu
+{
+	/**
+	 * Capability for this post type
+	 *
+	 * @var string
+	 */
+	public const ADMIN_MENU_CAPABILITY = 'edit_posts';
+
+	/**
+	 * Get the title to use for the admin page.
+	 *
+	 * @return string The text to be displayed in the title tags of the page when the menu is selected.
+	 */
+	protected function getTitle(): string
+	{
+		return \esc_html__('Admin Title', 'eightshift-libs');
+	}
+
+	/**
+	 * Get the menu title to use for the admin menu.
+	 *
+	 * @return string The text to be used for the menu.
+	 */
+	protected function getMenuTitle(): string
+	{
+		return \esc_html__('Admin Title', 'eightshift-libs');
+	}
+
+	/**
+	 * Get the capability required for this menu to be displayed.
+	 *
+	 * @return string The capability required for this menu to be displayed to the user.
+	 */
+	protected function getCapability(): string
+	{
+		return \esc_html__('Admin Title', 'eightshift-libs');
+	}
+
+	/**
+	 * Get the menu slug.
+	 *
+	 * @return string The slug name to refer to this menu by.
+	 *                Should be unique for this menu page and only include lowercase alphanumeric,
+	 *                dashes, and underscores characters to be compatible with sanitize_key().
+	 */
+	protected function getMenuSlug(): string
+	{
+		return self::ADMIN_MENU_CAPABILITY;
+	}
+
+	/**
+	 * Get the view component that will render correct view.
+	 *
+	 * @return string View uri.
+	 */
+	protected function getViewComponent(): string
+	{
+		return 'layout';
+	}
+
+	/**
+	 * Process the admin menu attributes.
+	 *
+	 * Here you can get any kind of metadata, query the database, etc..
+	 * This data will be passed to the component view to be rendered out in the
+	 * processAdminMenu parent method.
+	 *
+	 * @param array<string, mixed>|string $attr Raw admin menu attributes passed into the
+	 *                           admin menu function.
+	 *
+	 * @return array<string, mixed> Processed admin menu attributes.
+	 */
+	protected function processAttributes($attr): array
+	{
+		return [
+			'pageTitle' => \esc_html__('Admin Title', 'eightshift-libs'),
+		];
+	}
+}

--- a/src/AdminMenus/AdminMenuExample.php
+++ b/src/AdminMenus/AdminMenuExample.php
@@ -151,5 +151,4 @@ class AdminMenuExample extends AbstractAdminMenu
 			'pageTitle' => \esc_html__('Admin Title', 'eightshift-libs'),
 		];
 	}
-
 }

--- a/src/AdminMenus/AdminMenuExample.php
+++ b/src/AdminMenus/AdminMenuExample.php
@@ -18,11 +18,32 @@ use EightshiftLibs\AdminMenus\AbstractAdminMenu;
 class AdminMenuExample extends AbstractAdminMenu
 {
 	/**
-	 * Capability for this post type
+	 * Capability for this admin menu
 	 *
 	 * @var string
 	 */
 	public const ADMIN_MENU_CAPABILITY = 'edit_posts';
+
+	/**
+	 * Menu slug for this admin menu
+	 *
+	 * @var string
+	 */
+	public const ADMIN_MENU_SLUG = 'example-menu-slug';
+
+	/**
+	 * Menu icon for this admin menu
+	 *
+	 * @var string
+	 */
+	public const ADMIN_MENU_ICON = 'dashicons-admin-generic';
+
+	/**
+	 * Menu position for this admin menu
+	 *
+	 * @var string
+	 */
+	public const ADMIN_MENU_POSITION = 100;
 
 	/**
 	 * Get the title to use for the admin page.
@@ -41,7 +62,7 @@ class AdminMenuExample extends AbstractAdminMenu
 	 */
 	protected function getMenuTitle(): string
 	{
-		return \esc_html__('Admin Title', 'eightshift-libs');
+		return \esc_html__('Admin Menu Title', 'eightshift-libs');
 	}
 
 	/**
@@ -51,7 +72,7 @@ class AdminMenuExample extends AbstractAdminMenu
 	 */
 	protected function getCapability(): string
 	{
-		return \esc_html__('Admin Title', 'eightshift-libs');
+		return self::ADMIN_MENU_CAPABILITY;
 	}
 
 	/**
@@ -63,7 +84,43 @@ class AdminMenuExample extends AbstractAdminMenu
 	 */
 	protected function getMenuSlug(): string
 	{
-		return self::ADMIN_MENU_CAPABILITY;
+		return self::ADMIN_MENU_SLUG;
+	}
+
+	/**
+	 * Get the URL to the icon to be used for this menu
+	 *
+	 * @return string The URL to the icon to be used for this menu.
+	 *                * Pass a base64-encoded SVG using a data URI, which will be colored to match
+	 *                  the color scheme. This should begin with 'data:image/svg+xml;base64,'.
+	 *                * Pass the name of a Dashicons helper class to use a font icon,
+	 *                  e.g. 'dashicons-chart-pie'.
+	 *                * Pass 'none' to leave div.wp-menu-image empty so an icon can be added via CSS.
+	 */
+	protected function getIcon(): string
+	{
+		return self::ADMIN_MENU_ICON;
+	}
+
+	/**
+	 * Get the position of the menu.
+	 *
+	 * @return int Number that indicates the position of the menu.
+	 * 5   - below Posts
+	 * 10  - below Media
+	 * 15  - below Links
+	 * 20  - below Pages
+	 * 25  - below comments
+	 * 60  - below first separator
+	 * 65  - below Plugins
+	 * 70  - below Users
+	 * 75  - below Tools
+	 * 80  - below Settings
+	 * 100 - below second separator
+	 */
+	protected function getPosition(): int
+	{
+		return self::ADMIN_MENU_POSITION;
 	}
 
 	/**
@@ -94,4 +151,5 @@ class AdminMenuExample extends AbstractAdminMenu
 			'pageTitle' => \esc_html__('Admin Title', 'eightshift-libs'),
 		];
 	}
+
 }

--- a/src/AdminMenus/AdminSubMenuCli.php
+++ b/src/AdminMenus/AdminSubMenuCli.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Class that registers WPCLI command for admin sub menu creation.
+ *
+ * @package EightshiftLibs\CustomPostType
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftLibs\AdminMenus;
+
+use EightshiftLibs\Cli\AbstractCli;
+
+/**
+ * Class AdminSubMenuCli
+ */
+class AdminSubMenuCli extends AbstractCli
+{
+
+	/**
+	 * Output dir relative path.
+	 *
+	 * @var string
+	 */
+	public const OUTPUT_DIR = 'src/AdminMenus';
+
+	/**
+	 * Define default develop props.
+	 *
+	 * @param array $args WPCLI eval-file arguments.
+	 *
+	 * @return array
+	 */
+	public function getDevelopArgs(array $args): array
+	{
+		return [
+			'parent_slug' => $args[1] ?? 'example-menu-slug',
+			'title' => $args[2] ?? 'Admin Title',
+			'menu_title' => $args[3] ?? 'Admin Title',
+			'capability' => $args[4] ?? 'edit_posts',
+			'menu_slug' => $args[5] ?? 'admin_title',
+		];
+	}
+
+	/**
+	 * Get WPCLI command doc.
+	 *
+	 * @return array
+	 */
+	public function getDoc(): array
+	{
+		return [
+			'shortdesc' => 'Generates admin sub menu class file.',
+			'synopsis' => [
+				[
+					'type' => 'assoc',
+					'name' => 'parent_slug',
+					'description' => 'The slug name for the parent menu (or the file name of a standard WordPress admin page)',
+					'optional' => false,
+				],
+				[
+					'type' => 'assoc',
+					'name' => 'tile',
+					'description' => 'The text to be displayed in the title tags of the page when the menu is selected.',
+					'optional' => false,
+				],
+				[
+					'type' => 'assoc',
+					'name' => 'menu_title',
+					'description' => 'The text to be used for the menu.',
+					'optional' => false,
+				],
+				[
+					'type' => 'assoc',
+					'name' => 'capability',
+					'description' => 'The capability required for this menu to be displayed to the user.',
+					'optional' => false,
+				],
+				[
+					'type' => 'assoc',
+					'name' => 'menu_slug',
+					'description' => 'The slug name to refer to this menu by. Should be unique for this menu page and only include lowercase alphanumeric, dashes, and underscores characters to be compatible with sanitize_key().',
+					'optional' => false,
+				],
+			],
+		];
+	}
+
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	{
+		// Get Arguments.
+		$parentSlug = $assocArgs['parent_slug'];
+		$title = $assocArgs['title'];
+		$menuTitle = $assocArgs['menu_title'];
+		$capability = $assocArgs['capability'];
+		$menuSlug = $this->prepareSlug($assocArgs['menu_slug']);
+
+		// Get full class name.
+		$className = $this->getFileName($menuSlug);
+		$className = $className . $this->getClassShortName();
+
+		// Read the template contents, and replace the placeholders with provided variables.
+		$class = $this->getExampleTemplate(__DIR__, $this->getClassShortName())
+			->renameClassNameWithPrefix($this->getClassShortName(), $className)
+			->renameNamespace($assocArgs)
+			->renameUse($assocArgs)
+			->renameTextDomain($assocArgs)
+			->searchReplaceString('example-parent-slug', $parentSlug)
+			->searchReplaceString('Admin Title', $title)
+			->searchReplaceString('Admin Menu Title', $menuTitle)
+			->searchReplaceString("'edit_posts'", "'{$capability}'")
+			->searchReplaceString('example-menu-slug', $menuSlug);
+
+		// Output final class to new file/folder and finish.
+		$class->outputWrite(static::OUTPUT_DIR, $className, $assocArgs);
+	}
+}

--- a/src/AdminMenus/AdminSubMenuExample.php
+++ b/src/AdminMenus/AdminSubMenuExample.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * File that holds class for admin sub menu example.
+ *
+ * @package EightshiftLibs\AdminMenus
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftBoilerplate\AdminMenus;
+
+use EightshiftLibs\AdminMenus\AbstractAdminSubMenu;
+
+/**
+ * AdminSubMenuExample class.
+ */
+class AdminSubMenuExample extends AbstractAdminSubMenu
+{
+	/**
+	 * Capability for this admin sub menu
+	 *
+	 * @var string
+	 */
+	public const ADMIN_MENU_CAPABILITY = 'edit_posts';
+
+	/**
+	 * Menu slug for this admin sub menu
+	 *
+	 * @var string
+	 */
+	public const ADMIN_MENU_SLUG = 'example-menu-slug';
+
+	/**
+	 * Parent menu slug for this admin sub menu
+	 *
+	 * @var string
+	 */
+	public const PARENT_MENU_SLUG = 'example-parent-slug';
+
+	/**
+	 * Get the title to use for the admin page.
+	 *
+	 * @return string The text to be displayed in the title tags of the page when the menu is selected.
+	 */
+	protected function getTitle(): string
+	{
+		return \esc_html__('Admin Title', 'eightshift-libs');
+	}
+
+	/**
+	 * Get the menu title to use for the admin menu.
+	 *
+	 * @return string The text to be used for the menu.
+	 */
+	protected function getMenuTitle(): string
+	{
+		return \esc_html__('Admin Sub Menu Title', 'eightshift-libs');
+	}
+
+	/**
+	 * Get the capability required for this menu to be displayed.
+	 *
+	 * @return string The capability required for this menu to be displayed to the user.
+	 */
+	protected function getCapability(): string
+	{
+		return self::ADMIN_MENU_CAPABILITY;
+	}
+
+	/**
+	 * Get the menu slug.
+	 *
+	 * @return string The slug name to refer to this menu by.
+	 *                Should be unique for this menu page and only include lowercase alphanumeric,
+	 *                dashes, and underscores characters to be compatible with sanitize_key().
+	 */
+	protected function getMenuSlug(): string
+	{
+		return self::ADMIN_MENU_SLUG;
+	}
+
+	/**
+	 * Get the slug of the parent menu.
+	 *
+	 * @return string The slug name for the parent menu (or the file name of a standard WordPress admin page.
+	 */
+	protected function getParentMenu(): string
+	{
+		return self::PARENT_MENU_SLUG;
+	}
+
+	/**
+	 * Get the view component that will render correct view.
+	 *
+	 * @return string View uri.
+	 */
+	protected function getViewComponent(): string
+	{
+		return 'layout';
+	}
+
+	/**
+	 * Process the admin menu attributes.
+	 *
+	 * Here you can get any kind of metadata, query the database, etc..
+	 * This data will be passed to the component view to be rendered out in the
+	 * processAdminMenu parent method.
+	 *
+	 * @param array<string, mixed>|string $attr Raw admin menu attributes passed into the
+	 *                           admin menu function.
+	 *
+	 * @return array<string, mixed> Processed admin menu attributes.
+	 */
+	protected function processAttributes($attr): array
+	{
+		return [
+			'pageTitle' => \esc_html__('Admin Title', 'eightshift-libs'),
+		];
+	}
+}

--- a/src/CustomPostType/PostTypeCli.php
+++ b/src/CustomPostType/PostTypeCli.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Class that registers WPCLI command for Custom Taxonomy.
+ * Class that registers WPCLI command for custom post type registration.
  *
  * @package EightshiftLibs\CustomPostType
  */
@@ -58,7 +58,7 @@ class PostTypeCli extends AbstractCli
 				[
 					'type' => 'assoc',
 					'name' => 'label',
-					'description' => 'The label of the custom taxonomy to show in WP admin.',
+					'description' => 'The label of the custom post type to show in WP admin.',
 					'optional' => false,
 				],
 				[

--- a/tests/AdminMenus/AdminMenuCliTest.php
+++ b/tests/AdminMenus/AdminMenuCliTest.php
@@ -47,7 +47,7 @@ test('Admin menu CLI command will correctly copy the admin menu example class wi
 });
 
 
-test('Admin menus CLI command will correctly copy the admin menu class with set arguments', function () {
+test('Admin menu CLI command will correctly copy the admin menu class with set arguments', function () {
 	$cpt = $this->cpt;
 	$cpt([], [
 		'tile' => 'Reusable Blocks',

--- a/tests/AdminMenus/AdminMenuCliTest.php
+++ b/tests/AdminMenus/AdminMenuCliTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Unit\CustomPostType;
+
+use EightshiftLibs\AdminMenus\AdminMenuCli;
+
+use function Tests\deleteCliOutput;
+use function Tests\mock;
+
+/**
+ * Mock before tests.
+ */
+beforeEach(function () {
+	$wpCliMock = mock('alias:WP_CLI');
+
+	$wpCliMock
+		->shouldReceive('success')
+		->andReturnArg(0);
+
+	$wpCliMock
+		->shouldReceive('error')
+		->andReturnArg(0);
+
+	$this->cpt = new AdminMenuCli('boilerplate');
+});
+
+/**
+ * Cleanup after tests.
+ */
+afterEach(function () {
+	$output = dirname(__FILE__, 3) . '/cliOutput';
+
+	deleteCliOutput($output);
+});
+
+
+test('Admin menu CLI command will correctly copy the admin menu example class with defaults', function () {
+	$cpt = $this->cpt;
+	$cpt([], $cpt->getDevelopArgs([]));
+
+	// Check the output dir if the generated method is correctly generated.
+	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/AdminTitleAdminMenu.php');
+
+	$this->assertStringContainsString('class AdminTitleAdminMenu extends AbstractAdminMenu', $generatedCPT, 'Class name not correctly set');
+	$this->assertStringContainsString('Admin Title', $generatedCPT, 'Menu title not correctly replaced');
+	$this->assertStringNotContainsString('product', $generatedCPT);
+});
+
+
+test('Admin menus CLI command will correctly copy the admin menu class with set arguments', function () {
+	$cpt = $this->cpt;
+	$cpt([], [
+		'tile' => 'Reusable Blocks',
+		'menu_title' => 'Reusable Blocks',
+		'capability' => 'edit_reusable_blocks',
+		'menu_slug' => 'reusable-blocks',
+		'menu_icon' => 'dashicons-editor-table',
+	]);
+
+	// Check the output dir if the generated method is correctly generated.
+	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/ReusableBlocksAdminMenu.php');
+
+	$this->assertStringContainsString('class ReusableBlocksAdminMenu extends AbstractAdminMenu', $generatedCPT, 'Class name not correctly set');
+	$this->assertStringContainsString('Reusable Blocks', $generatedCPT, 'Menu title not correctly replaced');
+	$this->assertStringContainsString('edit_reusable_blocks', $generatedCPT, 'Capability not correctly replaced');
+	$this->assertStringContainsString('100', $generatedCPT, 'Menu position not correctly replaced');
+	$this->assertStringContainsString('dashicons-editor-table', $generatedCPT, 'Icon not correctly replaced');
+	$this->assertStringNotContainsString('dashicons-analytics', $generatedCPT, 'String found that should not be here');
+});
+
+
+test('Admin menu CLI documentation is correct', function () {
+	$cpt = $this->cpt;
+
+	$documentation = $cpt->getDoc();
+
+	$key = 'shortdesc';
+
+	$this->assertIsArray($documentation);
+	$this->assertArrayHasKey($key, $documentation);
+	$this->assertArrayHasKey('synopsis', $documentation);
+	$this->assertSame('Generates admin menu class file.', $documentation[$key]);
+});

--- a/tests/AdminMenus/AdminMenuExampleTest.php
+++ b/tests/AdminMenus/AdminMenuExampleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Unit\AdminMenus;
+
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use EightshiftBoilerplate\AdminMenus\AdminMenuExample;
+
+use function Tests\setupMocks;
+
+beforeEach(function() {
+	Monkey\setUp();
+	setupMocks();
+
+	$this->example = new AdminMenuExample();
+});
+
+afterEach(function() {
+	Monkey\tearDown();
+});
+
+
+test('Register method will call admin_menu hook', function () {
+	Actions\expectAdded('admin_menu')->with(\Mockery::type('Closure'));
+
+	$this->example->register();
+
+	$this->assertSame(10, has_action('admin_menu', 'function()'));
+});

--- a/tests/AdminMenus/AdminSubMenuCliTest.php
+++ b/tests/AdminMenus/AdminSubMenuCliTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\CustomPostType;
+
+use EightshiftLibs\AdminMenus\AdminSubMenuCli;
+
+use function Tests\deleteCliOutput;
+use function Tests\mock;
+
+/**
+ * Mock before tests.
+ */
+beforeEach(function () {
+	$wpCliMock = mock('alias:WP_CLI');
+
+	$wpCliMock
+		->shouldReceive('success')
+		->andReturnArg(0);
+
+	$wpCliMock
+		->shouldReceive('error')
+		->andReturnArg(0);
+
+	$this->cpt = new AdminSubMenuCli('boilerplate');
+});
+
+/**
+ * Cleanup after tests.
+ */
+afterEach(function () {
+	$output = dirname(__FILE__, 3) . '/cliOutput';
+
+	deleteCliOutput($output);
+});
+
+
+test('Admin submenu CLI command will correctly copy the admin menu example class with defaults', function () {
+	$cpt = $this->cpt;
+	$cpt([], $cpt->getDevelopArgs([]));
+
+	// Check the output dir if the generated method is correctly generated.
+	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/AdminTitleAdminSubMenu.php');
+
+	$this->assertStringContainsString('class AdminTitleAdminSubMenu extends AbstractAdminSubMenu', $generatedCPT, 'Class name not correctly set');
+	$this->assertStringContainsString('Admin Title', $generatedCPT, 'Menu title not correctly replaced');
+	$this->assertStringNotContainsString('product', $generatedCPT);
+});
+
+
+test('Admin submenu CLI command will correctly copy the admin menu class with set arguments', function () {
+	$cpt = $this->cpt;
+	$cpt([], [
+		'parent_slug' => 'reusable-blocks',
+		'title' => 'Options',
+		'menu_title' => 'Options',
+		'capability' => 'edit_reusable_blocks',
+		'menu_slug' => 'reusable-block-options',
+	]);
+
+	// Check the output dir if the generated method is correctly generated.
+	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/ReusableBlockOptionsAdminSubMenu.php');
+
+	$this->assertStringContainsString('class ReusableBlockOptionsAdminSubMenu extends AbstractAdminSubMenu', $generatedCPT, 'Class name not correctly set');
+	$this->assertStringContainsString('Options', $generatedCPT, 'Menu title not correctly replaced');
+	$this->assertStringContainsString('edit_reusable_blocks', $generatedCPT, 'Capability not correctly replaced');
+	$this->assertStringNotContainsString('dashicons-analytics', $generatedCPT, 'String found that should not be here');
+});
+
+
+test('Admin submenu CLI documentation is correct', function () {
+	$cpt = $this->cpt;
+
+	$documentation = $cpt->getDoc();
+
+	$key = 'shortdesc';
+
+	$this->assertIsArray($documentation);
+	$this->assertArrayHasKey($key, $documentation);
+	$this->assertArrayHasKey('synopsis', $documentation);
+	$this->assertSame('Generates admin sub menu class file.', $documentation[$key]);
+});


### PR DESCRIPTION
The first commit kinda violates the SRP of this PR, but it's a minor addition that helps save the trees.

I've added the templates for generating admin menus and submenus, with an example for usage purposes.

The things that are missing are

- [x] Tests
- [x] CLI for generating menus and submenus using these templates

I also noticed 2 minor phpstan issues that should be fixed but didn't want to add them here to prevent further pollution of the PR. 