### PR TITLE
Gutenberg internationalization and PHPCS fix

### DIFF
--- a/src/AdminMenus/AbstractAdminMenu.php
+++ b/src/AdminMenus/AbstractAdminMenu.php
@@ -21,7 +21,6 @@ use EightshiftLibs\Blocks\RenderableBlockInterface;
  */
 abstract class AbstractAdminMenu implements ServiceInterface, RenderableBlockInterface
 {
-
 	/**
 	 * Register all the hooks
 	 *

--- a/src/AdminMenus/AbstractAdminSubMenu.php
+++ b/src/AdminMenus/AbstractAdminSubMenu.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\AdminMenus;
  */
 abstract class AbstractAdminSubMenu extends AbstractAdminMenu
 {
-
 	/**
 	 * Register all the hooks
 	 *

--- a/src/AdminMenus/AdminSubMenuCli.php
+++ b/src/AdminMenus/AdminSubMenuCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class AdminSubMenuCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/BlockPatterns/AbstractBlockPattern.php
+++ b/src/BlockPatterns/AbstractBlockPattern.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractBlockPattern implements ServiceInterface
 {
-
 	/**
 	 * Register block pattern.
 	 *

--- a/src/BlockPatterns/BlockPatternCli.php
+++ b/src/BlockPatterns/BlockPatternCli.php
@@ -18,7 +18,6 @@ use EightshiftLibs\Cli\CliHelpers;
  */
 class BlockPatternCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/BlockPatterns/BlockPatternExample.php
+++ b/src/BlockPatterns/BlockPatternExample.php
@@ -17,7 +17,6 @@ use EightshiftLibs\BlockPatterns\AbstractBlockPattern;
  */
 class BlockPatternExample extends AbstractBlockPattern
 {
-
 	/**
 	 * Get the pattern categories.
 	 *

--- a/src/Blocks/AbstractBlocks.php
+++ b/src/Blocks/AbstractBlocks.php
@@ -21,7 +21,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterface
 {
-
 	/**
 	 * Full data of blocks, settings and wrapper data.
 	 *

--- a/src/Blocks/BlockVariationCli.php
+++ b/src/Blocks/BlockVariationCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class BlockVariationCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path
 	 *

--- a/src/Blocks/BlockWrapperCli.php
+++ b/src/Blocks/BlockWrapperCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class BlockWrapperCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path
 	 *

--- a/src/Blocks/BlocksCli.php
+++ b/src/Blocks/BlocksCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class BlocksCli extends AbstractCli
 {
-
 	/**
 	 * Toggle to see if this is running inside tests or not
 	 *

--- a/src/Blocks/BlocksExample.php
+++ b/src/Blocks/BlocksExample.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Blocks\AbstractBlocks;
  */
 class BlocksExample extends AbstractBlocks
 {
-
 	/**
 	 * Reusable blocks Capability Name.
 	 */

--- a/src/Blocks/BlocksStorybookCli.php
+++ b/src/Blocks/BlocksStorybookCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class BlocksStorybookCli extends AbstractCli
 {
-
 	/**
 	 * Get WPCLI command doc
 	 *

--- a/src/Blocks/RenderableBlockInterface.php
+++ b/src/Blocks/RenderableBlockInterface.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\Blocks;
  */
 interface RenderableBlockInterface
 {
-
 	/**
 	 * Provides block registration render callback method.
 	 *

--- a/src/CiExclude/CiExcludeCli.php
+++ b/src/CiExclude/CiExcludeCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class CiExcludeCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path
 	 *

--- a/src/Cli/CliInterface.php
+++ b/src/Cli/CliInterface.php
@@ -12,7 +12,6 @@ namespace EightshiftLibs\Cli;
 
 interface CliInterface
 {
-
 	/**
 	 * Register method for WPCLI command
 	 *

--- a/src/Cli/CliReset.php
+++ b/src/Cli/CliReset.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\Cli;
  */
 class CliReset extends AbstractCli
 {
-
 	/**
 	 * Get WPCLI command name.
 	 *

--- a/src/Cli/CliRunAll.php
+++ b/src/Cli/CliRunAll.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\Cli;
  */
 class CliRunAll extends AbstractCli
 {
-
 	/**
 	 * Get WPCLI command name
 	 *

--- a/src/Cli/CliShowAll.php
+++ b/src/Cli/CliShowAll.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\Cli;
  */
 class CliShowAll extends AbstractCli
 {
-
 	/**
 	 * Get WPCLI command name
 	 *

--- a/src/Columns/PostType/AbstractPostTypeColumns.php
+++ b/src/Columns/PostType/AbstractPostTypeColumns.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractPostTypeColumns implements ServiceInterface
 {
-
 	/**
 	 * Register the post columns and content in them.
 	 *

--- a/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
+++ b/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractTaxonomyColumns implements ServiceInterface
 {
-
 	/**
 	 * Register the taxonomy columns and content in them.
 	 *

--- a/src/Columns/User/AbstractUserColumns.php
+++ b/src/Columns/User/AbstractUserColumns.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractUserColumns implements ServiceInterface
 {
-
 	/**
 	 * Register the user columns and content in them.
 	 *

--- a/src/Config/AbstractConfigData.php
+++ b/src/Config/AbstractConfigData.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Exception\InvalidPath;
  */
 abstract class AbstractConfigData implements ConfigDataInterface
 {
-
 	/**
 	 * Return project absolute path.
 	 *

--- a/src/Config/ConfigCli.php
+++ b/src/Config/ConfigCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class ConfigCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/Config/ConfigDataInterface.php
+++ b/src/Config/ConfigDataInterface.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\Config;
  */
 interface ConfigDataInterface
 {
-
 	/**
 	 * Method that returns project name.
 	 *

--- a/src/Config/ConfigExample.php
+++ b/src/Config/ConfigExample.php
@@ -20,7 +20,6 @@ use EightshiftLibs\Config\AbstractConfigData;
  */
 class ConfigExample extends AbstractConfigData
 {
-
 	/**
 	 * Method that returns project name.
 	 *

--- a/src/ConfigProject/ConfigProjectCli.php
+++ b/src/ConfigProject/ConfigProjectCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class ConfigProjectCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/CustomMeta/AbstractAcfMeta.php
+++ b/src/CustomMeta/AbstractAcfMeta.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractAcfMeta implements ServiceInterface
 {
-
 	/**
 	 * Register custom acf meta.
 	 *

--- a/src/CustomMeta/AcfMetaCli.php
+++ b/src/CustomMeta/AcfMetaCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class AcfMetaCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/CustomMeta/AcfMetaExample.php
+++ b/src/CustomMeta/AcfMetaExample.php
@@ -17,7 +17,6 @@ use EightshiftLibs\CustomMeta\AbstractAcfMeta;
  */
 class AcfMetaExample extends AbstractAcfMeta
 {
-
 	/**
 	 * Render acf fields.
 	 *

--- a/src/CustomPostType/AbstractPostType.php
+++ b/src/CustomPostType/AbstractPostType.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractPostType implements ServiceInterface
 {
-
 	/**
 	 * Register custom post type.
 	 *

--- a/src/CustomPostType/LabelGenerator.php
+++ b/src/CustomPostType/LabelGenerator.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Exception\InvalidNouns;
  */
 final class LabelGenerator
 {
-
 	/**
 	 * Singular name UC Constant
 	 *

--- a/src/CustomPostType/PostTypeCli.php
+++ b/src/CustomPostType/PostTypeCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class PostTypeCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/CustomPostType/PostTypeExample.php
+++ b/src/CustomPostType/PostTypeExample.php
@@ -17,7 +17,6 @@ use EightshiftLibs\CustomPostType\AbstractPostType;
  */
 class PostTypeExample extends AbstractPostType
 {
-
 	/**
 	 * Post type slug constant.
 	 *

--- a/src/CustomTaxonomy/AbstractTaxonomy.php
+++ b/src/CustomTaxonomy/AbstractTaxonomy.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractTaxonomy implements ServiceInterface
 {
-
 	/**
 	 * Register custom taxonomy.
 	 *

--- a/src/CustomTaxonomy/TaxonomyCli.php
+++ b/src/CustomTaxonomy/TaxonomyCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class TaxonomyCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/CustomTaxonomy/TaxonomyExample.php
+++ b/src/CustomTaxonomy/TaxonomyExample.php
@@ -17,7 +17,6 @@ use EightshiftLibs\CustomTaxonomy\AbstractTaxonomy;
  */
 class TaxonomyExample extends AbstractTaxonomy
 {
-
 	/**
 	 * Taxonomy slug constant.
 	 *

--- a/src/Db/ExportCli.php
+++ b/src/Db/ExportCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class ExportCli extends AbstractCli
 {
-
 	/**
 	 * Get WPCLI command name
 	 *

--- a/src/Db/ImportCli.php
+++ b/src/Db/ImportCli.php
@@ -18,7 +18,6 @@ use WP_CLI\ExitException;
  */
 class ImportCli extends AbstractCli
 {
-
 	/**
 	 * Get WPCLI command name
 	 *

--- a/src/Enqueue/AbstractAssets.php
+++ b/src/Enqueue/AbstractAssets.php
@@ -22,7 +22,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractAssets implements ServiceInterface
 {
-
 	/**
 	 * Media style const
 	 */

--- a/src/Enqueue/Admin/AbstractEnqueueAdmin.php
+++ b/src/Enqueue/Admin/AbstractEnqueueAdmin.php
@@ -20,7 +20,6 @@ use EightshiftLibs\Manifest\ManifestInterface;
  */
 abstract class AbstractEnqueueAdmin extends AbstractAssets
 {
-
 	public const ADMIN_SCRIPT_URI = 'applicationAdmin.js';
 	public const ADMIN_STYLE_URI = 'applicationAdmin.css';
 

--- a/src/Enqueue/Admin/EnqueueAdminCli.php
+++ b/src/Enqueue/Admin/EnqueueAdminCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class EnqueueAdminCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/Enqueue/Admin/EnqueueAdminExample.php
+++ b/src/Enqueue/Admin/EnqueueAdminExample.php
@@ -21,7 +21,6 @@ use EightshiftLibs\Enqueue\Admin\AbstractEnqueueAdmin;
  */
 class EnqueueAdminExample extends AbstractEnqueueAdmin
 {
-
 	/**
 	 * Create a new admin instance.
 	 *

--- a/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
+++ b/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
@@ -18,7 +18,6 @@ use EightshiftLibs\Manifest\ManifestInterface;
  */
 abstract class AbstractEnqueueBlocks extends AbstractAssets
 {
-
 	public const BLOCKS_EDITOR_SCRIPT_URI = 'applicationBlocksEditor.js';
 	public const BLOCKS_EDITOR_STYLE_URI = 'applicationBlocksEditor.css';
 

--- a/src/Enqueue/Blocks/EnqueueBlocksCli.php
+++ b/src/Enqueue/Blocks/EnqueueBlocksCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class EnqueueBlocksCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/Enqueue/Blocks/EnqueueBlocksExample.php
+++ b/src/Enqueue/Blocks/EnqueueBlocksExample.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Enqueue\Blocks\AbstractEnqueueBlocks;
  */
 class EnqueueBlocksExample extends AbstractEnqueueBlocks
 {
-
 	/**
 	 * Create a new admin instance.
 	 *

--- a/src/Enqueue/Theme/AbstractEnqueueTheme.php
+++ b/src/Enqueue/Theme/AbstractEnqueueTheme.php
@@ -18,7 +18,6 @@ use EightshiftLibs\Manifest\ManifestInterface;
  */
 abstract class AbstractEnqueueTheme extends AbstractAssets
 {
-
 	public const THEME_SCRIPT_URI = 'application.js';
 	public const THEME_STYLE_URI = 'application.css';
 

--- a/src/Enqueue/Theme/EnqueueThemeCli.php
+++ b/src/Enqueue/Theme/EnqueueThemeCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class EnqueueThemeCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/Enqueue/Theme/EnqueueThemeExample.php
+++ b/src/Enqueue/Theme/EnqueueThemeExample.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Enqueue\Theme\AbstractEnqueueTheme;
  */
 class EnqueueThemeExample extends AbstractEnqueueTheme
 {
-
 	/**
 	 * Create a new admin instance.
 	 *

--- a/src/Exception/ComponentException.php
+++ b/src/Exception/ComponentException.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\Exception;
  */
 final class ComponentException extends \InvalidArgumentException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Throws exception if ensure_string argument is invalid.
 	 *

--- a/src/Exception/FailedToLoadView.php
+++ b/src/Exception/FailedToLoadView.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Exception;
  */
 final class FailedToLoadView extends \RuntimeException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Create a new instance of the exception if the view file itself created
 	 * an exception.

--- a/src/Exception/GeneralExceptionInterface.php
+++ b/src/Exception/GeneralExceptionInterface.php
@@ -17,5 +17,4 @@ namespace EightshiftLibs\Exception;
  */
 interface GeneralExceptionInterface
 {
-
 }

--- a/src/Exception/InvalidAutowireDependency.php
+++ b/src/Exception/InvalidAutowireDependency.php
@@ -18,7 +18,6 @@ namespace EightshiftLibs\Exception;
  */
 final class InvalidAutowireDependency extends \InvalidArgumentException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Throws exception if we cant guess the class to inject.
 	 *

--- a/src/Exception/InvalidBlock.php
+++ b/src/Exception/InvalidBlock.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Exception;
  */
 final class InvalidBlock extends \InvalidArgumentException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Throws error if blocks are missing.
 	 *

--- a/src/Exception/InvalidCallback.php
+++ b/src/Exception/InvalidCallback.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Exception;
  */
 final class InvalidCallback extends \InvalidArgumentException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Create a new instance of the exception for a callback class name that is
 	 * not recognized.

--- a/src/Exception/InvalidManifest.php
+++ b/src/Exception/InvalidManifest.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Exception;
  */
 final class InvalidManifest extends \InvalidArgumentException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Throws error if manifest key is missing
 	 *

--- a/src/Exception/InvalidNouns.php
+++ b/src/Exception/InvalidNouns.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Exception;
  */
 final class InvalidNouns extends \InvalidArgumentException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Create a new instance of the exception for an array of nouns that is
 	 * missing a required key.

--- a/src/Exception/InvalidService.php
+++ b/src/Exception/InvalidService.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Exception;
  */
 final class InvalidService extends \InvalidArgumentException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Create a new instance of the exception for a service class name that is
 	 * not recognized.

--- a/src/Exception/NonPsr4CompliantClass.php
+++ b/src/Exception/NonPsr4CompliantClass.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Exception;
  */
 final class NonPsr4CompliantClass extends \InvalidArgumentException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Throws exception if class has non psr-4 compliant namespace.
 	 *

--- a/src/Exception/PluginActivationFailure.php
+++ b/src/Exception/PluginActivationFailure.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Exception;
  */
 final class PluginActivationFailure extends \RuntimeException implements GeneralExceptionInterface
 {
-
 	/**
 	 * Create a new instance of the exception in case plugin cannot be activated.
 	 *

--- a/src/GitIgnore/GitIgnoreCli.php
+++ b/src/GitIgnore/GitIgnoreCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class GitIgnoreCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Exception\ComponentException;
  */
 class Components
 {
-
 	/**
 	 * Makes sure the output is string. Useful for converting an array of components into a string.
 	 * If you pass an associative array it will output strings with keys, used for generating data-attributes from array.

--- a/src/Helpers/ErrorLoggerTrait.php
+++ b/src/Helpers/ErrorLoggerTrait.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Helpers;
  */
 trait ErrorLoggerTrait
 {
-
 	/**
 	 * Ensure correct response for rest using handler function.
 	 *

--- a/src/Helpers/ObjectHelperTrait.php
+++ b/src/Helpers/ObjectHelperTrait.php
@@ -16,7 +16,6 @@ namespace EightshiftLibs\Helpers;
  */
 trait ObjectHelperTrait
 {
-
 	/**
 	 * Check if XML is valid file used for svg.
 	 *

--- a/src/Helpers/Post.php
+++ b/src/Helpers/Post.php
@@ -16,7 +16,6 @@ namespace EightshiftLibs\Helpers;
  */
 class Post
 {
-
 	/**
 	 * Average reading speed.
 	 *

--- a/src/Helpers/Shortcode.php
+++ b/src/Helpers/Shortcode.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Helpers;
  */
 class Shortcode
 {
-
 	/**
 	 * Call a shortcode function by tag name.
 	 *

--- a/src/I18n/I18nCli.php
+++ b/src/I18n/I18nCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class I18nCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/I18n/I18nExample.php
+++ b/src/I18n/I18nExample.php
@@ -46,9 +46,9 @@ class I18nExample implements ServiceInterface
 		);
 	}
 
-
 	/**
-	 * Load the theme text domain for JavaScript translations.
+	 * Load the theme text domain for JavaScript translations
+	 *
 	 * You should export your locales as a JED file named
 	 * {textdomain}-{locale}-{handle}.json into the project path
 	 * defined below.

--- a/src/I18n/I18nExample.php
+++ b/src/I18n/I18nExample.php
@@ -29,6 +29,7 @@ class I18nExample implements ServiceInterface
 	public function register(): void
 	{
 		\add_action('after_setup_theme', [$this, 'loadThemeTextdomain'], 20);
+		\add_action('enqueue_block_editor_assets', [$this, 'setScriptTranslations'], 20);
 	}
 
 	/**
@@ -39,6 +40,26 @@ class I18nExample implements ServiceInterface
 	public function loadThemeTextdomain(): void
 	{
 		\load_theme_textdomain(
+			Config::getProjectName(),
+			Config::getProjectPath('src/I18n/languages')
+		);
+	}
+
+
+	/**
+	 * Load the theme text domain for JavaScript translations.
+	 * You should export your locales as a JED file named
+	 * {textdomain}-{locale}-{handle}.json into the project path
+	 * defined below.
+	 *
+	 * @return void
+	 */
+	public function setScriptTranslations(): void
+	{
+
+		$handle = "{$this->getAssetsPrefix()}-block-editor-scripts";
+		\wp_set_script_translations(
+			$handle,
 			Config::getProjectName(),
 			Config::getProjectPath('src/I18n/languages')
 		);

--- a/src/I18n/I18nExample.php
+++ b/src/I18n/I18nExample.php
@@ -21,7 +21,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 class I18nExample implements ServiceInterface
 {
-
 	/**
 	 * Register all the hooks
 	 *

--- a/src/I18n/I18nExample.php
+++ b/src/I18n/I18nExample.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftBoilerplate\I18n;
 
 use EightshiftBoilerplate\Config\Config;
+use EightshiftBoilerplate\Enqueue\Assets;
 use EightshiftLibs\Services\ServiceInterface;
 
 /**
@@ -56,8 +57,8 @@ class I18nExample implements ServiceInterface
 	 */
 	public function setScriptTranslations(): void
 	{
-
-		$handle = "{$this->getAssetsPrefix()}-block-editor-scripts";
+		$assetsPrefix = Assets::getAssetsPrefix();
+		$handle = "{$assetsPrefix}-block-editor-scripts";
 		\wp_set_script_translations(
 			$handle,
 			Config::getProjectName(),

--- a/src/Login/LoginCli.php
+++ b/src/Login/LoginCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class LoginCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/Login/LoginExample.php
+++ b/src/Login/LoginExample.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 class LoginExample implements ServiceInterface
 {
-
 	/**
 	 * Register all the hooks
 	 *

--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -23,7 +23,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractMain extends Autowiring implements ServiceInterface
 {
-
 	/**
 	 * Array of instantiated services.
 	 *

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 class Autowiring
 {
-
 	/**
 	 * Array of psr-4 prefixes. Should be provided by Composer's ClassLoader. $ClassLoader->getPsr4Prefixes().
 	 *

--- a/src/Main/MainCli.php
+++ b/src/Main/MainCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class MainCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/Main/MainExample.php
+++ b/src/Main/MainExample.php
@@ -26,7 +26,6 @@ use EightshiftLibs\Main\AbstractMain;
  */
 class MainExample extends AbstractMain
 {
-
 	/**
 	 * Register the project with the WordPress system.
 	 *

--- a/src/Manifest/AbstractManifest.php
+++ b/src/Manifest/AbstractManifest.php
@@ -20,7 +20,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractManifest implements ServiceInterface, ManifestInterface
 {
-
 	/**
 	 * Full data of manifest items.
 	 *

--- a/src/Manifest/ManifestCli.php
+++ b/src/Manifest/ManifestCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class ManifestCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/Manifest/ManifestExample.php
+++ b/src/Manifest/ManifestExample.php
@@ -20,7 +20,6 @@ use EightshiftLibs\Manifest\AbstractManifest;
  */
 class ManifestExample extends AbstractManifest
 {
-
 	/**
 	 * Manifest item filter name constant.
 	 *

--- a/src/Manifest/ManifestInterface.php
+++ b/src/Manifest/ManifestInterface.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\Manifest;
  */
 interface ManifestInterface
 {
-
 	/**
 	 * Return full path for specific asset from manifest.json
 	 * This is used for cache busting assets.

--- a/src/Media/MediaCli.php
+++ b/src/Media/MediaCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class MediaCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/Media/MediaExample.php
+++ b/src/Media/MediaExample.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 class MediaExample implements ServiceInterface
 {
-
 	/**
 	 * Register all the hooks
 	 *

--- a/src/Menu/AbstractMenu.php
+++ b/src/Menu/AbstractMenu.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractMenu implements ServiceInterface, MenuPositionsInterface
 {
-
 	/**
 	 * Register All Menu positions
 	 *

--- a/src/Menu/MenuCli.php
+++ b/src/Menu/MenuCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class MenuCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/Menu/MenuExample.php
+++ b/src/Menu/MenuExample.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Menu\AbstractMenu;
  */
 class MenuExample extends AbstractMenu
 {
-
 	/**
 	 * Register all the hooks
 	 *

--- a/src/Menu/MenuPositionsInterface.php
+++ b/src/Menu/MenuPositionsInterface.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\Menu;
  */
 interface MenuPositionsInterface
 {
-
 	/**
 	 * Return all menu positions
 	 *

--- a/src/ModifyAdminAppearance/ModifyAdminAppearanceCli.php
+++ b/src/ModifyAdminAppearance/ModifyAdminAppearanceCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class ModifyAdminAppearanceCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/ModifyAdminAppearance/ModifyAdminAppearanceExample.php
+++ b/src/ModifyAdminAppearance/ModifyAdminAppearanceExample.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 class ModifyAdminAppearanceExample implements ServiceInterface
 {
-
 	/**
 	 * List of admin color schemes.
 	 *

--- a/src/Readme/ReadmeCli.php
+++ b/src/Readme/ReadmeCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class ReadmeCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/Rest/CallableFieldInterface.php
+++ b/src/Rest/CallableFieldInterface.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Rest;
  */
 interface CallableFieldInterface
 {
-
 	/**
 	 * Method that returns rest response for custom fields get_callback callable
 	 *

--- a/src/Rest/CallableRouteInterface.php
+++ b/src/Rest/CallableRouteInterface.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Rest;
  */
 interface CallableRouteInterface
 {
-
 	/**
 	 * Method that returns rest response
 	 *

--- a/src/Rest/Fields/AbstractField.php
+++ b/src/Rest/Fields/AbstractField.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractField implements ServiceInterface
 {
-
 	/**
 	 * A register method holds register_rest_route function to register or override api field.
 	 *

--- a/src/Rest/Fields/FieldCli.php
+++ b/src/Rest/Fields/FieldCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class FieldCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 *

--- a/src/Rest/Fields/FieldExample.php
+++ b/src/Rest/Fields/FieldExample.php
@@ -18,7 +18,6 @@ use EightshiftLibs\Rest\CallableFieldInterface;
  */
 class FieldExample extends AbstractField implements CallableFieldInterface
 {
-
 	/**
 	 * Method that returns field object type
 	 *

--- a/src/Rest/RouteInterface.php
+++ b/src/Rest/RouteInterface.php
@@ -15,7 +15,6 @@ namespace EightshiftLibs\Rest;
  */
 interface RouteInterface
 {
-
 	/**
 	 * Alias for GET transport method.
 	 *

--- a/src/Rest/RouteSecurityInterface.php
+++ b/src/Rest/RouteSecurityInterface.php
@@ -17,7 +17,6 @@ namespace EightshiftLibs\Rest;
  */
 interface RouteSecurityInterface
 {
-
 	/**
 	 * Authenticate the access of the endpoint
 	 *

--- a/src/Rest/Routes/AbstractRoute.php
+++ b/src/Rest/Routes/AbstractRoute.php
@@ -18,7 +18,6 @@ use EightshiftLibs\Rest\RouteInterface;
  */
 abstract class AbstractRoute implements RouteInterface, ServiceInterface
 {
-
 	/**
 	 * A register method holds register_rest_route function to register api route
 	 *

--- a/src/Rest/Routes/RouteExample.php
+++ b/src/Rest/Routes/RouteExample.php
@@ -19,7 +19,6 @@ use EightshiftLibs\Rest\CallableRouteInterface;
  */
 class RouteExample extends AbstractRoute implements CallableRouteInterface
 {
-
 	/**
 	 * Method that returns project Route namespace.
 	 *

--- a/src/Services/ServiceExample.php
+++ b/src/Services/ServiceExample.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 class ServiceExample implements ServiceInterface
 {
-
 	/**
 	 * Register all the hooks
 	 *

--- a/src/Services/ServiceExampleCli.php
+++ b/src/Services/ServiceExampleCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class ServiceExampleCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/ThemeOptions/ThemeOptionsCli.php
+++ b/src/ThemeOptions/ThemeOptionsCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class ThemeOptionsCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/ThemeOptions/ThemeOptionsExample.php
+++ b/src/ThemeOptions/ThemeOptionsExample.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 class ThemeOptionsExample implements ServiceInterface
 {
-
 	/**
 	 * Theme options api page slug
 	 *

--- a/src/View/AbstractEscapedView.php
+++ b/src/View/AbstractEscapedView.php
@@ -15,7 +15,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractEscapedView implements ServiceInterface
 {
-
 	/**
 	 * Tags that are allowed to be rendered for SVG.
 	 */

--- a/src/View/EscapedViewCli.php
+++ b/src/View/EscapedViewCli.php
@@ -17,7 +17,6 @@ use EightshiftLibs\Cli\AbstractCli;
  */
 class EscapedViewCli extends AbstractCli
 {
-
 	/**
 	 * Output dir relative path.
 	 */

--- a/src/View/EscapedViewExample.php
+++ b/src/View/EscapedViewExample.php
@@ -16,7 +16,6 @@ use EightshiftLibs\View\AbstractEscapedView;
  */
 class EscapedViewExample extends AbstractEscapedView implements ServiceInterface
 {
-
 	/**
 	 * Register all the hooks
 	 */

--- a/tests/I18n/I18nExampleTest.php
+++ b/tests/I18n/I18nExampleTest.php
@@ -24,11 +24,12 @@ test('Register method will call init hook', function () {
 	$this->i18n->register();
 
 	$this->assertSame(20, has_action('after_setup_theme', 'EightshiftBoilerplate\I18n\I18nExample->loadThemeTextdomain()'));
+	$this->assertSame(20, has_action('enqueue_block_editor_assets', 'EightshiftBoilerplate\I18n\I18nExample->setScriptTranslations()'));
 });
 
 test('Registering load_theme_textdomain works', function () {
 
-	// Set up a side-affect.
+	// Set up a side effect.
 	putenv('I18N_ABSTRACTED=false');
 
 	mock('alias:EightshiftBoilerplate\Config\Config')
@@ -41,5 +42,27 @@ test('Registering load_theme_textdomain works', function () {
 
 	$this->i18n->loadThemeTextdomain();
 
-	$this->assertSame(getenv('I18N_ABSTRACTED'), 'true', 'Calling void method load_theme_textdomain caused no sideaffects');
+	$this->assertSame(getenv('I18N_ABSTRACTED'), 'true', 'Calling void method loadThemeTextdomain caused no side effects');
+});
+
+test('Registering wp_set_script_translations works', function () {
+
+	// Set up a side effect.
+	putenv('GUT_I18N_ABSTRACTED=false');
+
+	mock('alias:EightshiftBoilerplate\Config\Config')
+		->shouldReceive('getProjectName', 'getProjectPath')
+		->andReturn('CoolProject', 'projectPath');
+
+	mock('alias:EightshiftBoilerplate\Enqueue\Assets')
+		->shouldReceive('getAssetsPrefix')
+		->andReturn('cool-project');
+
+	Functions\when('wp_set_script_translations')->alias(function () {
+		putenv('GUT_I18N_ABSTRACTED=true');
+	});
+
+	$this->i18n->setScriptTranslations();
+
+	$this->assertSame(getenv('I18N_ABSTRACTED'), 'true', 'Calling void method setScriptTranslations caused no side effects');
 });


### PR DESCRIPTION
# Description

Adds a method to `I18nExample.php` which hooks to `enqueue_block_editor_assets` to allow blocks in the editor to be internationalized.

Translations should be exported as JED files and have the name in this format: `{textdomain}-{locale}-{handle}.json` into path defined by the method (`src/I18n/languages` in this example). 

This export can be done automatically with Glotpress, and there are tools in WP-CLI to help with that (but they seemed to produce more than one file when I tried using them, so I'm not really sure they're behaving properly. maybe I'm just being dumb :shrug:)

~Also adds a `getProjectPath` helper to `ConfigExample.php`, as it's referenced in other example classes, but missing from the `ConfigExample.php`~ Didn't notice this was provided by `AbstractConfigData` in the current version of Libs.

Also fixes PHPCS errors introduced today (2021-12-13): https://github.com/infinum/eightshift-libs/pull/250#issuecomment-992262160

<!--- Show us what you did. -->
# Screenshots / Videos
![Screenshot 2021-12-09 at 17 34 15](https://user-images.githubusercontent.com/1742806/145437279-83124525-5829-4b03-960a-8facb257c6bc.png)

# Linked documentation PR

<!--- If this PR has documentation please put the link here. -->
Docs: https://github.com/infinum/eightshift-docs/pull/129