### PR TITLE
A11y improvements

### DIFF
--- a/src/Media/MediaExample.php
+++ b/src/Media/MediaExample.php
@@ -41,7 +41,9 @@ class MediaExample implements ServiceInterface
 	public function addThemeSupport(): void
 	{
 		\add_theme_support('title-tag');
-		\add_theme_support('html5');
+		\add_theme_support('html5', ['style', 'script']); 
+		// Enables HTML5 markup support and explicitly states support for script and style tags, so WP doesn't insert the type attribute on those tags.
+		// Registering the type attribute is not compliant with the HTML5 specification.
 		\add_theme_support('post-thumbnails');
 	}
 }

--- a/src/Media/MediaExample.php
+++ b/src/Media/MediaExample.php
@@ -41,7 +41,7 @@ class MediaExample implements ServiceInterface
 	public function addThemeSupport(): void
 	{
 		\add_theme_support('title-tag');
-		\add_theme_support('html5', ['style', 'script']); 
+		\add_theme_support('html5', ['style', 'script']);
 		// Enables HTML5 markup support and explicitly states support for script and style tags, so WP doesn't insert the type attribute on those tags.
 		// Registering the type attribute is not compliant with the HTML5 specification.
 		\add_theme_support('post-thumbnails');


### PR DESCRIPTION
This PR fixes these issues reported in https://github.com/infinum/eightshift-frontend-libs/issues/491:

- [x] "The type attribute is unnecessary for JavaScript resources."
- [x] "The type attribute for the style element is not needed and should be omitted."
- [x] "Element head is missing a required instance of child element title."