### PR TITLE
Fix for default breakpoints

### DIFF
--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -429,7 +429,7 @@ test('Asserts that outputCssVariables returns the correct CSS variables output f
 	$this->assertIsString($output);
 	$this->assertStringContainsString('<style>', $output);
 	$this->assertStringContainsString('--variable-default: default;', $output);
-	$this->assertStringContainsString('@media (min-width: 1200px)', $output);
+	$this->assertStringContainsString('@media (min-width: 1199px)', $output);
 	$this->assertStringContainsString('--variable-default-large: large;', $output);
 	$this->assertStringContainsString('--variable-default-tablet: test;', $output);
 	$this->assertStringContainsString(".variables[data-id='uniqueString']", $output);
@@ -474,7 +474,7 @@ test('Asserts that outputCssVariables returns the correct CSS variables output f
 	$this->assertIsString($output);
 	$this->assertStringContainsString('<style>', $output);
 	$this->assertStringContainsString('--variable-value-default: default;', $output);
-	$this->assertStringContainsString('@media (min-width: 991px)', $output);
+	$this->assertStringContainsString('@media (min-width: 767px)', $output);
 	$this->assertStringContainsString('--variable-value-tablet: tablet;', $output);
 	$this->assertStringContainsString(".variables[data-id='uniqueString']", $output);
 });
@@ -814,7 +814,7 @@ test('Asserts that only responsive variables are defined', function () {
 	$this->assertIsString($output);
 	$this->assertStringContainsString('<style>', $output);
 	$this->assertStringContainsString("variable-default-responsive: default-responsive-{$value}", $output);
-	$this->assertStringContainsString('@media (min-width: 1199px)', $output);
+	$this->assertStringContainsString('@media (min-width: 991px)', $output);
 	$this->assertStringContainsString("variable-default: default-responsive-{$value}", $output);
 	$this->assertStringNotContainsString("variable-default-normal: default-desktop-{$value}", $output);
 });
@@ -839,7 +839,7 @@ test('Asserts that responsive variables and default variables are defined', func
 	$this->assertStringContainsString('<style>', $output);
 	$this->assertStringContainsString('variable-value-default-responsive: value1-responsive', $output);
 	$this->assertStringContainsString('variable-value-default-responsive: value2-responsive', $output);
-	$this->assertStringContainsString('@media (min-width: 1199px)', $output);
+	$this->assertStringContainsString('@media (min-width: 991px)', $output);
 	$this->assertStringContainsString('variable-value-default: value2-desktop', $output);
 	$this->assertStringContainsString('variable-value-default: value1-mobile', $output);
 


### PR DESCRIPTION
There's been an issue in a case where you put `"breakpoint": "mobile"` in mobile-first "mode" in responsive or the largest breakpoint in the `inverse: true`, desktop-first responsive "mode".

The issue is resolved by adding default breakpoints recognition. By recognizing the default breakpoint, the breakpoint is reset to value 'default' which allows the variable to be set in a 'default' mode by setting the breakpoint.

Screenshots
![Screen Shot 2021-07-23 at 9 27 26 AM](https://user-images.githubusercontent.com/46056662/126754194-fd3875cf-736a-408e-b357-6cb3eba640a2.png)
![Screen Shot 2021-07-23 at 9 27 55 AM](https://user-images.githubusercontent.com/46056662/126754198-60b98a30-3035-4d59-aaac-7432094c16b9.png)
![Screen Shot 2021-07-23 at 9 28 13 AM](https://user-images.githubusercontent.com/46056662/126754200-9d101fc6-e327-4dc3-847c-839e9207d50b.png)
![Screen Shot 2021-07-23 at 9 28 38 AM](https://user-images.githubusercontent.com/46056662/126754202-3e27ad9f-4126-4897-969f-04f3121e037c.png)
![Screen Shot 2021-07-23 at 9 31 08 AM](https://user-images.githubusercontent.com/46056662/126754204-188805fc-e673-4892-9ced-9cc71ba23603.png)
![Screen Shot 2021-07-23 at 9 27 02 AM](https://user-images.githubusercontent.com/46056662/126754193-224bdebe-9308-45c2-b7a9-e2c48a2c68f8.png)
