### PR TITLE
Add automatic documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@
 /phpstan.neon.dist export-ignore
 /phpunit.xml export-ignore
 /package export-ignore
+/docs export-ignore
 
 /package export-ignore
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor
 node_modules
 /docs
+.phpdoc/*
 
 composer.lock
 package-lock.json

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+		configVersion="3"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns="https://raw.githubusercontent.com/phpDocumentor/phpDocumentor/master/data/xsd/phpdoc.xsd"
+>
+	<title>Eightshift Libs</title>
+	<paths>
+		<output>docs/.build</output>
+	</paths>
+
+	<version number="3.0.0">
+		<api>
+			<source dsn=".">
+				<path>src</path>
+			</source>
+			<output>api</output>
+			<ignore hidden="true" symlinks="true">
+				<path>tests/**/*</path>
+				<path>vendor/**/*</path>
+				<path>.github/**/*</path>
+			</ignore>
+			<extensions>
+				<extension>php</extension>
+			</extensions>
+		</api>
+	</version>
+	<template name="default"/>
+</phpdocumentor>


### PR DESCRIPTION
# Description

Added a configuration for phpdocumentor generation

# Screenshots / Videos
Looks like this once it's compiled 

<img width="1279" alt="image (1)" src="https://user-images.githubusercontent.com/8638515/154439188-689c7c52-8bae-412a-9a19-227922dd5161.png">
<img width="1910" alt="image" src="https://user-images.githubusercontent.com/8638515/154439190-44fe963b-8dc6-47fe-a3e8-778667df4a70.png">

Next steps can be to set up an automatic documentation build so that it can be served on the eightshift-docs, like API docs.
