### PR TITLE
Fix variable type errors in Components::variablesInner on PHP 8  

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -865,7 +865,7 @@ class Components
 
 			// If value contains magic variable swap that variable with original attribute value.
 			if (strpos($variableValue, '%value%') !== false) {
-				$variableValue = str_replace('%value%', $attributeValue, $variableValue);
+				$variableValue = str_replace('%value%', (string)$attributeValue, $variableValue);
 			}
 
 			// Output the custom CSS variable by adding the attribute key + custom object key.


### PR DESCRIPTION
The `Components::variablesInner` function is defined with a mixed type parameter `$attributeValue` which is then passed to `str_replace` as a parameter. 

Since PHP 8, [types for internal functions](https://externals.io/message/106522) have been added, including for [str_replace](https://www.php.net/str_replace), so passing anything other than a `string|array` to str_replace throws a fatal error.

As it's sometimes needed to pass an int to variablesInner (for example, in the columns block in https://github.com/infinum/eightshift-frontend-libs/pull/414), it makes sense to cast this parameter to string. 