### PR TITLE
Feature/all blocks

### DIFF
--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Class that hold abstractions for for Blocks CLI
+ *
+ * @package EightshiftLibs\Blocks
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftLibs\Blocks;
+
+use EightshiftLibs\Cli\AbstractCli;
+
+/**
+ * Abstract class used for Blocks and Components
+ */
+abstract class AbstractBlocksCli extends AbstractCli
+{
+	/**
+	 * Move block/component to project folder.
+	 *
+	 * @param array $assocArgs Array of arguments from WP-CLI command.
+	 * @param string $outputDir Output dir path.
+	 * @param bool $isComponents Is output used for components.
+	 *
+	 * @return void
+	 */
+	protected function blocksMove(array $assocArgs, string $outputDir, bool $isComponents = false): void
+	{
+		// Get Props.
+		$name = $assocArgs['name'] ?? '';
+
+		// Set optional arguments.
+		$skipExisting = $this->getSkipExisting($assocArgs);
+
+		$root = $this->getProjectRootPath();
+		$rootNode = $this->getFrontendLibsBlockPath();
+
+		$sourcePathFolder = "{$rootNode}/{$outputDir}/";
+
+		$blocks = [];
+		$blocks = scandir($sourcePathFolder);
+		$blocksFullList = array_diff((array)$blocks, ['..', '.']);
+
+		$blocks = [$name];
+
+		if ($name === 'all') {
+			$skipExisting = true;
+			$blocks = $blocksFullList;
+		}
+
+		foreach ($blocks as $block) {
+			$path = "{$outputDir}/{$block}";
+			$sourcePath = "{$sourcePathFolder}{$block}";
+
+			if (!getenv('TEST')) {
+				$destinationPath = $root . '/' . $path;
+			} else {
+				$destinationPath = $this->getProjectRootPath(true) . '/cliOutput';
+			}
+
+			$typePlural = !$isComponents ?  'blocks' : 'components';
+			$typeSingular = !$isComponents ?  'block' : 'component';
+
+			// Source doesn't exist.
+			if (!file_exists($sourcePath)) {
+				$blocksList = implode(PHP_EOL, $blocksFullList);
+
+				\WP_CLI::log(
+					"Please check the docs for all available {$typePlural}."
+				);
+				\WP_CLI::log(
+					"You can find all available {$typePlural} on this link: https://infinum.github.io/eightshift-docs/storybook/."
+				);
+				\WP_CLI::log(
+					"Or here is the list of all available {$typeSingular} names: \n{$blocksList}"
+				);
+
+				self::cliError("The {$typeSingular} '{$sourcePath}' doesn\'t exist in our library.");
+			}
+
+			// Destination exists.
+			if (file_exists($destinationPath) && $skipExisting === false) {
+				self::cliError(
+					sprintf(
+						'The %s in you project exists on this "%s" path. Please check or remove that folder before running this command again.',
+						$typeSingular,
+						$destinationPath,
+					)
+				);
+			}
+
+			$this->moveBlock($destinationPath, $sourcePath, $block, $assocArgs, $path, $typeSingular);
+		}
+
+		\WP_CLI::success('Please start `npm start` again to make sure everything works correctly.');
+	}
+
+	/**
+	 * Move block/component from frontend libs to project.
+	 *
+	 * @param string $destinationPath Path where to move.
+	 * @param string $sourcePath Path of the block/component.
+	 * @param string $name Name of block/component.
+	 * @param array $assocArgs WP-CLI command arguments.
+	 * @param string $path Path to write.
+	 * @param string $typeSingular If block or component output string.
+	 *
+	 * @return void
+	 */
+	private function moveBlock(string $destinationPath, string $sourcePath, string $name, array $assocArgs, string $path, string $typeSingular): void
+	{
+		system("mkdir -p {$destinationPath}/");
+
+		system("cp -R {$sourcePath}/. {$destinationPath}/");
+
+		$typeSingular = ucfirst($typeSingular);
+
+		\WP_CLI::success("{$typeSingular} successfully moved to your project.");
+
+		\WP_CLI::log('--------------------------------------------------');
+
+		foreach ($this->getFullBlocksFiles($name) as $file) {
+			// Set output file path.
+			$class = $this->getExampleTemplate($destinationPath, $file, true);
+
+			if (!empty($class->fileContents)) {
+				$class->renameProjectName($assocArgs)
+					->renameNamespace($assocArgs)
+					->renameTextDomainFrontendLibs($assocArgs)
+					->renameUseFrontendLibs($assocArgs)
+					->outputWrite($path, $file, ['skip_existing' => true]);
+			}
+		}
+
+		\WP_CLI::log('--------------------------------------------------');
+	}
+}

--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -45,7 +45,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 
 		$blocks = [$name];
 
-		// If you pass a name all it will move all blocks/components to the project.
+		// If you pass a name "all" it will move all blocks/components to the project.
 		if ($name === 'all') {
 			$skipExisting = true;
 			$blocks = $blocksFullList;

--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -45,11 +45,13 @@ abstract class AbstractBlocksCli extends AbstractCli
 
 		$blocks = [$name];
 
+		// If you pass a name all it will move all blocks/components to the project.
 		if ($name === 'all') {
 			$skipExisting = true;
 			$blocks = $blocksFullList;
 		}
 
+		// Iterate blocks/components.
 		foreach ($blocks as $block) {
 			$path = "{$outputDir}/{$block}";
 			$sourcePath = "{$sourcePathFolder}{$block}";
@@ -65,6 +67,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 
 			// Source doesn't exist.
 			if (!file_exists($sourcePath)) {
+				// Make a list for output.
 				$blocksList = implode(PHP_EOL, $blocksFullList);
 
 				\WP_CLI::log(
@@ -91,6 +94,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 				);
 			}
 
+			// Move all files from library to project.
 			$this->moveBlock($destinationPath, $sourcePath, $block, $assocArgs, $path, $typeSingular);
 		}
 
@@ -111,8 +115,10 @@ abstract class AbstractBlocksCli extends AbstractCli
 	 */
 	private function moveBlock(string $destinationPath, string $sourcePath, string $name, array $assocArgs, string $path, string $typeSingular): void
 	{
+		// Create folder in project if missing.
 		system("mkdir -p {$destinationPath}/");
 
+		// Move block/component to project folder.
 		system("cp -R {$sourcePath}/. {$destinationPath}/");
 
 		$typeSingular = ucfirst($typeSingular);
@@ -121,6 +127,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 
 		\WP_CLI::log('--------------------------------------------------');
 
+		// Move all files from library to project.
 		foreach ($this->getFullBlocksFiles($name) as $file) {
 			// Set output file path.
 			$class = $this->getExampleTemplate($destinationPath, $file, true);

--- a/src/Blocks/BlockCli.php
+++ b/src/Blocks/BlockCli.php
@@ -10,12 +10,10 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Blocks;
 
-use EightshiftLibs\Cli\AbstractCli;
-
 /**
  * Class BlockCli
  */
-class BlockCli extends AbstractCli
+class BlockCli extends AbstractBlocksCli
 {
 
 	/**
@@ -71,84 +69,6 @@ class BlockCli extends AbstractCli
 
 	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
-		// Get Props.
-		$name = $assocArgs['name'] ?? '';
-
-		// Set optional arguments.
-		$skipExisting = $this->getSkipExisting($assocArgs);
-
-		$root = $this->getProjectRootPath();
-		$rootNode = $this->getFrontendLibsBlockPath();
-
-		$path = static::OUTPUT_DIR . '/' . $name;
-		$sourcePathFolder = $rootNode . '/' . static::OUTPUT_DIR . '/';
-		$sourcePath = "{$sourcePathFolder}{$name}";
-
-		if (!getenv('TEST')) {
-			$destinationPath = $root . '/' . $path;
-		} else {
-			$destinationPath = $this->getProjectRootPath(true) . '/cliOutput';
-		}
-
-		// Source doesn't exist.
-		if (!file_exists($sourcePath)) {
-			$nameList = '';
-			$filesList = scandir($sourcePathFolder);
-
-			if (!$filesList) {
-				self::cliError("The folder in the '{$sourcePath}' seems to be empty.");
-			}
-
-			foreach (array_diff((array)$filesList, ['..', '.']) as $item) {
-				$nameList .= "- {$item} \n";
-			}
-
-			\WP_CLI::log(
-				"Please check the docs for all available blocks."
-			);
-			\WP_CLI::log(
-				"You can find all available blocks on this link: https://infinum.github.io/eightshift-docs/storybook/."
-			);
-			\WP_CLI::log(
-				"Or here is the list of all available block names: \n{$nameList}"
-			);
-
-			self::cliError("The block '{$sourcePath}' doesn\'t exist in our library.");
-		}
-
-		// Destination exists.
-		if (file_exists($destinationPath) && $skipExisting === false) {
-			self::cliError(
-				sprintf(
-					'The block in you project exists on this "%s" path. Please check or remove that folder before running this command again.',
-					$destinationPath
-				)
-			);
-		} else {
-			system("mkdir -p {$destinationPath}/");
-		}
-
-		system("cp -R {$sourcePath}/. {$destinationPath}/");
-
-		\WP_CLI::success('Block successfully moved to your project.');
-
-		\WP_CLI::log('--------------------------------------------------');
-
-		foreach ($this->getFullBlocksFiles($name) as $file) {
-			// Set output file path.
-			$class = $this->getExampleTemplate($destinationPath, $file, true);
-
-			if (!empty($class->fileContents)) {
-				$class->renameProjectName($assocArgs)
-					->renameNamespace($assocArgs)
-					->renameTextDomainFrontendLibs($assocArgs)
-					->renameUseFrontendLibs($assocArgs)
-					->outputWrite($path, $file, ['skip_existing' => true]);
-			}
-		}
-
-		\WP_CLI::log('--------------------------------------------------');
-
-		\WP_CLI::success('Please start `npm start` again to make sure everything works correctly.');
+		$this->blocksMove($assocArgs, static::OUTPUT_DIR);
 	}
 }

--- a/src/Blocks/BlockComponentCli.php
+++ b/src/Blocks/BlockComponentCli.php
@@ -10,12 +10,10 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Blocks;
 
-use EightshiftLibs\Cli\AbstractCli;
-
 /**
  * Class BlockComponentCli
  */
-class BlockComponentCli extends AbstractCli
+class BlockComponentCli extends AbstractBlocksCli
 {
 
 	/**
@@ -71,83 +69,6 @@ class BlockComponentCli extends AbstractCli
 
 	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
-		// Get Props.
-		$name = $assocArgs['name'] ?? '';
-
-		// Set optional arguments.
-		$skipExisting = $this->getSkipExisting($assocArgs);
-
-		$root = $this->getProjectRootPath();
-		$rootNode = $this->getFrontendLibsBlockPath();
-
-		$path = static::OUTPUT_DIR . '/' . $name;
-		$sourcePathFolder = $rootNode . '/' . static::OUTPUT_DIR . '/';
-		$sourcePath = "{$sourcePathFolder}{$name}";
-
-		if (!getenv('TEST')) {
-			$destinationPath = $root . '/' . $path;
-		} else {
-			$destinationPath = $this->getProjectRootPath(true) . '/cliOutput';
-		}
-
-		// Source doesn't exist.
-		if (!file_exists($sourcePath)) {
-			$nameList = '';
-			$filesList = scandir($sourcePathFolder);
-
-			if (!$filesList) {
-				self::cliError("The folder in the '{$sourcePath}' seems to be empty.");
-			}
-
-			foreach (array_diff((array)$filesList, ['..', '.']) as $item) {
-				$nameList .= "- {$item} \n";
-			}
-
-			\WP_CLI::log(
-				"Please check the docs for all available components."
-			);
-			\WP_CLI::log(
-				"You can find all available components on this link: https://infinum.github.io/eightshift-docs/storybook/."
-			);
-			\WP_CLI::log(
-				"Or here is the list of all available component names: \n{$nameList}"
-			);
-
-			self::cliError("The component '{$sourcePath}' doesn\'t exist in our library.");
-		}
-
-		// Destination exists.
-		if (file_exists($destinationPath) && $skipExisting === false) {
-			self::cliError(
-				/* translators: %s will be replaced with the path. */
-				sprintf(
-					'The component in you project exists on this "%s" path. Please check or remove that folder before running this command again.',
-					$destinationPath
-				)
-			);
-		}
-
-		system("cp -R {$sourcePath}/. {$destinationPath}/");
-
-		\WP_CLI::success('Component successfully moved to your project.');
-
-		\WP_CLI::log('--------------------------------------------------');
-
-		foreach ($this->getFullBlocksFiles($name) as $file) {
-			// Set output file path.
-			$class = $this->getExampleTemplate($destinationPath, $file, true);
-
-			if (!empty($class->fileContents)) {
-				$class->renameProjectName($assocArgs)
-				->renameNamespace($assocArgs)
-				->renameTextDomainFrontendLibs($assocArgs)
-				->renameUseFrontendLibs($assocArgs)
-				->outputWrite($path, $file, ['skip_existing' => true]);
-			}
-		}
-
-		\WP_CLI::log('--------------------------------------------------');
-
-		\WP_CLI::success('Please start `npm start` again to make sure everything works correctly.');
+		$this->blocksMove($assocArgs, static::OUTPUT_DIR, true);
 	}
 }

--- a/src/Cli/CliInitTheme.php
+++ b/src/Cli/CliInitTheme.php
@@ -18,7 +18,6 @@ use EightshiftLibs\Enqueue\Theme\EnqueueThemeCli;
 use EightshiftLibs\Main\MainCli;
 use EightshiftLibs\Manifest\ManifestCli;
 use EightshiftLibs\Menu\MenuCli;
-use EightshiftLibs\Readme\ReadmeCli;
 
 /**
  * Class CliInitTheme


### PR DESCRIPTION
abstracting command to move blocks/components to the project because they are 99% the same and making the option to iterate multiple bocks in one go, also adding option to move all blocks/components to the project for debugging and develop purposes. 

to move all components use this command:
`wp boilerplate use_component --name='all'`

to move all blocks use this command:
`wp boilerplate use_block --name='all'`


⚠️ Test are failing do to the issue in the Components Helper with css variables. I have notified @goranalkovic-infinum and @volfkarlo  about that