### PR TITLE
Added undefined attribute option to checkAttr and checkAttrResponsive helpers

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -230,15 +230,16 @@ class Components
 	 * Check if attribute exist in attributes list and add default value if not.
 	 * This is used because Block editor will not output attributes that don't have a default value.
 	 *
-	 * @param string               $key Key to check.
+	 * @param string $key Key to check.
 	 * @param array<string, mixed> $attributes Array of attributes.
 	 * @param array<string, mixed> $manifest Array of default attributes from manifest.json.
+	 * @param bool $undefinedAllowed Allowed detection of undefined values.
 	 *
 	 * @throws \Exception When we're unable to find the component by $component.
 	 *
 	 * @return mixed
 	 */
-	public static function checkAttr(string $key, array $attributes, array $manifest)
+	public static function checkAttr(string $key, array $attributes, array $manifest, bool $undefinedAllowed = false)
 	{
 
 		// Get the correct key for the check in the attributes object.
@@ -257,6 +258,11 @@ class Components
 			} else {
 				throw new \Exception("{$key} key does not exist in the {$manifest['componentName']} component manifest. Please check your implementation.");
 			}
+		}
+
+		// If undefinedAllowed is true and attribute is missing default just return undefined to be able to unset attribute in block editor.
+		if (empty($manifestKey['default']) && $undefinedAllowed) {
+			return;
 		}
 
 		$defaultType = $manifestKey['type'];
@@ -283,13 +289,14 @@ class Components
 	 * @param string $keyName Key name to find in the responsiveAttributes object.
 	 * @param array<string, mixed> $attributes Array of attributes.
 	 * @param array<string, mixed> $manifest Array of default attributes from manifest.json.
+	 * @param bool $undefinedAllowed Allowed detection of undefined values.
 	 *
 	 * @throws \Exception If missing responsiveAttributes or keyName in responsiveAttributes.
 	 * @throws \Exception If missing keyName in responsiveAttributes.
 	 *
 	 * @return array<mixed>
 	 */
-	public static function checkAttrResponsive(string $keyName, array $attributes, array $manifest): array
+	public static function checkAttrResponsive(string $keyName, array $attributes, array $manifest, bool $undefinedAllowed = false): array
 	{
 		$output = [];
 
@@ -306,7 +313,7 @@ class Components
 		}
 
 		foreach ($manifest['responsiveAttributes'][$keyName] as $key => $value) {
-			$output[$key] = self::checkAttr($value, $attributes, $manifest);
+			$output[$key] = self::checkAttr($value, $attributes, $manifest, $undefinedAllowed);
 		}
 
 		return $output;

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -260,7 +260,7 @@ class Components
 			}
 		}
 
-		// If undefinedAllowed is true and attribute is missing default just return undefined to be able to unset attribute in block editor.
+		// If undefinedAllowed is true and attribute is missing default just return null to be able to recognize non set variable.
 		if (empty($manifestKey['default']) && $undefinedAllowed) {
 			return;
 		}

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -168,7 +168,7 @@ test('Asserts that checkAttr works in case attribute is boolean', function () {
 
 	$results = Components::checkAttr('buttonIsAnchor', $attributes, $manifest);
 
-	$this->assertIsBool($results, 'THe result should be a boolean');
+	$this->assertIsBool($results, 'The result should be a boolean');
 	$this->assertSame(true, $results, "The set attribute should be {$attributes['buttonIsAnchor']}");
 });
 
@@ -178,7 +178,7 @@ test('Asserts that checkAttr returns false in case attribute is boolean and defa
 
 	$results = Components::checkAttr('buttonIsNewTab', $attributes, $manifest);
 
-	$this->assertIsBool($results, 'THe result should be a boolean');
+	$this->assertIsBool($results, 'The result should be a boolean');
 	$this->assertSame(false, $results, "The set attribute should be false");
 });
 
@@ -188,7 +188,7 @@ test('Asserts that checkAttr returns null in case attribute is boolean, default 
 
 	$results = Components::checkAttr('buttonIsNewTab', $attributes, $manifest, true);
 
-	$this->assertIsNotBool($results, 'THe result should not be a boolean');
+	$this->assertIsNotBool($results, 'The result should not be a boolean');
 	$this->assertSame(null, $results, "The set attribute should be null");
 });
 

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -182,6 +182,16 @@ test('Asserts that checkAttr returns false in case attribute is boolean and defa
 	$this->assertSame(false, $results, "The set attribute should be false");
 });
 
+test('Asserts that checkAttr returns null in case attribute is boolean, default is not set and undefined is allowed', function () {
+	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$attributes['buttonIsAnchor'] = true;
+
+	$results = Components::checkAttr('buttonIsNewTab', $attributes, $manifest, true);
+
+	$this->assertIsNotBool($results, 'THe result should not be a boolean');
+	$this->assertSame(null, $results, "The set attribute should be null");
+});
+
 test('Asserts that checkAttr works in case attribute is array', function () {
 	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['buttonAttrs'] = ['attr 1', 'attr 2'];
@@ -201,6 +211,16 @@ test('Asserts that checkAttr returns empty array in case attribute is array or o
 
 	$this->assertIsArray($results, 'The result should be an empty array');
 	$this->assertSame([], $results, "The set attribute should be empty array");
+});
+
+test('Asserts that checkAttr returns null in case attribute is array or object, default is not set, and undefined is allowed', function () {
+	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$attributes['buttonSize'] = 'large';
+
+	$results = Components::checkAttr('buttonAttrs', $attributes, $manifest, true);
+
+	$this->assertIsNotArray($results, 'The result should not be an empty array');
+	$this->assertSame(null, $results, "The set attribute should be null");
 });
 
 test('Asserts that checkAttr returns default value', function () {
@@ -261,6 +281,23 @@ test('Asserts that checkAttrResponsive returns empty values if attribute is not 
 	$this->assertIsArray($results, 'Result should be an array');
 	$this->assertArrayHasKey('large', $results);
 	$this->assertSame($results['large'], '');
+});
+
+test('Asserts that checkAttrResponsive returns null if default is not set and undefined is allowed.', function () {
+	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
+	$attributes = [
+		'headingContentSpacingDesktop' => '2'
+	];
+
+	$results = Components::checkAttrResponsive('headingContentSpacing', $attributes, $manifest, true);
+
+	$this->assertIsArray($results, 'Result should be an array');
+	$this->assertArrayHasKey('large', $results);
+	$this->assertArrayHasKey('desktop', $results);
+	$this->assertArrayHasKey('tablet', $results);
+	$this->assertSame($results['large'], null);
+	$this->assertSame($results['desktop'], '2');
+	$this->assertSame($results['tablet'], null);
 });
 
 test('Asserts that checkAttrResponsive throws error if responsiveAttribute key is missing.', function () {


### PR DESCRIPTION
Changelog:
- added undefined attribute option to checkAttr and checkAttrResponsive helper

Note:
I tried to detect whether the value of a responsive attribute is false or not set(what we need from inheriting) and it turned out I can't distinguish that one with checkAttr nor checkAttrResponsive helpers.

So I figured this could be a reasonable approach. Even though it's technically different from the JS implementation(JS makes difference between `undefined` and `null`). I believe setting parameters to `NULL` makes perfect sense in PHP part.

The reasoning is that in PHP when a variable is unset or not set it is represented as "NULL" if you try to make something with it(even if you check the variable with a function `isset` result is `false`). That's why I believe that setting values to `NULL` when they should represent the JS' "undefined" should be ok.