### PR TITLE
Fix for responsive variables mobile first

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -620,6 +620,9 @@ class Components
 		// Define variables from globalManifest.
 		$breakpoints = $globalManifest['globalVariables']['breakpoints'];
 
+		// Sort breakpoints in ascending order.
+		asort($breakpoints);
+
 		// Define variables from manifest.
 		$variables = $manifest['variables'];
 
@@ -744,26 +747,33 @@ class Components
 
 			// Inner object for min values.
 			$itemObjectMin = array_merge(
+				$itemObject,
 				[
 					'type' => 'min',
-				],
-				$itemObject
+					'value' => $minBreakpointValue ?? 0,
+				]
 			);
 
 			// Inner object for max values.
 			$itemObjectMax = array_merge(
+				$itemObject,
 				[
 					'type' => 'max',
-				],
-				$itemObject
+				]
 			);
+
+			// Transfer value to bigger breakpoint.
+			$minBreakpointValue = $itemValue;
 
 			// Push both min and max to the defined arrays.
 			$min[] = $itemObjectMin;
 			$max[] = $itemObjectMax;
 		};
 
-		// Add default object to the top of the array.
+		// Pop largest breakpoint out of min array.
+		array_shift($min);
+
+		// Add default object to the top of the array as minimum.
 		array_unshift(
 			$min,
 			[
@@ -777,7 +787,10 @@ class Components
 		// Reverse order of max array.
 		$max = array_reverse($max);
 
-		// Add default object to the top of the array.
+		// Throw out the largest.
+		array_shift($max);
+
+		// Switch the largest to default.
 		array_unshift(
 			$max,
 			[


### PR DESCRIPTION
Changelog:
- added sort of global breakpoints in output CSS vars function
- corrected output for mobile first

Screenshots:
![MIN FIRST spacing bottom in](https://user-images.githubusercontent.com/46056662/126171151-3d4faa8d-cc16-42e3-bb8f-e8c29d0ea122.png)
![MIN FIRST editor spacing bottom in](https://user-images.githubusercontent.com/46056662/126171157-68ab07f3-7a72-4891-a436-70576c215feb.png)
![MAX first editor spacing top in](https://user-images.githubusercontent.com/46056662/126171158-da40cd7d-3a7e-4184-bb5c-79a7c45d8e48.png)
![MAX first spacing top in](https://user-images.githubusercontent.com/46056662/126171164-22d06e8e-2156-4ab9-8cb9-c204be453b2d.png)


**What is corrected and how it used to be:**

![wrong](https://user-images.githubusercontent.com/46056662/126172148-f3d0377f-97c5-4e90-a6d7-54d8e8da9b32.png)
