### PR TITLE
Set only variables custom

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -613,7 +613,7 @@ class Components
 		}
 
 		// Bailout if manifest is missing variables key.
-		if (!isset($manifest['variables'])) {
+		if (!isset($manifest['variables']) && !isset($manifest['variablesCustom'])) {
 			return '';
 		}
 
@@ -624,7 +624,7 @@ class Components
 		asort($breakpoints);
 
 		// Define variables from manifest.
-		$variables = $manifest['variables'];
+		$variables = $manifest['variables'] ?? [];
 
 		// Define responsiveAttributes from manifest.
 		$responsiveAttributes = $manifest['responsiveAttributes'] ?? [];
@@ -665,8 +665,10 @@ class Components
 			$data = self::setVariablesToBreakpoints($attributes, $responsiveVariables, $data, $manifest);
 		}
 
-		// Iterate each variable.
-		$data = self::setVariablesToBreakpoints($attributes, $variables, $data, $manifest);
+		if (!empty($variables)) {
+			// Iterate each variable.
+			$data = self::setVariablesToBreakpoints($attributes, $variables, $data, $manifest);
+		}
 
 		// Loop data and provide correct selectors from data array.
 		foreach ($data as $values) {


### PR DESCRIPTION
Changelog:
- changed condition for bailout

I've noticed that one block couldn't publish only custom CSS variable(translating from wrapper variable to block variable one). So I made these changes.

Use case:
<img width="646" alt="Screen Shot 2021-07-20 at 9 18 02 AM" src="https://user-images.githubusercontent.com/46056662/126278360-b830f5be-3bea-45b8-bc2c-80867a247abe.png">


Screenshots:
![front - varcustom](https://user-images.githubusercontent.com/46056662/126278259-b4d535a1-498a-4760-94a7-173a717c4d00.png)

