### PR TITLE
Fix extra spaces

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -60,7 +60,7 @@ class Components
 	 */
 	public static function classnames(array $classes): string
 	{
-		return trim(implode(' ', $classes));
+		return trim(implode(' ', array_filter($classes)));
 	}
 
 	/**


### PR DESCRIPTION
Removes the annoying extra spaces in class string if any of the classes inside the array is empty string (which tends to happen a lot).