### PR TITLE
CI/CD improvements for GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ on:
     paths-ignore:
       - '**.md'
 
+# Prevent multiple unnecessary CI runs on the same branch.
+# Link: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phpcs:
     name: PHPCS check on PHP ${{ matrix.php }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,12 @@ on:
     paths-ignore:
       - '**.md'
 
+# Prevent multiple unnecessary CI runs on the same branch.
+# Link: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Unit tests


### PR DESCRIPTION
# Description

This PR improves the CI/CD workflows in that it will cancel the running builds for the same branch when an update is made (a push to the branch will cancel the previous run so that the new one can start).

This is useful for paid and free actions, as it conserves the minutes spend on CI runs (free is good for the environment, as we're not running unnecessary code and wasting GH's resources, paid is good because we're conserving the GH minutes).

# Linked documentation PR

https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency
