### PR TITLE
Add fill property to SVG in AbstractEscapedView class

### DIFF
--- a/src/View/AbstractEscapedView.php
+++ b/src/View/AbstractEscapedView.php
@@ -15,6 +15,7 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractEscapedView implements ServiceInterface
 {
+
 	/**
 	 * Tags that are allowed to be rendered for SVG.
 	 */
@@ -26,6 +27,7 @@ abstract class AbstractEscapedView implements ServiceInterface
 			'height' => true,
 			'width' => true,
 			'class' => true,
+			'fill' => true,
 		],
 		'defs' => true,
 		'path' => [

--- a/src/View/AbstractEscapedView.php
+++ b/src/View/AbstractEscapedView.php
@@ -15,7 +15,6 @@ use EightshiftLibs\Services\ServiceInterface;
  */
 abstract class AbstractEscapedView implements ServiceInterface
 {
-
 	/**
 	 * Tags that are allowed to be rendered for SVG.
 	 */


### PR DESCRIPTION
I couldn't add fill to the SVG so I figured it should be added as standard on our projects.
Changelog:
- add fill property to SVG in abstract escaped view

Example screenshots(`fill: none`):
**Before**
![before - no fill none](https://user-images.githubusercontent.com/46056662/147351318-97212967-614b-4102-a82b-6742d4a26f80.png) 
**After**
![after - with fill none](https://user-images.githubusercontent.com/46056662/147351317-5bd285ed-e003-487d-b674-37d3a3b3bb4f.png)

