### PR TITLE
Convert variable to string when replacing value

### DIFF
--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -872,7 +872,7 @@ class Components
 
 			// If value contains magic variable swap that variable with original attribute value.
 			if (strpos($variableValue, '%value%') !== false) {
-				$variableValue = str_replace('%value%', $attributeValue, $variableValue);
+				$variableValue = str_replace('%value%', (string) $attributeValue, $variableValue);
 			}
 
 			// Output the custom CSS variable by adding the attribute key + custom object key.


### PR DESCRIPTION
When looping through css variables, some values are passed as integers. Using `str_replace()` in internal helper `variablesInner` throws fatal error on integers. Convert it to string when replacing value.