### PR TITLE
Feature/linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 - Option to override default block class prefix in the blocks global settings manifest.
 
 ### Fixed
-- Changed directory separator from `/` to `DIRECTORY_SEPARATOR` constant to be able to work cross-platform.
+- Changed directory separator from `/` to `\DIRECTORY_SEPARATOR` constant to be able to work cross-platform.
 - Various fixes and improvements.
 
 ### Changed

--- a/bin/cli.php
+++ b/bin/cli.php
@@ -9,7 +9,7 @@
 use EightshiftLibs\Cli\Cli;
 use WP_CLI\ExitException;
 
-$root = dirname(__DIR__, 1);
+$root = \dirname(__DIR__, 1);
 
 require "{$root}/vendor/autoload.php";
 require  "{$root}/src/Cli/Cli.php";

--- a/composer.json
+++ b/composer.json
@@ -70,8 +70,8 @@
   },
   "scripts": {
     "analyze": "@php ./vendor/bin/phpstan analyze",
-    "standards:check": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 7.3-",
-    "standards:fix": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --runtime-set testVersion 7.3-",
+    "standards:check": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 7.4-",
+    "standards:fix": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --runtime-set testVersion 7.4-",
     "test:unit": "@php ./vendor/bin/pest",
     "test:coverage": "@php ./vendor/bin/pest --coverage"
   }

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,12 @@
   "require-dev": {
     "brain/monkey": "^2.6",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-    "infinum/eightshift-coding-standards": "^1.3",
+    "infinum/eightshift-coding-standards": "^1.5",
     "pestphp/pest": "^1.2",
     "php-stubs/wordpress-stubs": "^5.9",
     "phpunit/phpunit": "^9.5",
     "roave/security-advisories": "dev-master",
-    "szepeviktor/phpstan-wordpress": "^1.0.2",
+    "szepeviktor/phpstan-wordpress": "^1.0.3",
     "wp-cli/wp-cli": "^2.4"
   },
   "suggest": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,11 +20,11 @@
 	<file>.</file>
 
 	<!-- Check for PHP cross-version compatibility. -->
-	<config name="testVersion" value="7.3-"/>
+	<config name="testVersion" value="7.4-"/>
 	<rule ref="PHPCompatibilityWP"/>
 
 	<!-- Support only latest 3 WP versions. -->
-	<config name="minimum_supported_wp_version" value="5.6"/>
+	<config name="minimum_supported_wp_version" value="7.0"/>
 
 	<exclude-pattern>/src/CompiledContainer\.php</exclude-pattern>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -24,7 +24,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 
 	<!-- Support only latest 3 WP versions. -->
-	<config name="minimum_supported_wp_version" value="7.0"/>
+	<config name="minimum_supported_wp_version" value="5.6"/>
 
 	<exclude-pattern>/src/CompiledContainer\.php</exclude-pattern>
 

--- a/src/AdminMenus/AbstractAdminMenu.php
+++ b/src/AdminMenus/AbstractAdminMenu.php
@@ -54,7 +54,7 @@ abstract class AbstractAdminMenu implements ServiceInterface, RenderableBlockInt
 	 * @param array<string, mixed>|string $attr Attributes as passed to the admin menu.
 	 *
 	 * @return void The rendered content needs to be echoed.
-	 * @throws Exception Exception in case the component is missing.
+	 * @throws \Exception Exception in case the component is missing.
 	 */
 	public function processAdminMenu($attr): void
 	{

--- a/src/AdminMenus/AbstractAdminMenu.php
+++ b/src/AdminMenus/AbstractAdminMenu.php
@@ -54,7 +54,7 @@ abstract class AbstractAdminMenu implements ServiceInterface, RenderableBlockInt
 	 * @param array<string, mixed>|string $attr Attributes as passed to the admin menu.
 	 *
 	 * @return void The rendered content needs to be echoed.
-	 * @throws \Exception Exception in case the component is missing.
+	 * @throws Exception Exception in case the component is missing.
 	 */
 	public function processAdminMenu($attr): void
 	{

--- a/src/AdminMenus/AbstractAdminMenu.php
+++ b/src/AdminMenus/AbstractAdminMenu.php
@@ -13,6 +13,7 @@ namespace EightshiftLibs\AdminMenus;
 use EightshiftLibs\Helpers\Components;
 use EightshiftLibs\Services\ServiceInterface;
 use EightshiftLibs\Blocks\RenderableBlockInterface;
+use Exception;
 
 /**
  * Abstract class AbstractAdminMenu class.
@@ -53,7 +54,7 @@ abstract class AbstractAdminMenu implements ServiceInterface, RenderableBlockInt
 	 * @param array<string, mixed>|string $attr Attributes as passed to the admin menu.
 	 *
 	 * @return void The rendered content needs to be echoed.
-	 * @throws \Exception Exception in case the component is missing.
+	 * @throws Exception Exception in case the component is missing.
 	 */
 	public function processAdminMenu($attr): void
 	{
@@ -72,15 +73,15 @@ abstract class AbstractAdminMenu implements ServiceInterface, RenderableBlockInt
 	 * @param string $innerBlockContent Not used here.
 	 *
 	 * @return string Rendered HTML.
-	 * @throws \Exception On missing attributes OR missing template.
+	 * @throws Exception On missing attributes OR missing template.
 	 */
 	public function render(array $attributes = [], string $innerBlockContent = ''): string
 	{
 		try {
 			return Components::render($this->getViewComponent(), $attributes);
-		} catch (\Exception $exception) { // To do: once new libs are released, replace with ComponentException.
+		} catch (Exception $exception) { // To do: once new libs are released, replace with ComponentException.
 			// Don't let exceptions bubble up. Just render the exception message into the admin menu.
-			return sprintf(
+			return \sprintf(
 				'<pre>%s</pre>',
 				$exception->getMessage()
 			);
@@ -141,14 +142,14 @@ abstract class AbstractAdminMenu implements ServiceInterface, RenderableBlockInt
 	 */
 	protected function renderNonce()
 	{
-		ob_start();
+		\ob_start();
 
 		\wp_nonce_field(
 			$this->getNonceAction(),
 			$this->getNonceName()
 		);
 
-		return ob_get_clean();
+		return \ob_get_clean();
 	}
 
 	/**

--- a/src/AdminMenus/AbstractAdminSubMenu.php
+++ b/src/AdminMenus/AbstractAdminSubMenu.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\AdminMenus;
 
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use Exception;
+
 /**
  * Abstract class AbstractAdminSubMenu class.
  *
@@ -48,7 +51,7 @@ abstract class AbstractAdminSubMenu extends AbstractAdminMenu
 	 * @param array<string, mixed>|string $attr Attributes as passed to the admin menu.
 	 *
 	 * @return void The rendered content needs to be echoed.
-	 * @throws \Exception Exception in case the component is missing.
+	 * @throws Exception Exception in case the component is missing.
 	 */
 	public function processAdminSubmenu($attr): void
 	{

--- a/src/AdminMenus/AbstractAdminSubMenu.php
+++ b/src/AdminMenus/AbstractAdminSubMenu.php
@@ -48,7 +48,7 @@ abstract class AbstractAdminSubMenu extends AbstractAdminMenu
 	 * @param array<string, mixed>|string $attr Attributes as passed to the admin menu.
 	 *
 	 * @return void The rendered content needs to be echoed.
-	 * @throws Exception Exception in case the component is missing.
+	 * @throws \Exception Exception in case the component is missing.
 	 */
 	public function processAdminSubmenu($attr): void
 	{

--- a/src/AdminMenus/AbstractAdminSubMenu.php
+++ b/src/AdminMenus/AbstractAdminSubMenu.php
@@ -48,7 +48,7 @@ abstract class AbstractAdminSubMenu extends AbstractAdminMenu
 	 * @param array<string, mixed>|string $attr Attributes as passed to the admin menu.
 	 *
 	 * @return void The rendered content needs to be echoed.
-	 * @throws \Exception Exception in case the component is missing.
+	 * @throws Exception Exception in case the component is missing.
 	 */
 	public function processAdminSubmenu($attr): void
 	{

--- a/src/AdminMenus/AdminMenuCli.php
+++ b/src/AdminMenus/AdminMenuCli.php
@@ -23,7 +23,7 @@ class AdminMenuCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'AdminMenus';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'AdminMenus';
 
 	/**
 	 * Define default develop props.
@@ -96,7 +96,7 @@ class AdminMenuCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Arguments.
 		$title = $assocArgs['title'] ?? 'Admin Title';

--- a/src/AdminMenus/AdminMenuCli.php
+++ b/src/AdminMenus/AdminMenuCli.php
@@ -58,26 +58,26 @@ class AdminMenuCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'title',
 					'description' => 'The text to be displayed in the title tags of the page when the menu is selected.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'menu_title',
 					'description' => 'The text to be used for the menu.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'capability',
 					'description' => 'The capability required for this menu to be displayed to the user.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'menu_slug',
 					'description' => 'The slug name to refer to this menu by.
 					Should be unique for this menu page and only include lowercase alphanumeric, dashes, and underscores characters to be compatible with sanitize_key().',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',

--- a/src/AdminMenus/AdminMenuCli.php
+++ b/src/AdminMenus/AdminMenuCli.php
@@ -58,26 +58,26 @@ class AdminMenuCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'title',
 					'description' => 'The text to be displayed in the title tags of the page when the menu is selected.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'menu_title',
 					'description' => 'The text to be used for the menu.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'capability',
 					'description' => 'The capability required for this menu to be displayed to the user.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'menu_slug',
 					'description' => 'The slug name to refer to this menu by.
 					Should be unique for this menu page and only include lowercase alphanumeric, dashes, and underscores characters to be compatible with sanitize_key().',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',

--- a/src/AdminMenus/AdminSubMenuCli.php
+++ b/src/AdminMenus/AdminSubMenuCli.php
@@ -23,7 +23,7 @@ class AdminSubMenuCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'AdminMenus';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'AdminMenus';
 
 	/**
 	 * Define default develop props.
@@ -88,7 +88,7 @@ class AdminSubMenuCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Arguments.
 		$parentSlug = $assocArgs['parent_slug'] ?? AdminSubMenuExample::PARENT_MENU_SLUG;

--- a/src/AdminMenus/AdminSubMenuCli.php
+++ b/src/AdminMenus/AdminSubMenuCli.php
@@ -57,31 +57,31 @@ class AdminSubMenuCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'parent_slug',
 					'description' => 'The slug name for the parent menu (or the file name of a standard WordPress admin page)',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'title',
 					'description' => 'The text to be displayed in the title tags of the page when the menu is selected.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'menu_title',
 					'description' => 'The text to be used for the menu.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'capability',
 					'description' => 'The capability required for this menu to be displayed to the user.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'menu_slug',
 					'description' => 'The slug name to refer to this menu by. Should be unique for this menu page and only include lowercase alphanumeric, dashes, and underscores characters to be compatible with sanitize_key().', // phpcs:ignore Generic.Files.LineLength.TooLong
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/AdminMenus/AdminSubMenuCli.php
+++ b/src/AdminMenus/AdminSubMenuCli.php
@@ -57,31 +57,31 @@ class AdminSubMenuCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'parent_slug',
 					'description' => 'The slug name for the parent menu (or the file name of a standard WordPress admin page)',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'title',
 					'description' => 'The text to be displayed in the title tags of the page when the menu is selected.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'menu_title',
 					'description' => 'The text to be used for the menu.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'capability',
 					'description' => 'The capability required for this menu to be displayed to the user.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'menu_slug',
 					'description' => 'The slug name to refer to this menu by. Should be unique for this menu page and only include lowercase alphanumeric, dashes, and underscores characters to be compatible with sanitize_key().', // phpcs:ignore Generic.Files.LineLength.TooLong
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/BlockPatterns/BlockPatternCli.php
+++ b/src/BlockPatterns/BlockPatternCli.php
@@ -56,7 +56,7 @@ class BlockPatternCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'title',
 					'description' => 'Pattern title',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',

--- a/src/BlockPatterns/BlockPatternCli.php
+++ b/src/BlockPatterns/BlockPatternCli.php
@@ -56,7 +56,7 @@ class BlockPatternCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'title',
 					'description' => 'Pattern title',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',

--- a/src/BlockPatterns/BlockPatternCli.php
+++ b/src/BlockPatterns/BlockPatternCli.php
@@ -23,7 +23,7 @@ class BlockPatternCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'BlockPatterns';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'BlockPatterns';
 
 	/**
 	 * Define default develop props.
@@ -81,7 +81,7 @@ class BlockPatternCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$title = $assocArgs['title'] ?? '';

--- a/src/Blocks/AbstractBlocks.php
+++ b/src/Blocks/AbstractBlocks.php
@@ -15,6 +15,8 @@ use EightshiftLibs\Exception\InvalidBlock;
 use EightshiftLibs\Exception\InvalidManifest;
 use EightshiftLibs\Helpers\Components;
 use EightshiftLibs\Services\ServiceInterface;
+use WP_Block_Editor_Context;
+use WP_Post;
 
 /**
  * Class Blocks
@@ -78,7 +80,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 		// Save namespace to internal variable.
 		$this->namespace = $namespace;
 
-		$blocks = array_map(
+		$blocks = \array_map(
 			static function ($block) use ($namespace) {
 				// Check if blocks-namespace is defined in block or in global manifest settings.
 				$block['namespace'] = $namespace;
@@ -112,26 +114,26 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 * @hook allowed_block_types_all Available from WP 5.8.
 	 *
 	 * @param bool|string[] $allowedBlockTypes Array of block type slugs, or boolean to enable/disable all.
-	 * @param \WP_Block_Editor_Context $blockEditorContext The current block editor context.
+	 * @param WP_Block_Editor_Context $blockEditorContext The current block editor context.
 	 *
 	 * @return bool|string[] Boolean if you want to disallow or allow all blocks, or a list of allowed blocks.
 	 */
-	public function getAllBlocksList($allowedBlockTypes, \WP_Block_Editor_Context $blockEditorContext)
+	public function getAllBlocksList($allowedBlockTypes, WP_Block_Editor_Context $blockEditorContext)
 	{
 		// Allow forms to be used correctly.
 		if (
-			$blockEditorContext->post instanceof \WP_Post &&
+			$blockEditorContext->post instanceof WP_Post &&
 			!empty($blockEditorContext->post->post_type) &&
 			$blockEditorContext->post->post_type === 'eightshift-forms'
 		) {
 			return true;
 		}
 
-		if (gettype($allowedBlockTypes) === 'boolean') {
+		if (\gettype($allowedBlockTypes) === 'boolean') {
 			return $allowedBlockTypes;
 		}
 
-		$allowedBlockTypes = array_map(
+		$allowedBlockTypes = \array_map(
 			function ($block) {
 				return $block['blockFullName'];
 			},
@@ -153,17 +155,17 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 * @hook allowed_block_types This is a WP 5 - WP 5.7 compatible hook callback. Will not work with WP 5.8!
 	 *
 	 * @param bool|string[] $allowedBlockTypes Array of block type slugs, or boolean to enable/disable all.
-	 * @param \WP_Post $post The post resource data.
+	 * @param WP_Post $post The post resource data.
 	 *
 	 * @return bool|string[] Boolean if you want to disallow or allow all blocks, or a list of allowed blocks.
 	 */
-	public function getAllBlocksListOld($allowedBlockTypes, \WP_Post $post)
+	public function getAllBlocksListOld($allowedBlockTypes, WP_Post $post)
 	{
-		if (gettype($allowedBlockTypes) === 'boolean') {
+		if (\gettype($allowedBlockTypes) === 'boolean') {
 			return $allowedBlockTypes;
 		}
 
-		$allowedBlockTypes = array_map(
+		$allowedBlockTypes = \array_map(
 			function ($block) {
 				return $block['blockFullName'];
 			},
@@ -232,23 +234,23 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 		$templatePath = $this->getBlockViewPath($blockName);
 
 		// Get block wrapper view path.
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 		$wrapperPath = "{$this->getWrapperPath()}{$sep}wrapper.php";
 
 		// Check if wrapper component exists.
-		if (!file_exists($wrapperPath)) {
+		if (!\file_exists($wrapperPath)) {
 			throw InvalidBlock::missingWrapperViewException($wrapperPath);
 		}
 
 		// Check if actual block exists.
-		if (!file_exists($templatePath)) {
+		if (!\file_exists($templatePath)) {
 			throw InvalidBlock::missingViewException($blockName, $templatePath);
 		}
 
 		// If everything is ok, return the contents of the template (return, NOT echo).
-		ob_start();
+		\ob_start();
 		include $wrapperPath;
-		$output = ob_get_clean();
+		$output = \ob_get_clean();
 
 		unset($blockName, $templatePath, $wrapperPath, $attributes, $innerBlockContent);
 
@@ -263,13 +265,13 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 * @hook block_categories_all Available from WP 5.8.
 	 *
 	 * @param array<int, array<string, string|null>> $categories Array of categories for block types.
-	 * @param \WP_Block_Editor_Context $blockEditorContext The current block editor context.
+	 * @param WP_Block_Editor_Context $blockEditorContext The current block editor context.
 	 *
 	 * @return array<int, array<string, string|null>> Array of categories for block types.
 	 */
-	public function getCustomCategory(array $categories, \WP_Block_Editor_Context $blockEditorContext): array
+	public function getCustomCategory(array $categories, WP_Block_Editor_Context $blockEditorContext): array
 	{
-		return array_merge(
+		return \array_merge(
 			$categories,
 			[
 				[
@@ -289,13 +291,13 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 * @hook block_categories This is a WP 5 - WP 5.7 compatible hook callback. Will not work with WP 5.8!
 	 *
 	 * @param array<int, array<string, string|null>> $categories Array of categories for block types.
-	 * @param \WP_Post $post Post being loaded.
+	 * @param WP_Post $post Post being loaded.
 	 *
 	 * @return array<int, array<string, string|null>> Array of categories for block types.
 	 */
-	public function getCustomCategoryOld(array $categories, \WP_Post $post): array
+	public function getCustomCategoryOld(array $categories, WP_Post $post): array
 	{
-		return array_merge(
+		return \array_merge(
 			$categories,
 			[
 				[
@@ -322,7 +324,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	public function renderWrapperView(string $src, array $attributes, ?string $innerBlockContent = null): void
 	{
-		if (!file_exists($src)) {
+		if (!\file_exists($src)) {
 			throw InvalidBlock::missingWrapperViewException($src);
 		}
 
@@ -345,7 +347,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	{
 		global $esBlocks;
 
-		$namespace = array_key_first($esBlocks);
+		$namespace = \array_key_first($esBlocks);
 
 		if ($parsedBlock['blockName'] === "{$namespace}/paragraph") {
 			if (
@@ -368,11 +370,11 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function getBlocksPath(): string
 	{
-		$sep = DIRECTORY_SEPARATOR;
-		$blocksPath = dirname(__DIR__, 5) . "{$sep}src{$sep}Blocks";
+		$sep = \DIRECTORY_SEPARATOR;
+		$blocksPath = \dirname(__DIR__, 5) . "{$sep}src{$sep}Blocks";
 
-		if (getenv('TEST')) {
-			$blocksPath = dirname(__DIR__, 2) . "{$sep}tests{$sep}data{$sep}src{$sep}Blocks";
+		if (\getenv('TEST')) {
+			$blocksPath = \dirname(__DIR__, 2) . "{$sep}tests{$sep}data{$sep}src{$sep}Blocks";
 		}
 
 		return $blocksPath;
@@ -385,7 +387,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function getBlocksCustomPath(): string
 	{
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 		return "{$this->getBlocksPath()}{$sep}custom";
 	}
 
@@ -396,7 +398,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function getBlocksComponentsPath(): string
 	{
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 		return "{$this->getBlocksPath()}{$sep}components";
 	}
 
@@ -409,7 +411,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function getBlockViewPath(string $blockName): string
 	{
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 		return "{$this->getBlocksCustomPath()}{$sep}{$blockName}{$sep}{$blockName}.php";
 	}
 
@@ -420,7 +422,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function getWrapperPath(): string
 	{
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 		return "{$this->getBlocksPath()}{$sep}wrapper";
 	}
 
@@ -433,15 +435,15 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function getWrapper(): array
 	{
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 		$manifestPath = "{$this->getWrapperPath()}{$sep}manifest.json";
 
-		if (!file_exists($manifestPath)) {
+		if (!\file_exists($manifestPath)) {
 			throw InvalidBlock::missingWrapperManifestException($manifestPath);
 		}
 
-		$settings = implode(' ', (array)file($manifestPath));
-		$settings = json_decode($settings, true);
+		$settings = \implode(' ', (array)\file($manifestPath));
+		$settings = \json_decode($settings, true);
 
 		return $settings;
 	}
@@ -459,15 +461,15 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	{
 		$componentName = Components::camelToKebabCase($componentName);
 
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 		$manifestPath = "{$this->getBlocksComponentsPath()}{$sep}{$componentName}{$sep}manifest.json";
 
-		if (!file_exists($manifestPath) && !defined('WP_CLI')) {
+		if (!\file_exists($manifestPath) && !\defined('WP_CLI')) {
 			throw InvalidBlock::missingComponentManifestException($manifestPath);
 		}
 
-		$settings = implode(' ', (array)file($manifestPath));
-		$settings = json_decode($settings, true);
+		$settings = \implode(' ', (array)\file($manifestPath));
+		$settings = \json_decode($settings, true);
 
 		return $settings;
 	}
@@ -482,15 +484,15 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function getGlobalSettings(): array
 	{
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 		$manifestPath = "{$this->getBlocksPath()}{$sep}manifest.json";
 
-		if (!file_exists($manifestPath)) {
+		if (!\file_exists($manifestPath)) {
 			throw InvalidBlock::missingSettingsManifestException($manifestPath);
 		}
 
-		$settings = implode(' ', (array)file(($manifestPath)));
-		$settings = json_decode($settings, true);
+		$settings = \implode(' ', (array)\file(($manifestPath)));
+		$settings = \json_decode($settings, true);
 
 		if (!isset($settings['namespace'])) {
 			throw InvalidBlock::missingNamespaceException();
@@ -516,7 +518,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 		$settings = Components::getSettings('settings', '', $this->namespace);
 		$blockClassPrefix = $settings['blockClassPrefix'] ?? 'block';
 
-		return array_merge(
+		return \array_merge(
 			[
 				'blockName' => [
 					'type' => 'string',
@@ -568,25 +570,25 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 		$newParent = Components::kebabToCamelCase($parent);
 
 		// Iterate each attribute and attach parent prefixes.
-		$componentAttributeKeys = array_keys($componentAttributes);
+		$componentAttributeKeys = \array_keys($componentAttributes);
 		foreach ($componentAttributeKeys as $componentAttribute) {
 			$attribute = $componentAttribute;
 
 			// If there is an attribute name switch, use the new one.
 			if ($newName !== $realName) {
-				$attribute = str_replace($realName, $newName, (string) $componentAttribute);
+				$attribute = \str_replace($realName, $newName, (string) $componentAttribute);
 			}
 
 			// Check if current attribute is used strip component prefix from attribute and replace it with parent prefix.
 			if ($currentAttributes) {
-				$attribute = str_replace(lcfirst(Components::kebabToCamelCase($realName)), '', (string) $componentAttribute);
+				$attribute = \str_replace(\lcfirst(Components::kebabToCamelCase($realName)), '', (string) $componentAttribute);
 			}
 
 			// Determine if parent is empty and if parent name is the same as component/block name and skip wrapper attributes.
-			if (substr((string)$attribute, 0, strlen('wrapper')) === 'wrapper') {
+			if (\substr((string)$attribute, 0, \strlen('wrapper')) === 'wrapper') {
 				$attributeName = $attribute;
 			} else {
-				$attributeName = $newParent . ucfirst((string)$attribute);
+				$attributeName = $newParent . \ucfirst((string)$attribute);
 			}
 
 			// Output new attribute names.
@@ -630,20 +632,20 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 
 			// If component has more components do recursive loop.
 			if (isset($component['components'])) {
-				$outputAttributes = $this->prepareComponentAttributes($component, $newParent . ucfirst(Components::camelToKebabCase($newComponentName)));
+				$outputAttributes = $this->prepareComponentAttributes($component, $newParent . \ucfirst(Components::camelToKebabCase($newComponentName)));
 			} else {
 				// Output the component attributes if there is no nesting left, and append the parent prefixes.
 				$outputAttributes = $this->prepareComponentAttribute($component, $newComponentName, $realComponentName, $newParent);
 			}
 
 			// Populate the output recursively.
-			$output = array_merge(
+			$output = \array_merge(
 				$output,
 				$outputAttributes
 			);
 		}
 
-		return array_merge(
+		return \array_merge(
 			$output,
 			$this->prepareComponentAttribute($manifest, '', $name, $newParent, true)
 		);
@@ -658,10 +660,10 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function getBlocksData(): array
 	{
-		$sep = DIRECTORY_SEPARATOR;
-		return array_map(
+		$sep = \DIRECTORY_SEPARATOR;
+		return \array_map(
 			function (string $blockPath) {
-				$block = implode(' ', (array)file(($blockPath)));
+				$block = \implode(' ', (array)\file(($blockPath)));
 
 				$block = $this->parseManifest($block);
 
@@ -683,7 +685,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 
 				return $block;
 			},
-			(array)glob("{$this->getBlocksCustomPath()}{$sep}*{$sep}manifest.json")
+			(array)\glob("{$this->getBlocksCustomPath()}{$sep}*{$sep}manifest.json")
 		);
 	}
 
@@ -696,11 +698,11 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function getComponentsManifest(): array
 	{
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 
-		return array_map(
+		return \array_map(
 			function (string $componentPath) {
-				$component = implode(' ', (array)file(($componentPath)));
+				$component = \implode(' ', (array)\file(($componentPath)));
 
 				$component = $this->parseManifest($component);
 
@@ -710,7 +712,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 
 				return $component;
 			},
-			(array)glob("{$this->getBlocksComponentsPath()}{$sep}*{$sep}manifest.json")
+			(array)\glob("{$this->getBlocksComponentsPath()}{$sep}*{$sep}manifest.json")
 		);
 	}
 
@@ -727,34 +729,34 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	 */
 	private function parseManifest(string $string): array
 	{
-		$result = json_decode($string, true);
+		$result = \json_decode($string, true);
 
-		switch (json_last_error()) {
-			case JSON_ERROR_NONE:
+		switch (\json_last_error()) {
+			case \JSON_ERROR_NONE:
 				$error = '';
 				break;
-			case JSON_ERROR_DEPTH:
+			case \JSON_ERROR_DEPTH:
 				$error = \esc_html__('The maximum stack depth has been exceeded.', 'eightshift-libs');
 				break;
-			case JSON_ERROR_STATE_MISMATCH:
+			case \JSON_ERROR_STATE_MISMATCH:
 				$error = \esc_html__('Invalid or malformed JSON.', 'eightshift-libs');
 				break;
-			case JSON_ERROR_CTRL_CHAR:
+			case \JSON_ERROR_CTRL_CHAR:
 				$error = \esc_html__('Control character error, possibly incorrectly encoded.', 'eightshift-libs');
 				break;
-			case JSON_ERROR_SYNTAX:
+			case \JSON_ERROR_SYNTAX:
 				$error = \esc_html__('Syntax error, malformed JSON.', 'eightshift-libs');
 				break;
-			case JSON_ERROR_UTF8:
+			case \JSON_ERROR_UTF8:
 				$error = \esc_html__('Malformed UTF-8 characters, possibly incorrectly encoded.', 'eightshift-libs');
 				break;
-			case JSON_ERROR_RECURSION:
+			case \JSON_ERROR_RECURSION:
 				$error = \esc_html__('One or more recursive references in the value to be encoded.', 'eightshift-libs');
 				break;
-			case JSON_ERROR_INF_OR_NAN:
+			case \JSON_ERROR_INF_OR_NAN:
 				$error = \esc_html__('One or more NAN or INF values in the value to be encoded.', 'eightshift-libs');
 				break;
-			case JSON_ERROR_UNSUPPORTED_TYPE:
+			case \JSON_ERROR_UNSUPPORTED_TYPE:
 				$error = \esc_html__('A value of a type that cannot be encoded was given.', 'eightshift-libs');
 				break;
 			default:

--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Blocks;
 
 use EightshiftLibs\Cli\AbstractCli;
-use FilesystemIterator;
+use WP_CLI;
 
 /**
  * Abstract class used for Blocks and Components
@@ -40,8 +40,8 @@ abstract class AbstractBlocksCli extends AbstractCli
 
 		$sourcePathFolder = "{$rootNode}/{$outputDir}/";
 
-		$blocks = scandir($sourcePathFolder);
-		$blocksFullList = array_diff((array)$blocks, ['..', '.']);
+		$blocks = \scandir($sourcePathFolder);
+		$blocksFullList = \array_diff((array)$blocks, ['..', '.']);
 
 		$blocks = [$name];
 
@@ -56,8 +56,8 @@ abstract class AbstractBlocksCli extends AbstractCli
 			$path = "{$outputDir}/{$block}";
 			$sourcePath = "{$sourcePathFolder}{$block}";
 
-			if (!getenv('TEST')) {
-				$destinationPath = $root . DIRECTORY_SEPARATOR . $path;
+			if (!\getenv('TEST')) {
+				$destinationPath = $root . \DIRECTORY_SEPARATOR . $path;
 			} else {
 				$destinationPath = $this->getProjectRootPath(true) . '/cliOutput';
 			}
@@ -66,17 +66,17 @@ abstract class AbstractBlocksCli extends AbstractCli
 			$typeSingular = !$isComponents ?  'block' : 'component';
 
 			// Source doesn't exist.
-			if (!file_exists($sourcePath)) {
+			if (!\file_exists($sourcePath)) {
 				// Make a list for output.
-				$blocksList = implode(PHP_EOL, $blocksFullList);
+				$blocksList = \implode(\PHP_EOL, $blocksFullList);
 
-				\WP_CLI::log(
+				WP_CLI::log(
 					"Please check the docs for all available {$typePlural}."
 				);
-				\WP_CLI::log(
+				WP_CLI::log(
 					"You can find all available {$typePlural} on this link: https://infinum.github.io/eightshift-docs/storybook/."
 				);
-				\WP_CLI::log(
+				WP_CLI::log(
 					"Or here is the list of all available {$typeSingular} names: \n{$blocksList}"
 				);
 
@@ -84,9 +84,9 @@ abstract class AbstractBlocksCli extends AbstractCli
 			}
 
 			// Destination exists.
-			if (file_exists($destinationPath) && $skipExisting === false) {
+			if (\file_exists($destinationPath) && $skipExisting === false) {
 				self::cliError(
-					sprintf(
+					\sprintf(
 						'The %s in you project exists on this "%s" path. Please check or remove that folder before running this command again.',
 						$typeSingular,
 						$destinationPath,
@@ -98,7 +98,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 			$this->moveBlock($destinationPath, $sourcePath, $block, $assocArgs, $path, $typeSingular);
 		}
 
-		\WP_CLI::success('Please start `npm start` again to make sure everything works correctly.');
+		WP_CLI::success('Please start `npm start` again to make sure everything works correctly.');
 	}
 
 	/**
@@ -116,16 +116,16 @@ abstract class AbstractBlocksCli extends AbstractCli
 	private function moveBlock(string $destinationPath, string $sourcePath, string $name, array $assocArgs, string $path, string $typeSingular): void
 	{
 		// Create folder in project if missing.
-		mkdir("{$destinationPath}/");
+		\mkdir("{$destinationPath}/");
 
 		// Move block/component to project folder.
 		$this->copyRecursively($sourcePath, "{$destinationPath}/");
 
-		$typeSingular = ucfirst($typeSingular);
+		$typeSingular = \ucfirst($typeSingular);
 
-		\WP_CLI::success("{$typeSingular} successfully moved to your project.");
+		WP_CLI::success("{$typeSingular} successfully moved to your project.");
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
 		// Move all files from library to project.
 		foreach ($this->getFullBlocksFiles($name) as $file) {
@@ -141,6 +141,6 @@ abstract class AbstractBlocksCli extends AbstractCli
 			}
 		}
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 	}
 }

--- a/src/Blocks/BlockCli.php
+++ b/src/Blocks/BlockCli.php
@@ -67,7 +67,7 @@ class BlockCli extends AbstractBlocksCli
 					'type' => 'assoc',
 					'name' => 'name',
 					'description' => 'Specify block name.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Blocks/BlockCli.php
+++ b/src/Blocks/BlockCli.php
@@ -74,7 +74,7 @@ class BlockCli extends AbstractBlocksCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore Eightshift.Commenting.FunctionComment.WrongStyle
 	{
 		$this->blocksMove($assocArgs, static::OUTPUT_DIR);
 	}

--- a/src/Blocks/BlockCli.php
+++ b/src/Blocks/BlockCli.php
@@ -27,7 +27,7 @@ class BlockCli extends AbstractBlocksCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Blocks' . DIRECTORY_SEPARATOR . 'custom';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Blocks' . \DIRECTORY_SEPARATOR . 'custom';
 
 	/**
 	 * Get WPCLI command name
@@ -74,7 +74,7 @@ class BlockCli extends AbstractBlocksCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$this->blocksMove($assocArgs, static::OUTPUT_DIR);
 	}

--- a/src/Blocks/BlockCli.php
+++ b/src/Blocks/BlockCli.php
@@ -67,7 +67,7 @@ class BlockCli extends AbstractBlocksCli
 					'type' => 'assoc',
 					'name' => 'name',
 					'description' => 'Specify block name.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Blocks/BlockComponentCli.php
+++ b/src/Blocks/BlockComponentCli.php
@@ -67,7 +67,7 @@ class BlockComponentCli extends AbstractBlocksCli
 					'type' => 'assoc',
 					'name' => 'name',
 					'description' => 'Specify component name.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Blocks/BlockComponentCli.php
+++ b/src/Blocks/BlockComponentCli.php
@@ -74,7 +74,7 @@ class BlockComponentCli extends AbstractBlocksCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore Eightshift.Commenting.FunctionComment.WrongStyle
 	{
 		$this->blocksMove($assocArgs, static::OUTPUT_DIR, true);
 	}

--- a/src/Blocks/BlockComponentCli.php
+++ b/src/Blocks/BlockComponentCli.php
@@ -27,7 +27,7 @@ class BlockComponentCli extends AbstractBlocksCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Blocks' . DIRECTORY_SEPARATOR . 'components';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Blocks' . \DIRECTORY_SEPARATOR . 'components';
 
 	/**
 	 * Get WPCLI command name
@@ -74,7 +74,7 @@ class BlockComponentCli extends AbstractBlocksCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$this->blocksMove($assocArgs, static::OUTPUT_DIR, true);
 	}

--- a/src/Blocks/BlockComponentCli.php
+++ b/src/Blocks/BlockComponentCli.php
@@ -67,7 +67,7 @@ class BlockComponentCli extends AbstractBlocksCli
 					'type' => 'assoc',
 					'name' => 'name',
 					'description' => 'Specify component name.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Blocks/BlockVariationCli.php
+++ b/src/Blocks/BlockVariationCli.php
@@ -63,7 +63,7 @@ class BlockVariationCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'name',
 					'description' => 'Specify variation name.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Blocks/BlockVariationCli.php
+++ b/src/Blocks/BlockVariationCli.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Blocks;
 
 use EightshiftLibs\Cli\AbstractCli;
+use WP_CLI;
 
 /**
  * Class BlockVariationCli
@@ -22,7 +23,7 @@ class BlockVariationCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Blocks' . DIRECTORY_SEPARATOR . 'variations';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Blocks' . \DIRECTORY_SEPARATOR . 'variations';
 
 	/**
 	 * Get WPCLI command name
@@ -69,7 +70,7 @@ class BlockVariationCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$name = $assocArgs['name'] ?? '';
@@ -79,38 +80,38 @@ class BlockVariationCli extends AbstractCli
 
 		$root = $this->getProjectRootPath();
 		$rootNode = $this->getFrontendLibsBlockPath();
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 
 		$path = static::OUTPUT_DIR . $ds . $name;
 		$sourcePathFolder = $rootNode . $ds . static::OUTPUT_DIR . $ds;
 		$sourcePath = "{$sourcePathFolder}{$name}";
 
-		if (!getenv('TEST')) {
+		if (!\getenv('TEST')) {
 			$destinationPath = $root . $ds . $path;
 		} else {
 			$destinationPath = $this->getProjectRootPath(true) . '/cliOutput';
 		}
 
 		// Source doesn't exist.
-		if (!file_exists($sourcePath)) {
+		if (!\file_exists($sourcePath)) {
 			$nameList = '';
-			$filesList = scandir($sourcePathFolder);
+			$filesList = \scandir($sourcePathFolder);
 
 			if (!$filesList) {
 				self::cliError("The folder in the '{$sourcePath}' seems to be empty.");
 			}
 
-			foreach (array_diff((array)$filesList, ['..', '.']) as $item) {
+			foreach (\array_diff((array)$filesList, ['..', '.']) as $item) {
 				$nameList .= "- {$item} \n";
 			}
 
-			\WP_CLI::log(
+			WP_CLI::log(
 				"Please check the docs for all available variations."
 			);
-			\WP_CLI::log(
+			WP_CLI::log(
 				"You can find all available variations on this link: https://infinum.github.io/eightshift-docs/storybook/."
 			);
-			\WP_CLI::log(
+			WP_CLI::log(
 				"Or here is the list of all available variation names: \n{$nameList}"
 			);
 
@@ -118,10 +119,10 @@ class BlockVariationCli extends AbstractCli
 		}
 
 		// Destination exists.
-		if (file_exists($destinationPath) && $skipExisting === false) {
+		if (\file_exists($destinationPath) && $skipExisting === false) {
 			self::cliError(
 				/* translators: %s will be replaced with the path. */
-				sprintf(
+				\sprintf(
 					'The variation in you project exists on this "%s" path. Please check or remove that folder before running this command again.',
 					$destinationPath
 				)
@@ -131,9 +132,9 @@ class BlockVariationCli extends AbstractCli
 		// Move block/component to project folder.
 		$this->copyRecursively($sourcePath, $destinationPath);
 
-		\WP_CLI::success('Variation successfully moved to your project.');
+		WP_CLI::success('Variation successfully moved to your project.');
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
 		foreach ($this->getFullBlocksFiles($name) as $file) {
 			// Set output file path.
@@ -148,8 +149,8 @@ class BlockVariationCli extends AbstractCli
 			}
 		}
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::success('Please start `npm start` again to make sure everything works correctly.');
+		WP_CLI::success('Please start `npm start` again to make sure everything works correctly.');
 	}
 }

--- a/src/Blocks/BlockVariationCli.php
+++ b/src/Blocks/BlockVariationCli.php
@@ -63,7 +63,7 @@ class BlockVariationCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'name',
 					'description' => 'Specify variation name.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Blocks/BlockWrapperCli.php
+++ b/src/Blocks/BlockWrapperCli.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Blocks;
 
 use EightshiftLibs\Cli\AbstractCli;
+use WP_CLI;
 
 /**
  * Class BlockWrapperCli
@@ -22,7 +23,7 @@ class BlockWrapperCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Blocks' . DIRECTORY_SEPARATOR . 'wrapper';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Blocks' . \DIRECTORY_SEPARATOR . 'wrapper';
 
 	/**
 	 * Get WPCLI command name
@@ -47,7 +48,7 @@ class BlockWrapperCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$name = 'wrapper';
@@ -58,36 +59,36 @@ class BlockWrapperCli extends AbstractCli
 		$root = $this->getProjectRootPath();
 		$rootNode = $this->getFrontendLibsBlockPath();
 
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 
 		$path = static::OUTPUT_DIR;
 		$sourcePathFolder = $rootNode . $ds . static::OUTPUT_DIR . $ds;
 		$sourcePath = "{$sourcePathFolder}";
 
-		if (!getenv('TEST')) {
+		if (!\getenv('TEST')) {
 			$destinationPath = $root . $ds . $path;
 		} else {
 			$destinationPath = $this->getProjectRootPath(true) . '/cliOutput';
 		}
 
 		// Destination exists.
-		if (file_exists($destinationPath) && $skipExisting === false) {
+		if (\file_exists($destinationPath) && $skipExisting === false) {
 			self::cliError(
 				/* translators: %s will be replaced with the path. */
-				sprintf(
+				\sprintf(
 					'The wrapper exists in your project on this "%s" path. Please check or remove that folder before running this command again.',
 					$destinationPath
 				)
 			);
 		} else {
-			mkdir("{$destinationPath}/");
+			\mkdir("{$destinationPath}/");
 		}
 
 		$this->copyRecursively($sourcePath, "{$destinationPath}/");
 
-		\WP_CLI::success('Wrapper successfully moved to your project.');
+		WP_CLI::success('Wrapper successfully moved to your project.');
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
 		foreach ($this->getFullBlocksFiles($name) as $file) {
 			// Set output file path.
@@ -102,8 +103,8 @@ class BlockWrapperCli extends AbstractCli
 			}
 		}
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::success('Please start `npm start` again to make sure everything works correctly.');
+		WP_CLI::success('Please start `npm start` again to make sure everything works correctly.');
 	}
 }

--- a/src/Blocks/BlockWrapperCli.php
+++ b/src/Blocks/BlockWrapperCli.php
@@ -74,8 +74,7 @@ class BlockWrapperCli extends AbstractCli
 		// Destination exists.
 		if (\file_exists($destinationPath) && $skipExisting === false) {
 			self::cliError(
-				/* translators: %s will be replaced with the path. */
-				\sprintf(
+				\sprintf( // phpcs:ignore Eightshift.Commenting.FunctionComment.WrongStyle
 					'The wrapper exists in your project on this "%s" path. Please check or remove that folder before running this command again.',
 					$destinationPath
 				)

--- a/src/Blocks/BlocksCli.php
+++ b/src/Blocks/BlocksCli.php
@@ -119,7 +119,7 @@ class BlocksCli extends AbstractCli
 			->renameUse($assocArgs);
 
 		if (! \defined('ES_DEVELOP_MODE')) {
-			if (!$this->isTest && function_exists('\add_action')) {
+			if (!$this->isTest && \function_exists('\add_action')) {
 				$this->blocksInit($assocArgs);
 			}
 		}

--- a/src/Blocks/BlocksCli.php
+++ b/src/Blocks/BlocksCli.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Blocks;
 
 use EightshiftLibs\Cli\AbstractCli;
+use WP_CLI;
 
 /**
  * Class BlocksCli
@@ -29,7 +30,7 @@ class BlocksCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Blocks';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Blocks';
 
 	/**
 	 * List of components
@@ -106,7 +107,7 @@ class BlocksCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 
@@ -149,8 +150,8 @@ class BlocksCli extends AbstractCli
 		];
 
 		foreach ($folders as $folder) {
-			if (!file_exists($folder)) {
-				mkdir($folder);
+			if (!\file_exists($folder)) {
+				\mkdir($folder);
 			}
 		}
 
@@ -159,17 +160,17 @@ class BlocksCli extends AbstractCli
 		$this->copyRecursively("{$rootNode}/src/Blocks/variations/", "{$folders['variations']}/");
 		$this->copyRecursively("{$rootNode}/src/Blocks/manifest.json", "{$folders['blocks']}/");
 
-		\WP_CLI::runcommand("{$this->commandParentName} use_wrapper {$this->prepareArgsManual($args)}");
+		WP_CLI::runcommand("{$this->commandParentName} use_wrapper {$this->prepareArgsManual($args)}");
 
 		foreach (static::COMPONENTS as $component) {
-			\WP_CLI::runcommand("{$this->commandParentName} use_component --name='{$component}' {$this->prepareArgsManual($args)}");
+			WP_CLI::runcommand("{$this->commandParentName} use_component --name='{$component}' {$this->prepareArgsManual($args)}");
 		}
 
 		foreach (static::BLOCKS as $block) {
-			\WP_CLI::runcommand("{$this->commandParentName} use_block --name='{$block}' {$this->prepareArgsManual($args)}");
+			WP_CLI::runcommand("{$this->commandParentName} use_block --name='{$block}' {$this->prepareArgsManual($args)}");
 		}
 
-		\WP_CLI::success('Blocks successfully set.');
+		WP_CLI::success('Blocks successfully set.');
 	}
 
 	/**

--- a/src/Blocks/BlocksExample.php
+++ b/src/Blocks/BlocksExample.php
@@ -35,7 +35,7 @@ class BlocksExample extends AbstractBlocks
 		\add_action('init', [$this, 'registerBlocks'], 11);
 
 		// Remove P tags from content.
-		remove_filter('the_content', 'wpautop');
+		\remove_filter('the_content', 'wpautop');
 
 		// Create new custom category for custom blocks.
 		if (\is_wp_version_compatible('5.8')) {

--- a/src/Blocks/BlocksStorybookCli.php
+++ b/src/Blocks/BlocksStorybookCli.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Blocks;
 
 use EightshiftLibs\Cli\AbstractCli;
+use WP_CLI;
 
 /**
  * Class BlocksStorybookCli
@@ -30,38 +31,38 @@ class BlocksStorybookCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
-		if (function_exists('\add_action')) {
+		if (\function_exists('\add_action')) {
 			$root = $this->getProjectRootPath();
 			$rootNode = $this->getFrontendLibsBlockPath();
 
 			$folder = "{$root}/.storybook";
 
-			if (!file_exists($folder)) {
-				mkdir($folder);
+			if (!\file_exists($folder)) {
+				\mkdir($folder);
 			}
 
 			$this->copyRecursively("{$rootNode}/storybook/", "{$folder}/");
 
-			\WP_CLI::success('Storybook config successfully set.');
+			WP_CLI::success('Storybook config successfully set.');
 
-			\WP_CLI::log('--------------------------------------------------');
+			WP_CLI::log('--------------------------------------------------');
 
-			\WP_CLI::log((string)shell_exec('npm install @eightshift/storybook --save-dev --legacy-peer-deps')); // phpcs:ignore
+			WP_CLI::log((string)shell_exec('npm install @eightshift/storybook --save-dev --legacy-peer-deps')); // phpcs:ignore
 
-			\WP_CLI::success('Storybook package successfully installed.');
+			WP_CLI::success('Storybook package successfully installed.');
 
-			\WP_CLI::log('--------------------------------------------------');
+			WP_CLI::log('--------------------------------------------------');
 
-			\WP_CLI::success('Storybook successfully set.');
-			\WP_CLI::log('Please open you package.json and add this commands in your scripts:');
-			\WP_CLI::log('"storybookBuild": "build-storybook -s public -o storybook"');
-			\WP_CLI::log('"storybook": "start-storybook -s public"');
+			WP_CLI::success('Storybook successfully set.');
+			WP_CLI::log('Please open you package.json and add this commands in your scripts:');
+			WP_CLI::log('"storybookBuild": "build-storybook -s public -o storybook"');
+			WP_CLI::log('"storybook": "start-storybook -s public"');
 
-			\WP_CLI::log('--------------------------------------------------');
+			WP_CLI::log('--------------------------------------------------');
 
-			\WP_CLI::success('To start storybook please run this command `npm run storybook`.');
+			WP_CLI::success('To start storybook please run this command `npm run storybook`.');
 		}
 	}
 }

--- a/src/Blocks/RenderableBlockInterface.php
+++ b/src/Blocks/RenderableBlockInterface.php
@@ -24,7 +24,7 @@ interface RenderableBlockInterface
 	 * @param string $innerBlockContent Block's content if using inner blocks.
 	 *
 	 * @return string
-	 * @throws Exception On missing attributes OR missing template.
+	 * @throws \Exception On missing attributes OR missing template.
 	 */
 	public function render(array $attributes, string $innerBlockContent): string;
 }

--- a/src/Blocks/RenderableBlockInterface.php
+++ b/src/Blocks/RenderableBlockInterface.php
@@ -24,7 +24,7 @@ interface RenderableBlockInterface
 	 * @param string $innerBlockContent Block's content if using inner blocks.
 	 *
 	 * @return string
-	 * @throws \Exception On missing attributes OR missing template.
+	 * @throws Exception On missing attributes OR missing template.
 	 */
 	public function render(array $attributes, string $innerBlockContent): string;
 }

--- a/src/Blocks/RenderableBlockInterface.php
+++ b/src/Blocks/RenderableBlockInterface.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Blocks;
 
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use Exception;
+
 /**
  * Interface Renderable Block.
  *
@@ -24,7 +27,7 @@ interface RenderableBlockInterface
 	 * @param string $innerBlockContent Block's content if using inner blocks.
 	 *
 	 * @return string
-	 * @throws \Exception On missing attributes OR missing template.
+	 * @throws Exception On missing attributes OR missing template.
 	 */
 	public function render(array $attributes, string $innerBlockContent): string;
 }

--- a/src/Build/BuildCli.php
+++ b/src/Build/BuildCli.php
@@ -29,7 +29,7 @@ class BuildCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+	public const OUTPUT_DIR = '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR;
 
 	/**
 	 * Get WPCLI command name
@@ -88,7 +88,7 @@ class BuildCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$root = $assocArgs['root'] ?? static::OUTPUT_DIR;

--- a/src/CiExclude/CiExcludeCli.php
+++ b/src/CiExclude/CiExcludeCli.php
@@ -22,7 +22,7 @@ class CiExcludeCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+	public const OUTPUT_DIR = '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR;
 
 	/**
 	 * Get WPCLI command name
@@ -81,7 +81,7 @@ class CiExcludeCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$root = $assocArgs['root'] ?? static::OUTPUT_DIR;

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -738,10 +738,11 @@ abstract class AbstractCli implements CliInterface
 	 * Loop array of classes and output the commands
 	 *
 	 * @param class-string[] $items Array of classes.
-	 * @param bool  $run Run or log output.
-	 * @param array $args CLI command args.
+	 * @param bool $run Run or log output.
+	 * @param array<string, mixed> $args CLI command args.
 	 *
 	 * @return void
+	 * @throws \ReflectionException Reflection exception.
 	 */
 	public function getEvalLoop(array $items = [], bool $run = false, array $args = []): void
 	{

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -35,17 +35,17 @@ abstract class AbstractCli implements CliInterface
 	 *
 	 * @var string
 	 */
-	protected $commandParentName;
+	protected string $commandParentName;
 
 	/**
 	 * Contents of the example class
 	 *
-	 * When some of the renaming classes will be called, contents will get
+	 * When some renaming classes will be called, contents will get
 	 * stored in this variable. That way we can chain the commands.
 	 *
 	 * @var string
 	 */
-	protected $fileContents;
+	protected string $fileContents;
 
 	/**
 	 * Output dir relative path.

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -307,7 +307,7 @@ abstract class AbstractCli implements CliInterface
 		}
 
 		// Open a new file on output.
-		// If there is any error bailout. For example, user permission.
+		// If there is any error, bailout. For example, user permission.
 		if (\fopen($outputFile, "wb") !== false) {
 			$fp = \fopen($outputFile, "wb");
 

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -121,7 +121,7 @@ abstract class AbstractCli implements CliInterface
 	/**
 	 * Method that creates actual WPCLI command in terminal
 	 *
-	 * @throws Exception Exception in case the WP_CLI::add_command fails.
+	 * @throws \Exception Exception in case the WP_CLI::add_command fails.
 	 *
 	 * @return void
 	 *

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -19,6 +19,8 @@ use ReflectionException;
 use RuntimeException;
 use UnexpectedValueException;
 use WP_CLI;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use Exception;
 
 /**
  * Class AbstractCli
@@ -121,7 +123,7 @@ abstract class AbstractCli implements CliInterface
 	/**
 	 * Method that creates actual WPCLI command in terminal
 	 *
-	 * @throws \Exception Exception in case the WP_CLI::add_command fails.
+	 * @throws Exception Exception in case the WP_CLI::add_command fails.
 	 *
 	 * @return void
 	 *
@@ -742,7 +744,7 @@ abstract class AbstractCli implements CliInterface
 	 * @param array<string, mixed> $args CLI command args.
 	 *
 	 * @return void
-	 * @throws \ReflectionException Reflection exception.
+	 * @throws ReflectionException Reflection exception.
 	 */
 	public function getEvalLoop(array $items = [], bool $run = false, array $args = []): void
 	{
@@ -751,14 +753,14 @@ abstract class AbstractCli implements CliInterface
 
 			$class = $reflectionClass->newInstanceArgs(['null']);
 
-			if (method_exists($class, 'getCommandName')) {
-				if (function_exists('\add_action')) {
-					\WP_CLI::runcommand("{$this->commandParentName} {$class->getCommandName()} {$this->prepareArgsManual($args)}");
+			if (\method_exists($class, 'getCommandName')) {
+				if (\function_exists('\add_action')) {
+					WP_CLI::runcommand("{$this->commandParentName} {$class->getCommandName()} {$this->prepareArgsManual($args)}");
 				} else {
 					if (!$run) {
-						\WP_CLI::log("wp eval-file bin/cli.php {$class->getCommandName()} --skip-wordpress");
+						WP_CLI::log("wp eval-file bin/cli.php {$class->getCommandName()} --skip-wordpress");
 					} else {
-						\WP_CLI::runcommand("eval-file bin/cli.php {$class->getCommandName()} --skip-wordpress");
+						WP_CLI::runcommand("eval-file bin/cli.php {$class->getCommandName()} --skip-wordpress");
 					}
 				}
 			}
@@ -885,7 +887,7 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getSkipExisting(array $args): bool
 	{
-		return isset($args['skip_existing']) ? (bool) $args['skip_existing'] : false;
+		return isset($args['skip_existing']) && $args['skip_existing'];
 	}
 
 	/**
@@ -964,8 +966,8 @@ abstract class AbstractCli implements CliInterface
 			$destinationPath = \rtrim($destination, $ds) . $ds . $subPathName;
 
 			if ($item->isDir()) {
-				if (!file_exists($destinationPath)) {
-					mkdir($destinationPath, 0755, true);
+				if (!\file_exists($destinationPath)) {
+					\mkdir($destinationPath, 0755, true);
 				}
 			} else {
 				\copy($item->getPathname(), $destinationPath);

--- a/src/Cli/Cli.php
+++ b/src/Cli/Cli.php
@@ -49,6 +49,8 @@ use EightshiftLibs\Setup\UpdateCli;
 use EightshiftLibs\ThemeOptions\ThemeOptionsCli;
 use EightshiftLibs\CliCommands\CustomCommandCli;
 use ReflectionClass;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use Exception;
 
 /**
  * Class Cli
@@ -164,7 +166,7 @@ class Cli
 	 *
 	 * @param string[] $args WPCLI eval-file arguments.
 	 *
-	 * @throws \Exception Exception if the class doesn't exist.
+	 * @throws Exception Exception if the class doesn't exist.
 	 *
 	 * @return void
 	 */
@@ -198,7 +200,7 @@ class Cli
 	 *
 	 * @param string $commandParentName Define top level commands name.
 	 *
-	 * @throws \Exception Exception if the class doesn't exist.
+	 * @throws Exception Exception if the class doesn't exist.
 	 *
 	 * @return void
 	 */

--- a/src/Cli/Cli.php
+++ b/src/Cli/Cli.php
@@ -13,7 +13,12 @@ namespace EightshiftLibs\Cli;
 use EightshiftLibs\AdminMenus\AdminMenuCli;
 use EightshiftLibs\AdminMenus\AdminSubMenuCli;
 use EightshiftLibs\BlockPatterns\BlockPatternCli;
-use EightshiftLibs\Blocks\{BlocksCli, BlockComponentCli, BlockCli, BlocksStorybookCli, BlockVariationCli, BlockWrapperCli};
+use EightshiftLibs\Blocks\BlocksCli;
+use EightshiftLibs\Blocks\BlockComponentCli;
+use EightshiftLibs\Blocks\BlockCli;
+use EightshiftLibs\Blocks\BlocksStorybookCli;
+use EightshiftLibs\Blocks\BlockVariationCli;
+use EightshiftLibs\Blocks\BlockWrapperCli;
 use EightshiftLibs\Build\BuildCli;
 use EightshiftLibs\CiExclude\CiExcludeCli;
 use EightshiftLibs\Config\ConfigCli;
@@ -36,12 +41,14 @@ use EightshiftLibs\Menu\MenuCli;
 use EightshiftLibs\ModifyAdminAppearance\ModifyAdminAppearanceCli;
 use EightshiftLibs\Rest\Fields\FieldCli;
 use EightshiftLibs\Rest\Routes\RouteCli;
-use EightshiftLibs\Db\{ExportCli, ImportCli};
+use EightshiftLibs\Db\ExportCli;
+use EightshiftLibs\Db\ImportCli;
 use EightshiftLibs\GitIgnore\GitIgnoreCli;
 use EightshiftLibs\Readme\ReadmeCli;
 use EightshiftLibs\Setup\UpdateCli;
 use EightshiftLibs\ThemeOptions\ThemeOptionsCli;
 use EightshiftLibs\CliCommands\CustomCommandCli;
+use ReflectionClass;
 
 /**
  * Class Cli
@@ -131,7 +138,7 @@ class Cli
 	 */
 	public function getDevelopClasses(): array
 	{
-		return array_merge(
+		return \array_merge(
 			static::CLASSES_LIST,
 			static::DEVELOP_CLASSES,
 			static::SETUP_CLASSES
@@ -145,7 +152,7 @@ class Cli
 	 */
 	public function getPublicClasses(): array
 	{
-		return array_merge(
+		return \array_merge(
 			static::CLASSES_LIST,
 			static::PUBLIC_CLASSES,
 			static::SETUP_CLASSES
@@ -157,7 +164,7 @@ class Cli
 	 *
 	 * @param string[] $args WPCLI eval-file arguments.
 	 *
-	 * @throws \ReflectionException Exception if the class doesn't exist.
+	 * @throws ReflectionException Exception if the class doesn't exist.
 	 *
 	 * @return void
 	 */
@@ -170,10 +177,10 @@ class Cli
 		}
 
 		foreach ($this->getDevelopClasses() as $item) {
-			$reflectionClass = new \ReflectionClass($item);
+			$reflectionClass = new ReflectionClass($item);
 			$class = $reflectionClass->newInstanceArgs(['null']);
 
-			if (method_exists($class, 'getCommandName') && method_exists($class, 'getDevelopArgs') && method_exists($class, '__invoke')) {
+			if (\method_exists($class, 'getCommandName') && \method_exists($class, 'getDevelopArgs') && \method_exists($class, '__invoke')) {
 				if ($class->getCommandName() === $commandName) {
 					$class->__invoke(
 						[],
@@ -191,14 +198,14 @@ class Cli
 	 *
 	 * @param string $commandParentName Define top level commands name.
 	 *
-	 * @throws \ReflectionException Exception if the class doesn't exist.
+	 * @throws ReflectionException Exception if the class doesn't exist.
 	 *
 	 * @return void
 	 */
 	public function load(string $commandParentName): void
 	{
 		foreach ($this->getPublicClasses() as $item) {
-			$reflectionClass = new \ReflectionClass($item);
+			$reflectionClass = new ReflectionClass($item);
 			$class = $reflectionClass->newInstanceArgs([$commandParentName]);
 
 			if ($class instanceof CliInterface) {

--- a/src/Cli/Cli.php
+++ b/src/Cli/Cli.php
@@ -164,7 +164,7 @@ class Cli
 	 *
 	 * @param string[] $args WPCLI eval-file arguments.
 	 *
-	 * @throws ReflectionException Exception if the class doesn't exist.
+	 * @throws \Exception Exception if the class doesn't exist.
 	 *
 	 * @return void
 	 */
@@ -198,7 +198,7 @@ class Cli
 	 *
 	 * @param string $commandParentName Define top level commands name.
 	 *
-	 * @throws ReflectionException Exception if the class doesn't exist.
+	 * @throws \Exception Exception if the class doesn't exist.
 	 *
 	 * @return void
 	 */

--- a/src/Cli/CliHelpers.php
+++ b/src/Cli/CliHelpers.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Cli;
 
+use WP_CLI;
 use WP_CLI\ExitException;
 
 /**
@@ -29,11 +30,11 @@ trait CliHelpers
 	public static function cliError(string $errorMessage): void
 	{
 		try {
-			\WP_CLI::error($errorMessage);
+			WP_CLI::error($errorMessage);
 			// @codeCoverageIgnoreStart
 			// Cannot test the exit.
 		} catch (ExitException $e) {
-			exit("{$e->getCode()}: {$e->getMessage()}"); // phpcs:ignore Eightshift.Security.CustomEscapeOutput.OutputNotEscaped
+			exit("{$e->getCode()}: {$e->getMessage()}"); // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
 			// @codeCoverageIgnoreEnd
 		}
 	}
@@ -46,9 +47,9 @@ trait CliHelpers
 	 */
 	public static function camelCaseToKebabCase(string $input): string
 	{
-		$output = ltrim(strtolower((string)preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $input)), '-');
-		$output = str_replace(['_', ' '], '-', $output);
-		return str_replace('--', '-', $output);
+		$output = \ltrim(\strtolower((string)\preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $input)), '-');
+		$output = \str_replace(['_', ' '], '-', $output);
+		return \str_replace('--', '-', $output);
 	}
 
 	/**
@@ -61,7 +62,7 @@ trait CliHelpers
 	 */
 	public static function kebabToCamelCase(string $string, string $separator = '-'): string
 	{
-		return lcfirst(str_replace($separator, '', ucwords(mb_strtolower($string), $separator)));
+		return \lcfirst(\str_replace($separator, '', \ucwords(mb_\strtolower($string), $separator)));
 	}
 
 	/**
@@ -74,12 +75,12 @@ trait CliHelpers
 	{
 
 		// If the plugin doesn't have a namespace, we're good, just return it.
-		if (strpos($name, '/') === false) {
+		if (\strpos($name, '/') === false) {
 			return $name;
 		}
 
-		$splitName = explode('/', $name);
+		$splitName = \explode('/', $name);
 
-		return $splitName[count($splitName) - 1];
+		return $splitName[\count($splitName) - 1];
 	}
 }

--- a/src/Cli/CliHelpers.php
+++ b/src/Cli/CliHelpers.php
@@ -47,7 +47,7 @@ trait CliHelpers
 	 */
 	public static function camelCaseToKebabCase(string $input): string
 	{
-		$output = \ltrim(\strtolower((string)\preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $input)), '-');
+		$output = \ltrim(\mb_strtolower((string)\preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $input)), '-');
 		$output = \str_replace(['_', ' '], '-', $output);
 		return \str_replace('--', '-', $output);
 	}
@@ -62,7 +62,7 @@ trait CliHelpers
 	 */
 	public static function kebabToCamelCase(string $string, string $separator = '-'): string
 	{
-		return \lcfirst(\str_replace($separator, '', \ucwords(mb_\strtolower($string), $separator)));
+		return \lcfirst(\str_replace($separator, '', \ucwords(\mb_strtolower($string), $separator)));
 	}
 
 	/**

--- a/src/Cli/CliInitAll.php
+++ b/src/Cli/CliInitAll.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Cli;
 
+use WP_CLI;
+
 /**
  * Class CliInitAll
  */
@@ -47,12 +49,12 @@ class CliInitAll extends AbstractCli
 	/* @phpstan-ignore-next-line */
 	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
 	{
-		if (!function_exists('\add_action')) {
+		if (!\function_exists('\add_action')) {
 			$this->runReset();
-			\WP_CLI::log('--------------------------------------------------');
+			WP_CLI::log('--------------------------------------------------');
 		}
 
-		$classes = array_merge(
+		$classes = \array_merge(
 			Cli::CLASSES_LIST,
 			Cli::PUBLIC_CLASSES,
 			Cli::SETUP_CLASSES
@@ -60,12 +62,12 @@ class CliInitAll extends AbstractCli
 
 		$this->getEvalLoop($classes, true, $assocArgs);
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
+		WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::success('All commands are finished.');
+		WP_CLI::success('All commands are finished.');
 	}
 }

--- a/src/Cli/CliInitAll.php
+++ b/src/Cli/CliInitAll.php
@@ -64,7 +64,9 @@ class CliInitAll extends AbstractCli
 
 		WP_CLI::log('--------------------------------------------------');
 
-		WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
+		if (!\getenv('TEST')) {
+			WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
+		}
 
 		WP_CLI::log('--------------------------------------------------');
 

--- a/src/Cli/CliInitProject.php
+++ b/src/Cli/CliInitProject.php
@@ -102,7 +102,9 @@ class CliInitProject extends AbstractCli
 
 		WP_CLI::log('--------------------------------------------------');
 
-		WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
+		if (!\getenv('TEST')) {
+			WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
+		}
 
 		WP_CLI::log('--------------------------------------------------');
 

--- a/src/Cli/CliInitProject.php
+++ b/src/Cli/CliInitProject.php
@@ -24,6 +24,8 @@ use EightshiftLibs\Manifest\ManifestCli;
 use EightshiftLibs\Menu\MenuCli;
 use EightshiftLibs\Readme\ReadmeCli;
 use EightshiftLibs\Setup\SetupCli;
+use ReflectionClass;
+use WP_CLI;
 
 /**
  * Class CliInitProject
@@ -77,33 +79,33 @@ class CliInitProject extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
-		if (!function_exists('\add_action')) {
+		if (!\function_exists('\add_action')) {
 			$this->runReset();
-			\WP_CLI::log('--------------------------------------------------');
+			WP_CLI::log('--------------------------------------------------');
 		}
 
 		foreach (static::INIT_PROJECT_CLASSES as $item) {
-			$reflectionClass = new \ReflectionClass($item);
+			$reflectionClass = new ReflectionClass($item);
 
 			$class = $reflectionClass->newInstanceArgs([$this->commandParentName]);
 
-			if (method_exists($class, 'getCommandName')) {
-				if (function_exists('\add_action')) {
-					\WP_CLI::runcommand("{$this->commandParentName} {$class->getCommandName()} {$this->prepareArgsManual($assocArgs)}");
+			if (\method_exists($class, 'getCommandName')) {
+				if (\function_exists('\add_action')) {
+					WP_CLI::runcommand("{$this->commandParentName} {$class->getCommandName()} {$this->prepareArgsManual($assocArgs)}");
 				} else {
-					\WP_CLI::runcommand("eval-file bin" . DIRECTORY_SEPARATOR . "cli.php {$class->getCommandName()} {$this->prepareArgsManual($assocArgs)} --skip-wordpress");
+					WP_CLI::runcommand("eval-file bin" . \DIRECTORY_SEPARATOR . "cli.php {$class->getCommandName()} {$this->prepareArgsManual($assocArgs)} --skip-wordpress");
 				}
 			}
 		}
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
+		WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::success('All commands are finished.');
+		WP_CLI::success('All commands are finished.');
 	}
 }

--- a/src/Cli/CliInitTheme.php
+++ b/src/Cli/CliInitTheme.php
@@ -18,6 +18,8 @@ use EightshiftLibs\Enqueue\Theme\EnqueueThemeCli;
 use EightshiftLibs\Main\MainCli;
 use EightshiftLibs\Manifest\ManifestCli;
 use EightshiftLibs\Menu\MenuCli;
+use ReflectionClass;
+use WP_CLI;
 
 /**
  * Class CliInitTheme
@@ -70,33 +72,33 @@ class CliInitTheme extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
-		if (!function_exists('\add_action')) {
+		if (!\function_exists('\add_action')) {
 			$this->runReset();
-			\WP_CLI::log('--------------------------------------------------');
+			WP_CLI::log('--------------------------------------------------');
 		}
 
 		foreach (static::INIT_THEME_CLASSES as $item) {
-			$reflectionClass = new \ReflectionClass($item);
+			$reflectionClass = new ReflectionClass($item);
 
 			$class = $reflectionClass->newInstanceArgs([$this->commandParentName]);
 
-			if (method_exists($class, 'getCommandName')) {
-				if (function_exists('\add_action')) {
-					\WP_CLI::runcommand("{$this->commandParentName} {$class->getCommandName()} {$this->prepareArgsManual($assocArgs)}");
+			if (\method_exists($class, 'getCommandName')) {
+				if (\function_exists('\add_action')) {
+					WP_CLI::runcommand("{$this->commandParentName} {$class->getCommandName()} {$this->prepareArgsManual($assocArgs)}");
 				} else {
-					\WP_CLI::runcommand("eval-file bin" . DIRECTORY_SEPARATOR . "cli.php {$class->getCommandName()} {$this->prepareArgsManual($assocArgs)} --skip-wordpress");
+					WP_CLI::runcommand("eval-file bin" . \DIRECTORY_SEPARATOR . "cli.php {$class->getCommandName()} {$this->prepareArgsManual($assocArgs)} --skip-wordpress");
 				}
 			}
 		}
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
+		WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::success('All commands are finished.');
+		WP_CLI::success('All commands are finished.');
 	}
 }

--- a/src/Cli/CliInitTheme.php
+++ b/src/Cli/CliInitTheme.php
@@ -95,8 +95,10 @@ class CliInitTheme extends AbstractCli
 
 		WP_CLI::log('--------------------------------------------------');
 
-		WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
-
+		if (!\getenv('TEST')) {
+			WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
+		}
+		
 		WP_CLI::log('--------------------------------------------------');
 
 		WP_CLI::success('All commands are finished.');

--- a/src/Cli/CliInitTheme.php
+++ b/src/Cli/CliInitTheme.php
@@ -98,7 +98,7 @@ class CliInitTheme extends AbstractCli
 		if (!\getenv('TEST')) {
 			WP_CLI::log((string)shell_exec('npm run start')); // phpcs:ignore
 		}
-		
+
 		WP_CLI::log('--------------------------------------------------');
 
 		WP_CLI::success('All commands are finished.');

--- a/src/Cli/CliReset.php
+++ b/src/Cli/CliReset.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Cli;
 
+use WP_CLI;
+
 /**
  * Class CliReset
  */
@@ -40,14 +42,14 @@ class CliReset extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$outputDir = $this->getOutputDir('');
 
-		if (is_dir($outputDir)) {
-			rmdir($outputDir);
+		if (\is_dir($outputDir)) {
+			\rmdir($outputDir);
 
-			\WP_CLI::success('Output directory successfully removed.');
+			WP_CLI::success('Output directory successfully removed.');
 		}
 	}
 }

--- a/src/Cli/CliRunAll.php
+++ b/src/Cli/CliRunAll.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Cli;
 
+use WP_CLI;
+
 /**
  * Class CliRunAll
  */
@@ -40,16 +42,16 @@ class CliRunAll extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$this->runReset();
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
 		$this->getEvalLoop(Cli::CLASSES_LIST, true);
 
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::log('--------------------------------------------------');
 
-		\WP_CLI::success('All commands are finished.');
+		WP_CLI::success('All commands are finished.');
 	}
 }

--- a/src/Cli/CliShowAll.php
+++ b/src/Cli/CliShowAll.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Cli;
 
+use WP_CLI;
+
 /**
  * Class CliShowAll
  */
@@ -40,32 +42,32 @@ class CliShowAll extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
-		\WP_CLI::log(\WP_CLI::colorize('%mCommands for wp-cli and development:%n'));
+		WP_CLI::log(WP_CLI::colorize('%mCommands for wp-cli and development:%n'));
 
 		$this->getEvalLoop(Cli::CLASSES_LIST);
 
-		\WP_CLI::log('-----------------------------------------');
+		WP_CLI::log('-----------------------------------------');
 
-		\WP_CLI::log(\WP_CLI::colorize('%mCommands for wp-cli only:%n'));
+		WP_CLI::log(WP_CLI::colorize('%mCommands for wp-cli only:%n'));
 
 		$this->getEvalLoop(Cli::PUBLIC_CLASSES);
 
-		\WP_CLI::log('-----------------------------------------');
+		WP_CLI::log('-----------------------------------------');
 
-		\WP_CLI::log(\WP_CLI::colorize('%mCommands for development:%n'));
+		WP_CLI::log(WP_CLI::colorize('%mCommands for development:%n'));
 
 		$this->getEvalLoop(Cli::DEVELOP_CLASSES);
 
-		\WP_CLI::log('-----------------------------------------');
+		WP_CLI::log('-----------------------------------------');
 
-		\WP_CLI::log(\WP_CLI::colorize('%mCommands for project setup:%n'));
+		WP_CLI::log(WP_CLI::colorize('%mCommands for project setup:%n'));
 
 		$this->getEvalLoop(Cli::SETUP_CLASSES);
 
-		\WP_CLI::log('-----------------------------------------');
+		WP_CLI::log('-----------------------------------------');
 
-		\WP_CLI::success('All commands are outputted.');
+		WP_CLI::success('All commands are outputted.');
 	}
 }

--- a/src/CliCommands/AbstractCustomCommand.php
+++ b/src/CliCommands/AbstractCustomCommand.php
@@ -130,7 +130,7 @@ abstract class AbstractCustomCommand implements ServiceInterface
 	/**
 	 * Method that creates actual WPCLI command in terminal
 	 *
-	 * @throws Exception Exception in case the WP_CLI::add_command fails.
+	 * @throws \Exception Exception in case the WP_CLI::add_command fails.
 	 *
 	 * @return void
 	 *  phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag.Missing

--- a/src/CliCommands/AbstractCustomCommand.php
+++ b/src/CliCommands/AbstractCustomCommand.php
@@ -16,6 +16,8 @@ use ReflectionClass;
 use ReflectionException;
 use RuntimeException;
 use WP_CLI;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use Exception;
 
 /**
  * Abstract base custom command class
@@ -130,7 +132,7 @@ abstract class AbstractCustomCommand implements ServiceInterface
 	/**
 	 * Method that creates actual WPCLI command in terminal
 	 *
-	 * @throws \Exception Exception in case the WP_CLI::add_command fails.
+	 * @throws Exception Exception in case the WP_CLI::add_command fails.
 	 *
 	 * @return void
 	 *  phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag.Missing

--- a/src/CliCommands/CustomCommandCli.php
+++ b/src/CliCommands/CustomCommandCli.php
@@ -70,7 +70,7 @@ class CustomCommandCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'command_name',
 					'description' => 'The name of cli command name. Example: command_name.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/CliCommands/CustomCommandCli.php
+++ b/src/CliCommands/CustomCommandCli.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\CliCommands;
 
 use EightshiftLibs\Cli\AbstractCli;
+use WP_CLI;
 
 /**
  * Class CustomCommandCli
@@ -29,7 +30,7 @@ class CustomCommandCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'CliCommands';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'CliCommands';
 
 	/**
 	 * Get WPCLI command name
@@ -76,7 +77,7 @@ class CustomCommandCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$commandName = $this->prepareSlug($assocArgs['command_name'] ?? 'custom-command');
@@ -87,7 +88,7 @@ class CustomCommandCli extends AbstractCli
 
 		// If slug is empty throw error.
 		if (empty($commandName)) {
-			\WP_CLI::error("Empty command name provided, please set the command name using --command_name=\"command-name\"");
+			WP_CLI::error("Empty command name provided, please set the command name using --command_name=\"command-name\"");
 		}
 
 		// Read the template contents, and replace the placeholders with provided variables.

--- a/src/CliCommands/CustomCommandExample.php
+++ b/src/CliCommands/CustomCommandExample.php
@@ -47,7 +47,7 @@ class CustomCommandExample extends AbstractCustomCommand
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs)
+	public function __invoke(array $args, array $assocArgs) // phpcs:ignore Eightshift.Commenting.FunctionComment.WrongStyle
 	{
 		// Place your logic here.
 	}

--- a/src/CliCommands/CustomCommandExample.php
+++ b/src/CliCommands/CustomCommandExample.php
@@ -47,7 +47,7 @@ class CustomCommandExample extends AbstractCustomCommand
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Place your logic here.
 	}

--- a/src/Config/AbstractConfigData.php
+++ b/src/Config/AbstractConfigData.php
@@ -31,21 +31,19 @@ abstract class AbstractConfigData implements ConfigDataInterface
 	public static function getProjectPath(string $path = ''): string
 	{
 		$locations = [
-			\trailingslashit(dirname(__DIR__, 5)) . $path,
+			\trailingslashit(\dirname(__DIR__, 5)) . $path,
 			\trailingslashit(\get_stylesheet_directory()) . $path,
 			\trailingslashit(\get_template_directory()) . $path,
 		];
 
 		foreach ($locations as $location) {
-			if (is_readable($location)) {
+			if (\is_readable($location)) {
 				return $location;
 			}
 		}
 
-		if (! \defined('ES_DEVELOP_MODE')) {
-			if (!is_readable($path)) {
-				throw InvalidPath::fromUri($path);
-			}
+		if (!\is_readable($path)) {
+			throw InvalidPath::fromUri($path);
 		}
 
 		return $path;

--- a/src/Config/ConfigCli.php
+++ b/src/Config/ConfigCli.php
@@ -20,7 +20,7 @@ class ConfigCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Config';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Config';
 
 	/**
 	 * Define default develop props.
@@ -71,7 +71,7 @@ class ConfigCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$name = $assocArgs['name'] ?? '';

--- a/src/ConfigProject/ConfigProjectCli.php
+++ b/src/ConfigProject/ConfigProjectCli.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\ConfigProject;
 
 use EightshiftLibs\Cli\AbstractCli;
+use WP_CLI;
 
 /**
  * Class ConfigProjectCli
@@ -20,7 +21,7 @@ class ConfigProjectCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+	public const OUTPUT_DIR = '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR;
 
 	/**
 	 * Get WPCLI command name
@@ -67,7 +68,7 @@ class ConfigProjectCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$root = $assocArgs['root'] ?? static::OUTPUT_DIR;
@@ -80,13 +81,13 @@ class ConfigProjectCli extends AbstractCli
 		// Output final class to new file/folder and finish.
 		$class->outputWrite($root, 'wp-config-project.php', $assocArgs);
 
-		\WP_CLI::success("Please do the following steps manually to complete the setup:");
-		\WP_CLI::success("1. In wp-config.php - Make sure to define WP_ENVIRONMENT_TYPE const to 'development' like so: <?php define( 'WP_ENVIRONMENT_TYPE', 'development' ); ?>`");
-		\WP_CLI::success("2. In wp-config.php - Make sure to require wp-config-project.php (at the end of the file) but before the wp-settings.php. Like this:`);");
-		\WP_CLI::success("
+		WP_CLI::success("Please do the following steps manually to complete the setup:");
+		WP_CLI::success("1. In wp-config.php - Make sure to define WP_ENVIRONMENT_TYPE const to 'development' like so: <?php define( 'WP_ENVIRONMENT_TYPE', 'development' ); ?>`");
+		WP_CLI::success("2. In wp-config.php - Make sure to require wp-config-project.php (at the end of the file) but before the wp-settings.php. Like this:`);");
+		WP_CLI::success("
 		/** Absolute path to the WordPress directory. */
-		if ( !defined('ABSPATH') ) {
-			define('ABSPATH', dirname(__FILE__) . '/');
+		if ( !\defined('ABSPATH') ) {
+			define('ABSPATH', \dirname(__FILE__) . '/');
 		}
 		
 		// Include wp config for your project.

--- a/src/ConfigProject/ConfigProjectExample.php
+++ b/src/ConfigProject/ConfigProjectExample.php
@@ -10,7 +10,7 @@
  */
 
 // phpcs:disable
-if (!defined('WP_ENVIRONMENT_TYPE')) {
+if (!\defined('WP_ENVIRONMENT_TYPE')) {
 	return false;
 }
 
@@ -32,14 +32,14 @@ define('AUTOSAVE_INTERVAL', 240);
 // Disable automatic updating of plugins.
 define('AUTOMATIC_UPDATER_DISABLED', true);
 
-if (WP_ENVIRONMENT_TYPE !== 'production') {
+if (\WP_ENVIRONMENT_TYPE !== 'production') {
 	// Enable debug and error logging.
 	define('WP_DEBUG', true);
 	define('WP_DEBUG_LOG', true);
 }
 
 // Environment based setup.
-if (WP_ENVIRONMENT_TYPE === 'development' || WP_ENVIRONMENT_TYPE === 'local') {
+if (\WP_ENVIRONMENT_TYPE === 'development' || \WP_ENVIRONMENT_TYPE === 'local') {
 	// Enable direct upload from admin.
 	define('FS_METHOD', 'direct');
 

--- a/src/CustomMeta/AbstractAcfMeta.php
+++ b/src/CustomMeta/AbstractAcfMeta.php
@@ -25,7 +25,7 @@ abstract class AbstractAcfMeta implements ServiceInterface
 	public function register(): void
 	{
 		// Silently exit if no ACF is installed.
-		if (!class_exists('ACF')) {
+		if (!\class_exists('ACF')) {
 			return;
 		}
 

--- a/src/CustomMeta/AcfMetaCli.php
+++ b/src/CustomMeta/AcfMetaCli.php
@@ -22,7 +22,7 @@ class AcfMetaCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'CustomMeta';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'CustomMeta';
 
 	/**
 	 * Define default develop props.
@@ -59,7 +59,7 @@ class AcfMetaCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$fieldName = $this->prepareSlug($assocArgs['name'] ?? '');

--- a/src/CustomMeta/AcfMetaCli.php
+++ b/src/CustomMeta/AcfMetaCli.php
@@ -52,7 +52,7 @@ class AcfMetaCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'name',
 					'description' => 'The name of the custom meta slug. Example: title.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/CustomMeta/AcfMetaCli.php
+++ b/src/CustomMeta/AcfMetaCli.php
@@ -52,7 +52,7 @@ class AcfMetaCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'name',
 					'description' => 'The name of the custom meta slug. Example: title.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/CustomMeta/AcfMetaExample.php
+++ b/src/CustomMeta/AcfMetaExample.php
@@ -24,7 +24,7 @@ class AcfMetaExample extends AbstractAcfMeta
 	 */
 	public function fields(): void
 	{
-		if (function_exists('acf_add_local_field_group')) {
+		if (\function_exists('acf_add_local_field_group')) {
 			\acf_add_local_field_group([]);
 		}
 	}

--- a/src/CustomPostType/AbstractPostType.php
+++ b/src/CustomPostType/AbstractPostType.php
@@ -107,7 +107,7 @@ abstract class AbstractPostType implements ServiceInterface
 	protected function getGeneratedLabels(array $nouns): array
 	{
 		foreach (self::REQUIRED_NOUNS as $nounKey) {
-			if (!array_key_exists($nounKey, $nouns)) {
+			if (!\array_key_exists($nounKey, $nouns)) {
 				throw InvalidNouns::fromKey($nounKey);
 			}
 		}
@@ -174,9 +174,9 @@ abstract class AbstractPostType implements ServiceInterface
 			'filter_by_date' => \esc_html__('Filter by date', 'eightshift-libs'),
 		];
 
-		return array_map(
+		return \array_map(
 			static function ($label) use ($nouns) {
-				return sprintf(
+				return \sprintf(
 					$label,
 					$nouns[self::SINGULAR_NAME_UC],
 					$nouns[self::SINGULAR_NAME_LC],

--- a/src/CustomPostType/PostTypeCli.php
+++ b/src/CustomPostType/PostTypeCli.php
@@ -22,7 +22,7 @@ class PostTypeCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'CustomPostType';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'CustomPostType';
 
 	/**
 	 * Define default develop props.
@@ -108,7 +108,7 @@ class PostTypeCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$label = $assocArgs['label'] ?? 'Custom Post Type';
@@ -134,9 +134,9 @@ class PostTypeCli extends AbstractCli
 			->searchReplaceString('example-url-slug', $rewriteUrl)
 			->searchReplaceString('example-endpoint-slug', $restEndpointSlug)
 			->searchReplaceString('Singular Name', $label)
-			->searchReplaceString('singular name', strtolower($label))
+			->searchReplaceString('singular name', \strtolower($label))
 			->searchReplaceString('Plural Name', $pluralLabel)
-			->searchReplaceString('plural name', strtolower($pluralLabel));
+			->searchReplaceString('plural name', \strtolower($pluralLabel));
 
 		if (!empty($capability)) {
 			$class->searchReplaceString("'post'", "'{$capability}'");

--- a/src/CustomPostType/PostTypeCli.php
+++ b/src/CustomPostType/PostTypeCli.php
@@ -59,25 +59,25 @@ class PostTypeCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'label',
 					'description' => 'The label of the custom post type to show in WP admin.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'slug',
 					'description' => 'The custom post type slug. Example: location.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'rewrite_url',
 					'description' => 'The custom post type url. Example: location.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'rest_endpoint_slug',
 					'description' => 'The name of the custom post type REST-API endpoint slug. Example: locations.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',

--- a/src/CustomTaxonomy/TaxonomyCli.php
+++ b/src/CustomTaxonomy/TaxonomyCli.php
@@ -23,7 +23,7 @@ class TaxonomyCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'CustomTaxonomy';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'CustomTaxonomy';
 
 	/**
 	 * Define default develop props.
@@ -81,7 +81,7 @@ class TaxonomyCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$label = $assocArgs['label'] ?? 'Example Name';

--- a/src/CustomTaxonomy/TaxonomyCli.php
+++ b/src/CustomTaxonomy/TaxonomyCli.php
@@ -56,25 +56,25 @@ class TaxonomyCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'label',
 					'description' => 'The label of the custom taxonomy to show in WP admin.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'slug',
 					'description' => 'The name of the custom taxonomy slug. Example: location.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'rest_endpoint_slug',
 					'description' => 'The name of the custom taxonomy REST-API endpoint slug. Example: locations.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'post_type_slug',
 					'description' => 'The position where to assign the new custom taxonomy. Example: post.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/CustomTaxonomy/TaxonomyCli.php
+++ b/src/CustomTaxonomy/TaxonomyCli.php
@@ -56,25 +56,25 @@ class TaxonomyCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'label',
 					'description' => 'The label of the custom taxonomy to show in WP admin.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'slug',
 					'description' => 'The name of the custom taxonomy slug. Example: location.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'rest_endpoint_slug',
 					'description' => 'The name of the custom taxonomy REST-API endpoint slug. Example: locations.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'post_type_slug',
 					'description' => 'The position where to assign the new custom taxonomy. Example: post.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Db/ExportCli.php
+++ b/src/Db/ExportCli.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Db;
 
 use EightshiftLibs\Cli\AbstractCli;
+use WP_CLI\ExitException;
 
 /**
  * Class ExportCli
@@ -54,16 +55,20 @@ class ExportCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		require $this->getLibsPath('src/Db/DbExport.php');
 
-		dbExport(
-			$this->getProjectConfigRootPath(),
-			[
-				'skip_db' => $assocArgs['skip_db'] ?? false,
-				'skip_uploads' => $assocArgs['skip_uploads'] ?? false,
-			]
-		);
+		try {
+			dbExport( // phpcs:ignore
+				$this->getProjectConfigRootPath(),
+				[
+					'skip_db' => $assocArgs['skip_db'] ?? false,
+					'skip_uploads' => $assocArgs['skip_uploads'] ?? false,
+				]
+			);
+		} catch (ExitException $e) {
+			exit("{$e->getCode()}: {$e->getMessage()}"); // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
+		}
 	}
 }

--- a/src/Db/ImportCli.php
+++ b/src/Db/ImportCli.php
@@ -55,12 +55,12 @@ class ImportCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		require $this->getLibsPath('src/Db/DbImport.php');
 
 		try {
-			dbImport(
+			dbImport( // phpcs:ignore
 				$this->getProjectConfigRootPath(),
 				[
 					'from' => $assocArgs['from'] ?? '',
@@ -68,7 +68,7 @@ class ImportCli extends AbstractCli
 				]
 			);
 		} catch (ExitException $e) {
-			exit("{$e->getCode()}: {$e->getMessage()}"); // phpcs:ignore Eightshift.Security.CustomEscapeOutput.OutputNotEscaped
+			exit("{$e->getCode()}: {$e->getMessage()}"); // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
 		}
 	}
 }

--- a/src/Enqueue/Admin/AbstractEnqueueAdmin.php
+++ b/src/Enqueue/Admin/AbstractEnqueueAdmin.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Enqueue\Admin;
 
 use EightshiftLibs\Enqueue\AbstractAssets;
+use EightshiftLibs\Manifest\ManifestInterface;
 
 /**
  * Class EnqueueAdmin
@@ -27,7 +28,7 @@ abstract class AbstractEnqueueAdmin extends AbstractAssets
 	 *
 	 * @var ManifestInterface
 	 */
-	protected $manifest;
+	protected ManifestInterface $manifest;
 
 	/**
 	 * Register the Stylesheets for the admin area.

--- a/src/Enqueue/Admin/AbstractEnqueueAdmin.php
+++ b/src/Enqueue/Admin/AbstractEnqueueAdmin.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace EightshiftLibs\Enqueue\Admin;
 
 use EightshiftLibs\Enqueue\AbstractAssets;
-use EightshiftLibs\Manifest\ManifestInterface;
 
 /**
  * Class EnqueueAdmin
@@ -91,7 +90,7 @@ abstract class AbstractEnqueueAdmin extends AbstractAssets
 
 		$screen = \get_current_screen();
 
-		if (is_object($screen) && $screen->is_block_editor) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+		if (\is_object($screen) && $screen->is_block_editor) { // phpcs:ignore Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 			return true;
 		}
 

--- a/src/Enqueue/Admin/EnqueueAdminCli.php
+++ b/src/Enqueue/Admin/EnqueueAdminCli.php
@@ -20,7 +20,7 @@ class EnqueueAdminCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Enqueue' . DIRECTORY_SEPARATOR . 'Admin';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Enqueue' . \DIRECTORY_SEPARATOR . 'Admin';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class EnqueueAdminCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
+++ b/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Enqueue\Blocks;
 
 use EightshiftLibs\Enqueue\AbstractAssets;
+use EightshiftLibs\Manifest\ManifestInterface;
 
 /**
  * Enqueue_Blocks class.
@@ -30,7 +31,7 @@ abstract class AbstractEnqueueBlocks extends AbstractAssets
 	 *
 	 * @var ManifestInterface
 	 */
-	protected $manifest;
+	protected ManifestInterface $manifest;
 
 	/**
 	 * Enqueue blocks script for editor only.

--- a/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
+++ b/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace EightshiftLibs\Enqueue\Blocks;
 
 use EightshiftLibs\Enqueue\AbstractAssets;
-use EightshiftLibs\Manifest\ManifestInterface;
 
 /**
  * Enqueue_Blocks class.

--- a/src/Enqueue/Blocks/EnqueueBlocksCli.php
+++ b/src/Enqueue/Blocks/EnqueueBlocksCli.php
@@ -22,7 +22,7 @@ class EnqueueBlocksCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Enqueue' . DIRECTORY_SEPARATOR . 'Blocks';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Enqueue' . \DIRECTORY_SEPARATOR . 'Blocks';
 
 	/**
 	 * Get WPCLI command doc
@@ -37,7 +37,7 @@ class EnqueueBlocksCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/Enqueue/Theme/AbstractEnqueueTheme.php
+++ b/src/Enqueue/Theme/AbstractEnqueueTheme.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Enqueue\Theme;
 
 use EightshiftLibs\Enqueue\AbstractAssets;
+use EightshiftLibs\Manifest\ManifestInterface;
 
 /**
  * Class Enqueue
@@ -25,7 +26,7 @@ abstract class AbstractEnqueueTheme extends AbstractAssets
 	 *
 	 * @var ManifestInterface
 	 */
-	protected $manifest;
+	protected ManifestInterface $manifest;
 
 	/**
 	 * Register the Stylesheets for the front end of the theme.

--- a/src/Enqueue/Theme/AbstractEnqueueTheme.php
+++ b/src/Enqueue/Theme/AbstractEnqueueTheme.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace EightshiftLibs\Enqueue\Theme;
 
 use EightshiftLibs\Enqueue\AbstractAssets;
-use EightshiftLibs\Manifest\ManifestInterface;
 
 /**
  * Class Enqueue

--- a/src/Enqueue/Theme/EnqueueThemeCli.php
+++ b/src/Enqueue/Theme/EnqueueThemeCli.php
@@ -20,7 +20,7 @@ class EnqueueThemeCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Enqueue' . DIRECTORY_SEPARATOR . 'Theme';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Enqueue' . \DIRECTORY_SEPARATOR . 'Theme';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class EnqueueThemeCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/Exception/ComponentException.php
+++ b/src/Exception/ComponentException.php
@@ -12,10 +12,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use InvalidArgumentException;
+
 /**
  * Class ComponentException
  */
-final class ComponentException extends \InvalidArgumentException implements GeneralExceptionInterface
+final class ComponentException extends InvalidArgumentException implements GeneralExceptionInterface
 {
 	/**
 	 * Throws exception if ensure_string argument is invalid.
@@ -26,12 +28,12 @@ final class ComponentException extends \InvalidArgumentException implements Gene
 	 */
 	public static function throwNotStringOrArray($variable): ComponentException
 	{
-		if (gettype($variable) !== 'object') {
-			$output = sprintf(
+		if (\gettype($variable) !== 'object') {
+			$output = \sprintf(
 				/* translators: %1$s is replaced with the name of the variable, and %2$s with its type. */
 				\esc_html__('%1$s variable is not a string or array but rather %2$s', 'eightshift-libs'),
 				$variable,
-				gettype($variable)
+				\gettype($variable)
 			);
 		} else {
 			$output = \esc_html__('Object couldn\'t be converted to string. Please provide only string or array.', 'eightshift-libs');
@@ -49,7 +51,7 @@ final class ComponentException extends \InvalidArgumentException implements Gene
 	public static function throwUnableToLocateComponent(string $component): ComponentException
 	{
 		return new ComponentException(
-			sprintf(
+			\sprintf(
 			/* translators: %s is replaced with the path of the component. */
 				\esc_html__('Unable to locate component by path: %s', 'eightshift-libs'),
 				$component

--- a/src/Exception/FailedToLoadView.php
+++ b/src/Exception/FailedToLoadView.php
@@ -10,10 +10,13 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use Exception;
+use RuntimeException;
+
 /**
  * Class FailedToLoadView
  */
-final class FailedToLoadView extends \RuntimeException implements GeneralExceptionInterface
+final class FailedToLoadView extends RuntimeException implements GeneralExceptionInterface
 {
 	/**
 	 * Create a new instance of the exception if the view file itself created
@@ -21,13 +24,13 @@ final class FailedToLoadView extends \RuntimeException implements GeneralExcepti
 	 *
 	 * @param string     $uri URI of the file that is not accessible or
 	 *                              not readable.
-	 * @param \Exception $exception Exception that was thrown by the view file.
+	 * @param Exception $exception Exception that was thrown by the view file.
 	 *
 	 * @return static
 	 */
-	public static function viewException(string $uri, \Exception $exception): FailedToLoadView
+	public static function viewException(string $uri, Exception $exception): FailedToLoadView
 	{
-		$message = sprintf(
+		$message = \sprintf(
 		/* translators: %1$s will be replaced with view URI, and %2$s with error. */
 			\esc_html__('Could not load the View URI: %1$s. Reason: %2$s.', 'eightshift-libs'),
 			$uri,

--- a/src/Exception/InvalidAutowireDependency.php
+++ b/src/Exception/InvalidAutowireDependency.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use InvalidArgumentException;
+
 /**
  * Class InvalidAutowireDependency
  */
-final class InvalidAutowireDependency extends \InvalidArgumentException implements GeneralExceptionInterface
+final class InvalidAutowireDependency extends InvalidArgumentException implements GeneralExceptionInterface
 {
 	/**
 	 * Throws exception if we cant guess the class to inject.
@@ -29,7 +31,7 @@ final class InvalidAutowireDependency extends \InvalidArgumentException implemen
 	public static function throwUnableToFindClass(string $className, string $interfaceName): InvalidAutowireDependency
 	{
 		return new InvalidAutowireDependency(
-			sprintf(
+			\sprintf(
 				/* translators: 1: the className, 2: the interface name. */
 				'Unable to find "%1$s" class that implements %2$s (looking in $filenameIndex).
 				When injecting Interface dependencies, please make sure your variable name in __construct()
@@ -53,7 +55,7 @@ final class InvalidAutowireDependency extends \InvalidArgumentException implemen
 	public static function throwMoreThanOneClassFound(string $className, string $interfaceName): InvalidAutowireDependency
 	{
 		return new InvalidAutowireDependency(
-			sprintf(
+			\sprintf(
 				/* translators: 1: The class name, 2: The interface name, 3: The interface name */
 				'Found more than 1 class called "%1$s" that implements %2$s interface.
 				Please make sure you don\'t have more than 1 class with the same name implementing the same interface.
@@ -76,7 +78,7 @@ final class InvalidAutowireDependency extends \InvalidArgumentException implemen
 	public static function throwPrimitiveDependencyFound(string $className): InvalidAutowireDependency
 	{
 		return new InvalidAutowireDependency(
-			sprintf(
+			\sprintf(
 				/* translators: %s is replaced with the className and interfaceName. */
 				"Found a primitive dependency for %s. Autowire is unable to figure out what value needs to be injected here.
 				Please define the dependency tree for this class manually using \$main->getServiceClasses().

--- a/src/Exception/InvalidBlock.php
+++ b/src/Exception/InvalidBlock.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use InvalidArgumentException;
+
 /**
  * Class InvalidBlock
  */
-final class InvalidBlock extends \InvalidArgumentException implements GeneralExceptionInterface
+final class InvalidBlock extends InvalidArgumentException implements GeneralExceptionInterface
 {
 	/**
 	 * Throws error if blocks are missing.
@@ -45,7 +47,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function missingNameException(string $blockPath): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 			/* translators: %s will be replaced with the path where the block should be. */
 				\esc_html__('Block in this path %s is missing blockName key in its manifest.json.', 'eightshift-libs'),
 				$blockPath
@@ -63,7 +65,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function missingComponentNameException(string $componmentPath): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 			/* translators: %s will be replaced with the path where the block should be. */
 				\esc_html__('Component at %s is missing the "componentName" key in its manifest.json.', 'eightshift-libs'),
 				$componmentPath
@@ -82,7 +84,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function missingViewException(string $blockName, string $blockPath): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 			/* translators: %1$s is going to be replaced with the template name, %2$s with the template path. */
 				\esc_html__(
 					'Block with this name %1$s is missing view template. Template name should be called %1$s.php, and it should be located in this path %2$s',
@@ -104,7 +106,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function missingRenderViewException(string $blockPath): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 			/* translators: %s will be replaced with the block path. */
 				\esc_html__(
 					'Block view is missing in the provided path. Please check if %s is the right path for your block view.',
@@ -125,7 +127,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function missingSettingsManifestException(string $settingsManifestPath): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 			/* translators: %s will be replaced with the location of the manifest for the block. */
 				\esc_html__('Global blocks settings manifest.json is missing on this location: %s.', 'eightshift-libs'),
 				$settingsManifestPath
@@ -143,7 +145,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function missingWrapperManifestException(string $settingsManifestPath): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 			/* translators: %s will be replaced with the manifest path location. */
 				\esc_html__('Wrapper blocks settings manifest.json is missing on this location: %s.', 'eightshift-libs'),
 				$settingsManifestPath
@@ -161,9 +163,9 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function missingComponentManifestException(string $settingsManifestPath): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 			/* translators: %s will be replaced with the manifest path location. */
-				esc_html__('Component manifest.json is missing on this location: %s.', 'eightshift-libs'),
+				\esc_html__('Component manifest.json is missing on this location: %s.', 'eightshift-libs'),
 				$settingsManifestPath
 			)
 		);
@@ -179,7 +181,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function missingWrapperViewException(string $wrapperPath): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 			/* translators: %s will be replaced with the view template path location. */
 				\esc_html__('Wrapper view is missing. Template should be located in this path %s', 'eightshift-libs'),
 				$wrapperPath
@@ -213,7 +215,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function wrongComponentNameException(string $name, string $componentName): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 				/* translators: %1$s is going to be replaced with the component/block name, %2$s with component name. */
 				\esc_html__('Component specified in %1$s manifest doesn\'t exist in your components list.
 				Please check if you project has %2$s component.', 'eightshift-libs'),
@@ -236,7 +238,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 
 		if ($key === 'block' || $key === 'component') {
 			return new InvalidBlock(
-				sprintf(
+				\sprintf(
 					/* translators: %1$s is going to be replaced with the key name. */
 					\esc_html__('Block/component %1$s not found in the blocks settings or the output data is empty.
 					Please check if the provided key and parent is correct.', 'eightshift-libs'),
@@ -247,7 +249,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 
 		if ($item) {
 			return new InvalidBlock(
-				sprintf(
+				\sprintf(
 					/* translators: %1$s is going to be replaced with the key name. */
 					\esc_html__('Key %1$s not found in the %2$s array blocks settings or the output data is empty.
 					Please check if the provided key and parent is correct.', 'eightshift-libs'),
@@ -258,7 +260,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 		}
 
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 				/* translators: %1$s is going to be replaced with the key name. */
 				\esc_html__('Key %1$s not found in the blocks settings or the output data is empty.
 				Please check if the provided key is correct.', 'eightshift-libs'),
@@ -277,7 +279,7 @@ final class InvalidBlock extends \InvalidArgumentException implements GeneralExc
 	public static function missingFileException(string $sourcePath): InvalidBlock
 	{
 		return new InvalidBlock(
-			sprintf(
+			\sprintf(
 				/* translators: %s is going to be replaced with the missing file path. */
 				\esc_html__('Failed to open path %s. No such file or directory.', 'eightshift-libs'),
 				$sourcePath,

--- a/src/Exception/InvalidCallback.php
+++ b/src/Exception/InvalidCallback.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use InvalidArgumentException;
+
 /**
  * Class InvalidCallback
  */
-final class InvalidCallback extends \InvalidArgumentException implements GeneralExceptionInterface
+final class InvalidCallback extends InvalidArgumentException implements GeneralExceptionInterface
 {
 	/**
 	 * Create a new instance of the exception for a callback class name that is
@@ -25,7 +27,7 @@ final class InvalidCallback extends \InvalidArgumentException implements General
 	 */
 	public static function fromCallback(string $callback): InvalidCallback
 	{
-		$message = sprintf(
+		$message = \sprintf(
 		/* translators: %s is replaced with callback name. */
 			\esc_html__('The callback %s is not recognized and cannot be registered.', 'eightshift-libs'),
 			$callback

--- a/src/Exception/InvalidManifest.php
+++ b/src/Exception/InvalidManifest.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use InvalidArgumentException;
+
 /**
  * Class InvalidManifest
  */
-final class InvalidManifest extends \InvalidArgumentException implements GeneralExceptionInterface
+final class InvalidManifest extends InvalidArgumentException implements GeneralExceptionInterface
 {
 	/**
 	 * Throws error if manifest key is missing
@@ -25,7 +27,7 @@ final class InvalidManifest extends \InvalidArgumentException implements General
 	public static function missingManifestItemException(string $key): InvalidManifest
 	{
 		return new InvalidManifest(
-			sprintf(
+			\sprintf(
 			/* translators: %s is replaced by the missing key in the manifest.json */
 				\esc_html__(
 					'%s key does not exist in manifest.json. Please check if provided key is correct.',
@@ -46,7 +48,7 @@ final class InvalidManifest extends \InvalidArgumentException implements General
 	public static function missingManifestException(string $path): InvalidManifest
 	{
 		return new InvalidManifest(
-			sprintf(
+			\sprintf(
 			/* translators: %s is replaced by the path where the manifest.json should be */
 				\esc_html__(
 					'manifest.json is missing at this path: %s. Bundle the theme before using it. Or your bundling process is returning an error.',

--- a/src/Exception/InvalidNouns.php
+++ b/src/Exception/InvalidNouns.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use InvalidArgumentException;
+
 /**
  * Class InvalidNouns
  */
-final class InvalidNouns extends \InvalidArgumentException implements GeneralExceptionInterface
+final class InvalidNouns extends InvalidArgumentException implements GeneralExceptionInterface
 {
 	/**
 	 * Create a new instance of the exception for an array of nouns that is
@@ -25,7 +27,7 @@ final class InvalidNouns extends \InvalidArgumentException implements GeneralExc
 	 */
 	public static function fromKey(string $key): InvalidNouns
 	{
-		$message = sprintf(
+		$message = \sprintf(
 		/* translators: %s is replaced with name of the noun. */
 			\esc_html__('The array of nouns passed into the Label_Generator is missing the %s noun.', 'eightshift-libs'),
 			$key

--- a/src/Exception/InvalidPath.php
+++ b/src/Exception/InvalidPath.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use InvalidArgumentException;
+
 /**
  * InvalidPath class
  */
-final class InvalidPath extends \InvalidArgumentException implements GeneralExceptionInterface
+final class InvalidPath extends InvalidArgumentException implements GeneralExceptionInterface
 {
 	/**
 	 * Create a new instance of the exception for a file that is not accessible
@@ -26,7 +28,7 @@ final class InvalidPath extends \InvalidArgumentException implements GeneralExce
 	 */
 	public static function fromUri(string $uri): InvalidPath
 	{
-		$message = sprintf(
+		$message = \sprintf(
 			/* translators: %s will be replaced by path. */
 			\esc_html__('The URI "%s" is not accessible or readable.', 'eightshift-libs'),
 			$uri

--- a/src/Exception/InvalidService.php
+++ b/src/Exception/InvalidService.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use InvalidArgumentException;
+
 /**
  * Class InvalidService
  */
-final class InvalidService extends \InvalidArgumentException implements GeneralExceptionInterface
+final class InvalidService extends InvalidArgumentException implements GeneralExceptionInterface
 {
 	/**
 	 * Create a new instance of the exception for a service class name that is
@@ -25,7 +27,7 @@ final class InvalidService extends \InvalidArgumentException implements GeneralE
 	 */
 	public static function fromService(string $service): InvalidService
 	{
-		$message = sprintf(
+		$message = \sprintf(
 		/* translators: %s is replaced with name of the service. */
 			\esc_html__('The service %s is not recognized and cannot be registered.', 'eightshift-libs'),
 			$service

--- a/src/Exception/NonPsr4CompliantClass.php
+++ b/src/Exception/NonPsr4CompliantClass.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use InvalidArgumentException;
+
 /**
  * Class NonPsr4CompliantClass
  */
-final class NonPsr4CompliantClass extends \InvalidArgumentException implements GeneralExceptionInterface
+final class NonPsr4CompliantClass extends InvalidArgumentException implements GeneralExceptionInterface
 {
 	/**
 	 * Throws exception if class has non psr-4 compliant namespace.
@@ -24,7 +26,7 @@ final class NonPsr4CompliantClass extends \InvalidArgumentException implements G
 	public static function throwInvalidNamespace(string $className): NonPsr4CompliantClass
 	{
 		return new NonPsr4CompliantClass(
-			sprintf(
+			\sprintf(
 				/* translators: %s is replaced with the className. */
 				'Unable to autowire %s. Please check if the namespace is PSR-4 compliant (i.e. it needs to match the folder structure).
 				See: https://www.php-fig.org/psr/psr-4/#3-examples',

--- a/src/Exception/PluginActivationFailure.php
+++ b/src/Exception/PluginActivationFailure.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Exception;
 
+use RuntimeException;
+
 /**
  * Class PluginActivationFailure
  */
-final class PluginActivationFailure extends \RuntimeException implements GeneralExceptionInterface
+final class PluginActivationFailure extends RuntimeException implements GeneralExceptionInterface
 {
 	/**
 	 * Create a new instance of the exception in case plugin cannot be activated.

--- a/src/GitIgnore/GitIgnoreCli.php
+++ b/src/GitIgnore/GitIgnoreCli.php
@@ -22,7 +22,7 @@ class GitIgnoreCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+	public const OUTPUT_DIR = '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR;
 
 	/**
 	 * Get WPCLI command name
@@ -69,7 +69,7 @@ class GitIgnoreCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$root = $assocArgs['root'] ?? static::OUTPUT_DIR;

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -768,7 +768,7 @@ class Components
 	public static function camelToKebabCase(string $string): string
 	{
 		$replace = \preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $string) ?? '';
-		return l\trim(\strtolower($replace), '-');
+		return \ltrim(\strtolower($replace), '-');
 	}
 
 	/**

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -12,6 +12,7 @@ namespace EightshiftLibs\Helpers;
 
 use EightshiftLibs\Exception\ComponentException;
 use EightshiftLibs\Exception\InvalidBlock;
+use Exception;
 
 /**
  * Helpers for components
@@ -39,17 +40,17 @@ class Components
 	{
 		$output = '';
 
-		if (is_array($variable)) {
-			$isAssociative = array_values($variable) === $variable;
+		if (\is_array($variable)) {
+			$isAssociative = \array_values($variable) === $variable;
 
 			if ($isAssociative) {
-				$output = implode('', $variable);
+				$output = \implode('', $variable);
 			} else {
 				foreach ($variable as $key => $value) {
-					$output .= $key . '="' . htmlspecialchars($value) . '" ';
+					$output .= $key . '="' . \htmlspecialchars($value) . '" ';
 				}
 			}
-		} elseif (is_string($variable)) {
+		} elseif (\is_string($variable)) {
 			$output = $variable;
 		} else {
 			throw ComponentException::throwNotStringOrArray($variable);
@@ -67,7 +68,7 @@ class Components
 	 */
 	public static function classnames(array $classes): string
 	{
-		return trim(implode(' ', array_filter($classes)));
+		return \trim(\implode(' ', \array_filter($classes)));
 	}
 
 	/**
@@ -89,7 +90,7 @@ class Components
 	 */
 	public static function render(string $component, array $attributes = [], string $parentPath = '', bool $useComponentDefaults = false): string
 	{
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 
 		if (empty($parentPath)) {
 			$parentPath = \get_template_directory();
@@ -107,7 +108,7 @@ class Components
 		 *
 		 * parentClass__componentName.php
 		 */
-		if (strpos($component, '.php') !== false) {
+		if (\strpos($component, '.php') !== false) {
 			$componentPath = "{$parentPath}{$sep}$component";
 
 			if ($useComponentDefaults) {
@@ -121,7 +122,7 @@ class Components
 			}
 		}
 
-		if (!file_exists($componentPath)) {
+		if (!\file_exists($componentPath)) {
 			throw ComponentException::throwUnableToLocateComponent($componentPath);
 		}
 
@@ -129,13 +130,13 @@ class Components
 			$attributes = self::getDefaultRenderAttributes($manifest, $attributes);
 		}
 
-		ob_start();
+		\ob_start();
 
 		// Wrap component with parent BEM selector if parent's class is provided. Used
 		// for setting specific styles for components rendered inside other components.
 		if (isset($attributes['parentClass'])) {
-			$component = str_replace('.php', '', $component);
-			printf('<div class="%s">', \esc_attr("{$attributes['parentClass']}__{$component}")); // phpcs:ignore Eightshift.Security.CustomEscapeOutput.OutputNotEscaped
+			$component = \str_replace('.php', '', $component);
+			\printf('<div class="%s">', \esc_attr("{$attributes['parentClass']}__{$component}")); // phpcs:ignore Eightshift.Security.CustomEscapeOutput.OutputNotEscaped
 		}
 
 		require $componentPath;
@@ -144,7 +145,7 @@ class Components
 			echo '</div>'; // phpcs:ignore Eightshift.Security.CustomEscapeOutput.OutputNotEscaped
 		}
 
-		return trim((string) ob_get_clean());
+		return \trim((string) \ob_get_clean());
 	}
 
 	/**
@@ -164,12 +165,12 @@ class Components
 			return self::getManifestDirect($path);
 		}
 
-		$path = rtrim($path, DIRECTORY_SEPARATOR);
+		$path = \trim($path, \DIRECTORY_SEPARATOR);
 
-		$path = explode(DIRECTORY_SEPARATOR, $path);
+		$path = \explode(\DIRECTORY_SEPARATOR, $path);
 
 		// Find last item to get name.
-		$item = $path[count($path) - 1] ?? '';
+		$item = $path[\count($path) - 1] ?? '';
 
 		// Global settings.
 		if ($item === 'Blocks') {
@@ -181,7 +182,7 @@ class Components
 			return self::getSettings('wrapper');
 		}
 
-		$type = $path[count($path) - 2] ?? '';
+		$type = $path[\count($path) - 2] ?? '';
 
 		// Components settings.
 		if ($type === 'components') {
@@ -218,9 +219,9 @@ class Components
 
 		foreach ($items as $itemKey => $itemValue) {
 			if (
-				(is_string($itemValue) && $itemValue === '') ||
-				(is_bool($itemValue) && $itemValue === false) ||
-				is_array($itemValue)
+				(\is_string($itemValue) && $itemValue === '') ||
+				(\is_bool($itemValue) && $itemValue === false) ||
+				\is_array($itemValue)
 			) {
 				continue;
 			}
@@ -244,7 +245,7 @@ class Components
 	 * @param array<string, mixed> $manifest Array of default attributes from manifest.json.
 	 * @param bool $undefinedAllowed Allowed detection of undefined values.
 	 *
-	 * @throws \Exception When we're unable to find the component by $component.
+	 * @throws Exception When we're unable to find the component by $component.
 	 *
 	 * @return mixed
 	 */
@@ -262,10 +263,10 @@ class Components
 		$manifestKey = $manifest['attributes'][$key] ?? null;
 
 		if ($manifestKey === null) {
-			if (isset($manifest['blockName']) || array_key_exists('blockName', $manifest)) {
-				throw new \Exception("{$key} key does not exist in the {$manifest['blockName']} block manifest. Please check your implementation.");
+			if (isset($manifest['blockName']) || \array_key_exists('blockName', $manifest)) {
+				throw new Exception("{$key} key does not exist in the {$manifest['blockName']} block manifest. Please check your implementation.");
 			} else {
-				throw new \Exception("{$key} key does not exist in the {$manifest['componentName']} component manifest. Please check your implementation.");
+				throw new Exception("{$key} key does not exist in the {$manifest['componentName']} component manifest. Please check your implementation.");
 			}
 		}
 
@@ -300,8 +301,8 @@ class Components
 	 * @param array<string, mixed> $manifest Array of default attributes from manifest.json.
 	 * @param bool $undefinedAllowed Allowed detection of undefined values.
 	 *
-	 * @throws \Exception If missing responsiveAttributes or keyName in responsiveAttributes.
-	 * @throws \Exception If missing keyName in responsiveAttributes.
+	 * @throws Exception If missing responsiveAttributes or keyName in responsiveAttributes.
+	 * @throws Exception If missing keyName in responsiveAttributes.
 	 *
 	 * @return array<mixed>
 	 */
@@ -310,15 +311,15 @@ class Components
 		$output = [];
 
 		if (!isset($manifest['responsiveAttributes'])) {
-			if (isset($manifest['blockName']) || array_key_exists('blockName', $manifest)) {
-				throw new \Exception("It looks like you are missing responsiveAttributes key in your {$manifest['blockName']} block manifest.");
+			if (isset($manifest['blockName']) || \array_key_exists('blockName', $manifest)) {
+				throw new Exception("It looks like you are missing responsiveAttributes key in your {$manifest['blockName']} block manifest.");
 			} else {
-				throw new \Exception("It looks like you are missing responsiveAttributes key in your {$manifest['componentName']} component manifest.");
+				throw new Exception("It looks like you are missing responsiveAttributes key in your {$manifest['componentName']} component manifest.");
 			}
 		}
 
 		if (!isset($manifest['responsiveAttributes'][$keyName])) {
-			throw new \Exception("It looks like you are missing the {$keyName} key in your manifest responsiveAttributes array.");
+			throw new Exception("It looks like you are missing the {$keyName} key in your manifest responsiveAttributes array.");
 		}
 
 		foreach ($manifest['responsiveAttributes'][$keyName] as $key => $value) {
@@ -340,7 +341,7 @@ class Components
 	public static function getAttrKey(string $key, array $attributes, array $manifest): string
 	{
 		// Just skip if attribute is wrapper.
-		if (strpos($key, 'wrapper') !== false) {
+		if (\strpos($key, 'wrapper') !== false) {
 			return $key;
 		}
 
@@ -356,7 +357,7 @@ class Components
 
 		// No need to test if this is block or component because on top level block there is no prefix.
 		// If there is a prefix, remove the attribute component name prefix and replace it with the new prefix.
-		return (string)str_replace(Components::kebabToCamelCase($manifest['componentName']), $attributes['prefix'], $key);
+		return (string)\str_replace(Components::kebabToCamelCase($manifest['componentName']), $attributes['prefix'], $key);
 	}
 
 	/**
@@ -375,9 +376,9 @@ class Components
 		$fullModifier = '';
 		$fullElement = '';
 
-		$element = trim($element);
-		$modifier = trim($modifier);
-		$block = trim($block);
+		$element = \trim($element);
+		$modifier = \trim($modifier);
+		$block = \trim($block);
 
 		if (!empty($element)) {
 			$fullElement = "__{$element}";
@@ -437,7 +438,7 @@ class Components
 		foreach ($globalManifest['globalVariables'] as $itemKey => $itemValue) {
 			$itemKey = self::camelToKebabCase($itemKey);
 
-			if (gettype($itemValue) === 'array') {
+			if (\gettype($itemValue) === 'array') {
 				$output .= self::globalInner($itemValue, $itemKey);
 			} else {
 				$output .= "--global-{$itemKey}: {$itemValue};\n";
@@ -491,7 +492,7 @@ class Components
 		$breakpoints = $globalManifest['globalVariables']['breakpoints'];
 
 		// Sort breakpoints in ascending order.
-		asort($breakpoints);
+		\asort($breakpoints);
 
 		$defaultBreakpoints = self::getDefaultBreakpoints($breakpoints);
 
@@ -513,13 +514,13 @@ class Components
 
 		// Check manifest for the attributes with variable key.
 		// As this is not JS we can't simply get this data from attributes array so we need to do it manually.
-		$defaultAttributes = array_keys(
-			array_filter(
+		$defaultAttributes = \array_keys(
+			\array_filter(
 				$variables,
 				static function ($key) use ($attributes) {
 					return !isset($attributes[$key]);
 				},
-				ARRAY_FILTER_USE_KEY
+				\ARRAY_FILTER_USE_KEY
 			)
 		);
 
@@ -533,7 +534,7 @@ class Components
 				}
 			}
 
-			$attributes = array_merge($default, $attributes);
+			$attributes = \array_merge($default, $attributes);
 		}
 
 		if (!empty($responsiveAttributes)) {
@@ -566,7 +567,7 @@ class Components
 			}
 
 			// Merge array of variables to string.
-			$breakpointData = implode("\n", $variable);
+			$breakpointData = \implode("\n", $variable);
 
 			// If breakpoint value is 0 then don't wrap the media query around it.
 			if ($outputGloballyFlag) {
@@ -585,7 +586,7 @@ class Components
 		}
 
 		// Output manual output from the array of variables.
-		$manual = isset($manifest['variablesCustom']) ? \esc_html(implode(";\n", $manifest['variablesCustom'])) : '';
+		$manual = isset($manifest['variablesCustom']) ? \esc_html(\implode(";\n", $manifest['variablesCustom'])) : '';
 
 		// Output to global if flag is set.
 		if ($outputGloballyFlag) {
@@ -611,7 +612,7 @@ class Components
 		";
 
 		// Check if final output is empty and and remove if it is.
-		if (empty(trim($fullOutput))) {
+		if (empty(\trim($fullOutput))) {
 			return '';
 		}
 
@@ -619,8 +620,8 @@ class Components
 		$finalManualOutput = $manual ? "\n .{$name}[data-id='{$unique}']{\n{$manual}\n}" : '';
 
 		if ($outputGloballyOptimizeFlag) {
-			$output = str_replace(["\n", "\r"], '', $output);
-			$finalManualOutput = str_replace(["\n", "\r"], '', $finalManualOutput);
+			$output = \str_replace(["\n", "\r"], '', $output);
+			$finalManualOutput = \str_replace(["\n", "\r"], '', $finalManualOutput);
 		}
 
 		// Output the style for CSS variables.
@@ -653,34 +654,34 @@ class Components
 		$breakpointsData = self::getSettings('settings', 'globalVariables')['breakpoints'];
 
 		// Sort breakpoints in ascending order.
-		asort($breakpointsData);
+		\asort($breakpointsData);
 
 		// Populate min values.
-		$breakpointsMin = array_map(
+		$breakpointsMin = \array_map(
 			static function ($item) {
 				return "min---{$item}";
 			},
-			array_values($breakpointsData)
+			\array_values($breakpointsData)
 		);
 		// Append 0 value.
-		array_unshift($breakpointsMin, 'min---0');
+		\array_unshift($breakpointsMin, 'min---0');
 
 		// Populate max values.
-		$breakpointsMax = array_map(
+		$breakpointsMax = \array_map(
 			static function ($item) {
 				return "max---{$item}";
 			},
-			array_reverse(array_values($breakpointsData))
+			\array_reverse(\array_values($breakpointsData))
 		);
 		// Append 0 value.
-		array_unshift($breakpointsMax, 'max---0');
+		\array_unshift($breakpointsMax, 'max---0');
 
 		// Return empty array of items.
-		$breakpoints = array_map(
+		$breakpoints = \array_map(
 			static function () {
 				return '';
 			},
-			array_flip(array_values(array_merge($breakpointsMin, $breakpointsMax)))
+			\array_flip(\array_values(\array_merge($breakpointsMin, $breakpointsMax)))
 		);
 
 		// Loop styles.
@@ -719,7 +720,7 @@ class Components
 
 		// Loop breakpoints in correct order.
 		foreach ($breakpoints as $breakpointKey => $breakpointValue) {
-			$breakpointKey = explode('---', $breakpointKey);
+			$breakpointKey = \explode('---', $breakpointKey);
 
 			$type = $breakpointKey[0] ?? '';
 			$value = $breakpointKey[1] ?? '';
@@ -739,7 +740,7 @@ class Components
 
 		// Remove newlines is config is set.
 		if ($outputGloballyOptimizeFlag) {
-			$output = str_replace(["\n", "\r"], '', $output);
+			$output = \str_replace(["\n", "\r"], '', $output);
 		}
 
 	  $selector = self::getSettings('config', 'outputCssVariablesSelectorName');
@@ -754,7 +755,7 @@ class Components
 	 */
 	public static function getUnique(): string
 	{
-		return md5(uniqid((string)\wp_rand(), true));
+		return \md5(\uniqid((string)\wp_rand(), true));
 	}
 
 	/**
@@ -766,8 +767,8 @@ class Components
 	 */
 	public static function camelToKebabCase(string $string): string
 	{
-		$replace = preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $string) ?? '';
-		return ltrim(strtolower($replace), '-');
+		$replace = \preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $string) ?? '';
+		return l\trim(\strtolower($replace), '-');
 	}
 
 	/**
@@ -780,7 +781,7 @@ class Components
 	 */
 	public static function kebabToCamelCase(string $string, string $separator = '-'): string
 	{
-		return lcfirst(str_replace($separator, '', ucwords($string, $separator)));
+		return \lcfirst(\str_replace($separator, '', \ucwords($string, $separator)));
 	}
 
 	/**
@@ -840,19 +841,19 @@ class Components
 		if (empty($prefix)) {
 			$output['prefix'] = self::kebabToCamelCase($newName);
 		} else {
-			$output['prefix'] = $prefix . ucfirst(self::kebabToCamelCase($newName));
+			$output['prefix'] = $prefix . \ucfirst(self::kebabToCamelCase($newName));
 		}
 
 		// Iterate over the attributes.
 		foreach ($attributes as $key => $value) {
 			// Include attributes from iteration.
-			if (in_array($key, $includes, true)) {
+			if (\in_array($key, $includes, true)) {
 				$output[$key] = $value;
 				continue;
 			}
 
 			// If attribute starts with the prefix key leave it in the object if not remove it.
-			if (substr((string)$key, 0, strlen($output['prefix'])) === $output['prefix']) {
+			if (\substr((string)$key, 0, \strlen($output['prefix'])) === $output['prefix']) {
 				$output[$key] = $value;
 			}
 		}
@@ -862,23 +863,23 @@ class Components
 			// Iterate manual attributes.
 			foreach ($manual as $key => $value) {
 				// Include attributes from iteration.
-				if (in_array($key, $includes, true)) {
+				if (\in_array($key, $includes, true)) {
 					$output[$key] = $value;
 					continue;
 				}
 
 				// Remove the current component name from the attribute name.
-				$newKey = str_replace(lcfirst(self::kebabToCamelCase($newName)), '', $key);
+				$newKey = \str_replace(\lcfirst(self::kebabToCamelCase($newName)), '', $key);
 
 				// Remove the old key.
 				unset($manual[$key]);
 
 				// Add new key to the output with prepared attribute name.
-				$manual[$output['prefix'] . ucfirst($newKey)] = $value;
+				$manual[$output['prefix'] . \ucfirst($newKey)] = $value;
 			}
 
 			// Merge manual and output objects to one.
-			$output = array_merge($output, $manual);
+			$output = \array_merge($output, $manual);
 		}
 
 		// Return the original attribute for optimization purposes.
@@ -896,7 +897,7 @@ class Components
 	{
 		$return = [];
 
-		array_walk_recursive(
+		\array_walk_recursive(
 			$array,
 			function ($a) use (&$return) {
 				$return[] = $a;
@@ -942,7 +943,7 @@ class Components
 				$keyDetails = 'components';
 			}
 
-			$items = array_filter(
+			$items = \array_filter(
 				$details[$keyDetails],
 				static function ($manifest) use ($item, $keyName) {
 					return $manifest[$keyName] === $item;
@@ -953,7 +954,7 @@ class Components
 				throw InvalidBlock::missingSettingsKeyException($type, $item);
 			}
 
-			return reset($items);
+			return \reset($items);
 		}
 
 		// If searching for one item in array.
@@ -989,7 +990,7 @@ class Components
 	{
 		$defaultAttributes = [];
 
-		if (!is_iterable($manifest['attributes'])) {
+		if (!\is_iterable($manifest['attributes'])) {
 			return [];
 		}
 
@@ -1002,7 +1003,7 @@ class Components
 			}
 		}
 
-		return array_merge($defaultAttributes, $attributes);
+		return \array_merge($defaultAttributes, $attributes);
 	}
 
 	/**
@@ -1095,7 +1096,7 @@ class Components
 			}
 
 			// Used for determination of default breakpoint.
-			$numberOfBreakpoints = count($responsiveAttributeObject);
+			$numberOfBreakpoints = \count($responsiveAttributeObject);
 			$responsiveAttribute = [];
 			$breakpointIndex = 0;
 
@@ -1107,7 +1108,7 @@ class Components
 				$breakpointVariables = [];
 
 				// Determines whether array is a key value pair or not.
-				$isAssociative = array_values($variables[$responsiveAttributeName]) === $variables[$responsiveAttributeName];
+				$isAssociative = \array_values($variables[$responsiveAttributeName]) === $variables[$responsiveAttributeName];
 
 				if ($isAssociative) {
 					// Array represents direct value(default or value).
@@ -1137,7 +1138,7 @@ class Components
 				$breakpointIndex++;
 			}
 			// Merge multiple responsive attributes to one array.
-			$responsiveAttributesVariables = array_merge($responsiveAttributesVariables, $responsiveAttribute);
+			$responsiveAttributesVariables = \array_merge($responsiveAttributesVariables, $responsiveAttribute);
 		};
 
 		return $responsiveAttributesVariables;
@@ -1155,8 +1156,8 @@ class Components
 	private static function getDefaultBreakpoints(array $breakpoints): array
 	{
 		return [
-			'min' => array_keys($breakpoints)[0] ?? '',
-			'max' => array_keys($breakpoints)[count($breakpoints) - 1] ?? '',
+			'min' => \array_keys($breakpoints)[0] ?? '',
+			'max' => \array_keys($breakpoints)[\count($breakpoints) - 1] ?? '',
 		];
 	}
 
@@ -1178,7 +1179,7 @@ class Components
 			$attributeValue = $attributes[self::getAttrKey($variableName, $attributes, $manifest)] ?? '';
 
 			// Make sure this works correctly for attributes which are toggles (booleans).
-			if (is_bool($attributeValue)) {
+			if (\is_bool($attributeValue)) {
 				$attributeValue = $attributeValue ? 'true' : 'false';
 			}
 
@@ -1188,7 +1189,7 @@ class Components
 			}
 
 			// Bailout if wrong type is provided.
-			if (!is_array($variableValue)) {
+			if (!\is_array($variableValue)) {
 				continue;
 			}
 
@@ -1209,9 +1210,19 @@ class Components
 				// Iterate each data array to find the correct breakpoint.
 				foreach ($data as $index => $item) {
 					// Check if breakpoint and type match.
-					if ($item['name'] === $breakpoint && $item['type'] === $type && (!empty((string) $attributeValue) || gettype($attributeValue) === 'integer' || gettype($attributeValue) === 'float' || gettype($attributeValue) === 'double' || $attributeValue === '0')) { // phpcs:ignore Generic.Files.LineLength.TooLong
+					if (
+						$item['name'] === $breakpoint &&
+						$item['type'] === $type &&
+						(
+							!empty((string) $attributeValue) ||
+							\gettype($attributeValue) === 'integer' ||
+							\gettype($attributeValue) === 'float' ||
+							\gettype($attributeValue) === 'double' ||
+							$attributeValue === '0'
+						)
+					) {
 						// Merge data variables with the new variables array.
-						$data[$index]['variable'] = array_merge($item['variable'], self::variablesInner($variable, $attributeValue));
+						$data[$index]['variable'] = \array_merge($item['variable'], self::variablesInner($variable, $attributeValue));
 					}
 				}
 			}
@@ -1244,7 +1255,7 @@ class Components
 			];
 
 			// Inner object for min values.
-			$itemObjectMin = array_merge(
+			$itemObjectMin = \array_merge(
 				$itemObject,
 				[
 					'type' => 'min',
@@ -1253,7 +1264,7 @@ class Components
 			);
 
 			// Inner object for max values.
-			$itemObjectMax = array_merge(
+			$itemObjectMax = \array_merge(
 				$itemObject,
 				[
 					'type' => 'max',
@@ -1269,10 +1280,10 @@ class Components
 		};
 
 		// Pop largest breakpoint out of min array.
-		array_shift($min);
+		\array_shift($min);
 
 		// Add default object to the top of the array as minimum.
-		array_unshift(
+		\array_unshift(
 			$min,
 			[
 				'type' => 'min',
@@ -1283,13 +1294,13 @@ class Components
 		);
 
 		// Reverse order of max array.
-		$max = array_reverse($max);
+		$max = \array_reverse($max);
 
 		// Throw out the largest.
-		array_shift($max);
+		\array_shift($max);
 
 		// Switch the largest to default.
-		array_unshift(
+		\array_unshift(
 			$max,
 			[
 				'type' => 'max',
@@ -1300,7 +1311,7 @@ class Components
 		);
 
 		// Merge both arrays.
-		return array_merge($min, $max);
+		return \array_merge($min, $max);
 	}
 
 	/**
@@ -1326,8 +1337,8 @@ class Components
 			$internalKey = self::camelToKebabCase($variableKey);
 
 			// If value contains magic variable swap that variable with original attribute value.
-			if (strpos($variableValue, '%value%') !== false) {
-				$variableValue = str_replace('%value%', (string) $attributeValue, $variableValue);
+			if (\strpos($variableValue, '%value%') !== false) {
+				$variableValue = \str_replace('%value%', (string) $attributeValue, $variableValue);
 			}
 
 			// Output the custom CSS variable by adding the attribute key + custom object key.
@@ -1351,20 +1362,20 @@ class Components
 			return self::$namespace;
 		}
 
-		$sep = DIRECTORY_SEPARATOR;
+		$sep = \DIRECTORY_SEPARATOR;
 
-		$manifestPath = dirname(__DIR__, 5) . "{$sep}src{$sep}Blocks{$sep}manifest.json";
+		$manifestPath = \dirname(__DIR__, 5) . "{$sep}src{$sep}Blocks{$sep}manifest.json";
 
-		if (getenv('TEST')) {
-			$manifestPath = dirname(__DIR__, 2) . "{$sep}tests{$sep}data{$sep}src{$sep}Blocks{$sep}manifest.json";
+		if (\getenv('TEST')) {
+			$manifestPath = \dirname(__DIR__, 2) . "{$sep}tests{$sep}data{$sep}src{$sep}Blocks{$sep}manifest.json";
 		}
 
-		if (!file_exists($manifestPath)) {
+		if (!\file_exists($manifestPath)) {
 			throw InvalidBlock::missingSettingsManifestException($manifestPath);
 		}
 
-		$settings = implode(' ', (array)file(($manifestPath)));
-		$settings = json_decode($settings, true);
+		$settings = \implode(' ', (array)\file(($manifestPath)));
+		$settings = \json_decode($settings, true);
 
 		if (!isset($settings['namespace'])) {
 			throw InvalidBlock::missingNamespaceException();
@@ -1385,15 +1396,15 @@ class Components
 	 */
 	private static function getManifestDirect(string $path): array
 	{
-		$sep = DIRECTORY_SEPARATOR;
-		$path = rtrim($path, $sep);
+		$sep = \DIRECTORY_SEPARATOR;
+		$path = \trim($path, $sep);
 
 		$manifest = "{$path}{$sep}manifest.json";
 
-		if (!file_exists($manifest)) {
+		if (!\file_exists($manifest)) {
 			throw ComponentException::throwUnableToLocateComponent($manifest);
 		}
 
-		return json_decode(implode(' ', (array)file($manifest)), true);
+		return \json_decode(\implode(' ', (array)\file($manifest)), true);
 	}
 }

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -398,21 +398,21 @@ class Components
 	 *
 	 * @return string
 	 */
-	public static function hexToRgb($hex)
+	public static function hexToRgb(string $hex): string
 	{
 		// Remove the # at the beginning and filter out invalid hex characters.
-		$hex = preg_replace("/[^0-9A-Fa-f]/", '', $hex);
+		$hex = \preg_replace("/[^0-9A-Fa-f]/", '', $hex);
 
-		$length = strlen($hex);
+		$length = \strlen($hex);
 
 		if ($length === 3) {
-			$r = hexdec(str_repeat(substr($hex, 0, 1), 2));
-			$g = hexdec(str_repeat(substr($hex, 1, 1), 2));
-			$b = hexdec(str_repeat(substr($hex, 2, 1), 2));
+			$r = \hexdec(\str_repeat(\substr($hex, 0, 1), 2));
+			$g = \hexdec(\str_repeat(\substr($hex, 1, 1), 2));
+			$b = \hexdec(\str_repeat(\substr($hex, 2, 1), 2));
 		} elseif ($length === 6) {
-			$r = hexdec(substr($hex, 0, 2));
-			$g = hexdec(substr($hex, 2, 2));
-			$b = hexdec(substr($hex, 4, 2));
+			$r = \hexdec(\substr($hex, 0, 2));
+			$g = \hexdec(\substr($hex, 2, 2));
+			$b = \hexdec(\substr($hex, 4, 2));
 		} else {
 			return '0 0 0';
 		}
@@ -743,7 +743,7 @@ class Components
 			$output = \str_replace(["\n", "\r"], '', $output);
 		}
 
-	  $selector = self::getSettings('config', 'outputCssVariablesSelectorName');
+		$selector = self::getSettings('config', 'outputCssVariablesSelectorName');
 
 		return "<style id='{$selector}'>{$output}</style>";
 	}

--- a/src/Helpers/ErrorLoggerTrait.php
+++ b/src/Helpers/ErrorLoggerTrait.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Helpers;
 
+use WP_Error;
+
 /**
  * Error logger trait.
  */
@@ -23,7 +25,7 @@ trait ErrorLoggerTrait
 	 * @param string|null $msg Response Message.
 	 * @param array|null  $data Response additional data.
 	 *
-	 * @return \WP_REST_Response|\WP_Error If response generated an error, WP_Error,
+	 * @return WP_REST_Response|WP_Error If response generated an error, WP_Error,
 	 *                                     if response is already an instance, WP_REST_Response,
 	 *                                     otherwise returns a new WP_REST_Response instance.
 	 */
@@ -37,13 +39,13 @@ trait ErrorLoggerTrait
 		];
 
 		if ($code >= 200 && $code < 300) {
-			ob_start();
+			\ob_start();
 			\wp_send_json_success($output, $code);
-			$response = ob_get_clean();
+			$response = \ob_get_clean();
 		} else {
-			ob_start();
-			\wp_send_json_error(new \WP_Error($output), $code);
-			$response = ob_get_clean();
+			\ob_start();
+			\wp_send_json_error(new WP_Error($output), $code);
+			$response = \ob_get_clean();
 		}
 
 		return \rest_ensure_response($response);

--- a/src/Helpers/ObjectHelperTrait.php
+++ b/src/Helpers/ObjectHelperTrait.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Helpers;
 
+use DOMDocument;
+
 /**
  * Class Object Helper
  */
@@ -25,10 +27,10 @@ trait ObjectHelperTrait
 	 */
 	public function isValidXml(string $xml)
 	{
-		libxml_use_internal_errors(true);
-		$doc = new \DOMDocument('1.0', 'utf-8');
+		\libxml_use_internal_errors(true);
+		$doc = new DOMDocument('1.0', 'utf-8');
 		$doc->loadXML($xml);
-		$errors = libxml_get_errors();
+		$errors = \libxml_get_errors();
 		return empty($errors);
 	}
 
@@ -41,8 +43,8 @@ trait ObjectHelperTrait
 	 */
 	public static function isJson(string $string): bool
 	{
-		json_decode($string);
-		return (json_last_error() === JSON_ERROR_NONE);
+		\json_decode($string);
+		return (\json_last_error() === \JSON_ERROR_NONE);
 	}
 
 	/**
@@ -56,7 +58,7 @@ trait ObjectHelperTrait
 	{
 		$output = [];
 
-		array_walk_recursive(
+		\array_walk_recursive(
 			$array,
 			function ($a) use (&$output) {
 				if (!empty($a)) {
@@ -83,7 +85,7 @@ trait ObjectHelperTrait
 		$sanitized = [];
 
 		foreach ($array as $key => $value) {
-			if (is_array($value)) {
+			if (\is_array($value)) {
 				$sanitizedValue = self::sanitizeArray($value, $sanitizationFunction);
 				$sanitized[$key] = $sanitizedValue;
 
@@ -104,7 +106,7 @@ trait ObjectHelperTrait
 	 */
 	public static function sortArrayByOrderKey(array $items): array
 	{
-		usort(
+		\usort(
 			$items,
 			function ($item1, $item2) {
 				return $item1['order'] <=> $item2['order'];

--- a/src/Helpers/Post.php
+++ b/src/Helpers/Post.php
@@ -40,27 +40,27 @@ class Post
 	{
 		$contentBlocks = \parse_blocks(\get_the_content(null, false, $postID));
 
-		$contentBlocksRendered = array_map(
+		$contentBlocksRendered = \array_map(
 			function ($block) {
 				return \wp_kses_post(\apply_filters('the_content', \render_block($block)));
 			},
 			$contentBlocks
 		);
 
-		$contentBlocksCleaned = array_map(
+		$contentBlocksCleaned = \array_map(
 			function ($item) {
-				return preg_replace('/\s+/', ' ', trim($item));
+				return \preg_replace('/\s+/', ' ', \trim($item));
 			},
 			$contentBlocksRendered
 		);
 
 		// Remove arrays with empty strings. These are usually remnants from returns (spaces).
-		$content = array_filter($contentBlocksCleaned, function ($str) {
+		$content = \array_filter($contentBlocksCleaned, function ($str) {
 			return $str !== "";
 		});
 
-		$wordCount = str_word_count(\wp_strip_all_tags(implode('', $content)));
-		$readingTime = ceil($wordCount / self::AVERAGE_WORD_COUNT);
+		$wordCount = \str_word_count(\wp_strip_all_tags(\implode('', $content)));
+		$readingTime = \ceil($wordCount / self::AVERAGE_WORD_COUNT);
 
 		/* translators: %d: number of minutes needed for reading the article. */
 		return (int)$readingTime;

--- a/src/I18n/I18nCli.php
+++ b/src/I18n/I18nCli.php
@@ -22,7 +22,7 @@ class I18nCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'I18n';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'I18n';
 
 	/**
 	 * Get WPCLI command doc
@@ -37,7 +37,7 @@ class I18nCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/I18n/I18nExample.php
+++ b/src/I18n/I18nExample.php
@@ -29,7 +29,7 @@ class I18nExample implements ServiceInterface
 	public function register(): void
 	{
 		\add_action('after_setup_theme', [$this, 'loadThemeTextdomain'], 20);
-		// \add_action('enqueue_block_editor_assets', [$this, 'setScriptTranslations'], 20);
+		\add_action('enqueue_block_editor_assets', [$this, 'setScriptTranslations'], 20);
 	}
 
 	/**
@@ -54,14 +54,14 @@ class I18nExample implements ServiceInterface
 	 *
 	 * @return void
 	 */
-	// public function setScriptTranslations(): void
-	// {
-	// 	$assetsPrefix = Assets::getAssetsPrefix();
-	// 	$handle = "{$assetsPrefix}-block-editor-scripts";
-	// 	\wp_set_script_translations(
-	// 		$handle,
-	// 		Config::getProjectName(),
-	// 		Config::getProjectPath('src/I18n/languages')
-	// 	);
-	// }
+	public function setScriptTranslations(): void
+	{
+		$assetsPrefix = Assets::getAssetsPrefix();
+		$handle = "{$assetsPrefix}-block-editor-scripts";
+		\wp_set_script_translations(
+			$handle,
+			Config::getProjectName(),
+			Config::getProjectPath('src/I18n/languages')
+		);
+	}
 }

--- a/src/Login/LoginCli.php
+++ b/src/Login/LoginCli.php
@@ -20,7 +20,7 @@ class LoginCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Login';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Login';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class LoginCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -97,7 +97,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * You can override autowired definition lists in $this->getServiceClasses().
 	 *
-	 * @throws ReflectionException Exception thrown in case class is missing.
+	 * @throws \Exception Exception thrown in case class is missing.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -131,7 +131,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 * Get services classes array and prepare it for dependency injection.
 	 * Key should be a class name, and value should be an empty array or the dependencies of the class.
 	 *
-	 * @throws ReflectionException Exception thrown in case class is missing.
+	 * @throws \Exception Exception thrown in case class is missing.
 	 *
 	 * @return array<string, mixed>
 	 */

--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -52,7 +52,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	/**
 	 * Register the individual services with optional dependency injection.
 	 *
-	 * @throws \Exception Exception thrown by DI container.
+	 * @throws Exception Exception thrown by DI container.
 	 *
 	 * @return void
 	 */
@@ -65,7 +65,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 
 		$this->services = $this->getServiceClassesWithDi();
 
-		array_walk(
+		\array_walk(
 			$this->services,
 			function ($class) {
 				if (!$class instanceof ServiceInterface) {
@@ -83,7 +83,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 * Allows it to be used in different context (for example in tests outside of WP environment).
 	 *
 	 * @return Container
-	 * @throws \Exception Exception thrown by the DI container.
+	 * @throws Exception Exception thrown by the DI container.
 	 */
 	public function buildDiContainer(): Container
 	{
@@ -97,7 +97,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * You can override autowired definition lists in $this->getServiceClasses().
 	 *
-	 * @throws \ReflectionException Exception thrown in case class is missing.
+	 * @throws ReflectionException Exception thrown in case class is missing.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -111,7 +111,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * @return Object[]
 	 *
-	 * @throws \Exception Exception thrown by the DI container.
+	 * @throws Exception Exception thrown by the DI container.
 	 */
 	private function getServiceClassesWithDi(): array
 	{
@@ -119,11 +119,11 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 
 		$container = $this->getDiContainer($services);
 
-		return array_map(
+		return \array_map(
 			function ($class) use ($container) {
 				return $container->get($class);
 			},
-			array_keys($services)
+			\array_keys($services)
 		);
 	}
 
@@ -131,7 +131,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 * Get services classes array and prepare it for dependency injection.
 	 * Key should be a class name, and value should be an empty array or the dependencies of the class.
 	 *
-	 * @throws \ReflectionException Exception thrown in case class is missing.
+	 * @throws ReflectionException Exception thrown in case class is missing.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -140,7 +140,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 		$output = [];
 
 		foreach ($this->getServiceClassesWithAutowire() as $class => $dependencies) {
-			if (is_array($dependencies)) {
+			if (\is_array($dependencies)) {
 				$output[$class] = $dependencies;
 				continue;
 			}
@@ -160,7 +160,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * @param array<string, mixed> $services Array of service.
 	 *
-	 * @throws \Exception Exception thrown by the DI container.
+	 * @throws Exception Exception thrown by the DI container.
 	 *
 	 * @return Container
 	 */
@@ -169,7 +169,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 		$definitions = [];
 
 		foreach ($services as $serviceKey => $serviceValues) {
-			if (gettype($serviceValues) !== 'array') {
+			if (\gettype($serviceValues) !== 'array') {
 				continue;
 			}
 
@@ -180,8 +180,8 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 
 		$builder = new ContainerBuilder();
 
-		if (defined('WP_ENVIRONMENT_TYPE') && (WP_ENVIRONMENT_TYPE === 'production' || WP_ENVIRONMENT_TYPE === 'staging')) {
-			$file = explode('\\', $this->namespace);
+		if (\defined('WP_ENVIRONMENT_TYPE') && (\WP_ENVIRONMENT_TYPE === 'production' || \WP_ENVIRONMENT_TYPE === 'staging')) {
+			$file = \explode('\\', $this->namespace);
 
 			$builder->enableCompilation(__DIR__ . '/Cache', "{$file[0]}CompiledContainer");
 		}
@@ -199,9 +199,9 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 */
 	private function getDiDependencies(array $dependencies): array
 	{
-		return array_map(
+		return \array_map(
 			function ($dependency) {
-				if (class_exists($dependency)) {
+				if (\class_exists($dependency)) {
 					return new Reference($dependency);
 				}
 				return $dependency;

--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -52,7 +52,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	/**
 	 * Register the individual services with optional dependency injection.
 	 *
-	 * @throws Exception Exception thrown by DI container.
+	 * @throws \Exception Exception thrown by DI container.
 	 *
 	 * @return void
 	 */
@@ -83,7 +83,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 * Allows it to be used in different context (for example in tests outside of WP environment).
 	 *
 	 * @return Container
-	 * @throws Exception Exception thrown by the DI container.
+	 * @throws \Exception Exception thrown by the DI container.
 	 */
 	public function buildDiContainer(): Container
 	{
@@ -111,7 +111,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * @return Object[]
 	 *
-	 * @throws Exception Exception thrown by the DI container.
+	 * @throws \Exception Exception thrown by the DI container.
 	 */
 	private function getServiceClassesWithDi(): array
 	{
@@ -160,7 +160,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * @param array<string, mixed> $services Array of service.
 	 *
-	 * @throws Exception Exception thrown by the DI container.
+	 * @throws \Exception Exception thrown by the DI container.
 	 *
 	 * @return Container
 	 */

--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -15,6 +15,8 @@ use DI\ContainerBuilder;
 use DI\Definition\Helper\AutowireDefinitionHelper;
 use DI\Definition\Reference;
 use EightshiftLibs\Services\ServiceInterface;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use Exception;
 
 /**
  * The main start class.
@@ -28,14 +30,14 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * @var Object[]
 	 */
-	private $services = [];
+	private array $services = [];
 
 	/**
 	 * DI container instance.
 	 *
 	 * @var Container
 	 */
-	private $container;
+	private Container $container;
 
 	/**
 	 * Constructs object and inserts prefixes from composer.
@@ -52,7 +54,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	/**
 	 * Register the individual services with optional dependency injection.
 	 *
-	 * @throws \Exception Exception thrown by DI container.
+	 * @throws Exception Exception thrown by DI container.
 	 *
 	 * @return void
 	 */
@@ -83,7 +85,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 * Allows it to be used in different context (for example in tests outside of WP environment).
 	 *
 	 * @return Container
-	 * @throws \Exception Exception thrown by the DI container.
+	 * @throws Exception Exception thrown by the DI container.
 	 */
 	public function buildDiContainer(): Container
 	{
@@ -97,7 +99,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * You can override autowired definition lists in $this->getServiceClasses().
 	 *
-	 * @throws \Exception Exception thrown in case class is missing.
+	 * @throws Exception Exception thrown in case class is missing.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -111,7 +113,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * @return Object[]
 	 *
-	 * @throws \Exception Exception thrown by the DI container.
+	 * @throws Exception Exception thrown by the DI container.
 	 */
 	private function getServiceClassesWithDi(): array
 	{
@@ -131,7 +133,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 * Get services classes array and prepare it for dependency injection.
 	 * Key should be a class name, and value should be an empty array or the dependencies of the class.
 	 *
-	 * @throws \Exception Exception thrown in case class is missing.
+	 * @throws Exception Exception thrown in case class is missing.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -160,7 +162,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * @param array<string, mixed> $services Array of service.
 	 *
-	 * @throws \Exception Exception thrown by the DI container.
+	 * @throws Exception Exception thrown by the DI container.
 	 *
 	 * @return Container
 	 */

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -36,7 +36,7 @@ class Autowiring
 	 *
 	 * @var string
 	 */
-	protected $namespace;
+	protected string $namespace;
 
 	/**
 	 * Autowiring.
@@ -44,7 +44,7 @@ class Autowiring
 	 * @param array<string, mixed> $manuallyDefinedDependencies Manually defined dependencies from Main.
 	 * @param bool $skipInvalid Skip invalid namespaces rather than throwing an exception. Used for tests.
 	 *
-	 * @throws ReflectionException Exception thrown in case class is missing.
+	 * @throws \Exception Exception thrown in case class is missing.
 	 *
 	 * @return  array<string, mixed> Array of fully qualified class names.
 	 */
@@ -65,7 +65,7 @@ class Autowiring
 		$classInterfaceIndex = $this->buildClassInterfaceIndex($projectReflectionClasses);
 
 		foreach ($projectReflectionClasses as $projectClass => $reflClass) {
-			// Skip abstract classes, interfaces & traits, and non service classes.
+			// Skip abstract classes, interfaces & traits, and non-service classes.
 			if (
 				$reflClass->isAbstract() ||
 				$reflClass->isInterface() ||
@@ -108,10 +108,10 @@ class Autowiring
 	 *
 	 * @param string $relevantClass Class we're building dependency tree for.
 	 * @param array<string, mixed> $filenameIndex Filename index. Maps filenames to class names.
-	 * @param array<string, mixed> $classInterfaceIndex Class interface index. Maps classes to interfaces they implement.
+	 * @param array<string, mixed> $classInterfaceIndex Class interface index. Map classes to interface they implement.
 	 *
 	 * @throws InvalidAutowireDependency If a primitive dependency is found.
-	 * @throws ReflectionException If reflection exception happens.
+	 * @throws \ReflectionException If reflection exception happens.
 	 * @throws Exception General exception.
 	 *
 	 * @return array<string, mixed>
@@ -158,7 +158,7 @@ class Autowiring
 					$reflClassForParam = new ReflectionClass($className);
 
 					// If the expected type is interface, try guessing based on var name.
-					// Otherwise just inject that class.
+					// Otherwise, just inject that class.
 					if ($reflClassForParam->isInterface()) {
 						$matchedClass = $this->tryToFindMatchingClass(
 							$reflParam->getName(),
@@ -247,7 +247,7 @@ class Autowiring
 	 * @param string $filename Filename based on variable name.
 	 * @param string $interfaceName Interface we're trying to match.
 	 * @param array<string, mixed> $filenameIndex Filename index. Maps filenames to class names.
-	 * @param array<string, mixed> $classInterfaceIndex Class interface index. Maps classes to interfaces they implement.
+	 * @param array<string, mixed> $classInterfaceIndex Class interface index. Map classes to interface they implement.
 	 *
 	 * @throws InvalidAutowireDependency If we didn't find exactly 1 class when trying to inject interface-based dependencies.
 	 * @throws Exception If things we're looking for are missing inside filename or classInterface index (which shouldn't happen).
@@ -267,7 +267,7 @@ class Autowiring
 			throw InvalidAutowireDependency::throwUnableToFindClass($className, $interfaceName);
 		}
 
-		// Lets go through each file that's called $filename and check which interfaces that class
+		// Let's go through each file that's called $filename and check which interfaces that class
 		// implements (if any).
 		$matches = 0;
 		$match = '';
@@ -319,7 +319,7 @@ class Autowiring
 	}
 
 	/**
-	 * Builds the PSR-4 class => [$interfaces] index. Maps classes to interfaces they implement.
+	 * Builds the PSR-4 class => [$interfaces] index. Map classes to interface they implement.
 	 *
 	 * @param array<string, ReflectionClass<object>> $reflectionClasses  Reflection classes of all relevant classes.
 	 *
@@ -363,7 +363,7 @@ class Autowiring
 	 *
 	 * @return array<string, mixed>
 	 */
-	private function convertDependencyTreeIntoDefinitionList(array $dependencyTree)
+	private function convertDependencyTreeIntoDefinitionList(array $dependencyTree): array
 	{
 		$classes = [];
 		foreach ($dependencyTree as $className => $dependencies) {
@@ -381,7 +381,7 @@ class Autowiring
 	 * Validates all classes.
 	 *
 	 * Validates that all classes/interfaces/traits/etc. provided here are valid (we can build a ReflectionClass
-	 * on them) and return them. Otherwise throw an exception.
+	 * on them) and return them. Otherwise, throw an exception.
 	 *
 	 * @param array<string, mixed> $classNames FQCNs found in $this->namespace.
 	 * @param bool  $skipInvalid Skip invalid namespaces rather than throwing an exception. Used for tests.

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -13,6 +13,11 @@ namespace EightshiftLibs\Main;
 use EightshiftLibs\Exception\InvalidAutowireDependency;
 use EightshiftLibs\Exception\NonPsr4CompliantClass;
 use EightshiftLibs\Services\ServiceInterface;
+use Exception;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use ReflectionNamedType;
 
 /**
  * The file that defines the autowiring process
@@ -39,7 +44,7 @@ class Autowiring
 	 * @param array<string, mixed> $manuallyDefinedDependencies Manually defined dependencies from Main.
 	 * @param bool $skipInvalid Skip invalid namespaces rather than throwing an exception. Used for tests.
 	 *
-	 * @throws \ReflectionException Exception thrown in case class is missing.
+	 * @throws ReflectionException Exception thrown in case class is missing.
 	 *
 	 * @return  array<string, mixed> Array of fully qualified class names.
 	 */
@@ -71,7 +76,7 @@ class Autowiring
 			}
 
 			// Build the dependency tree.
-			$dependencyTree = array_merge(
+			$dependencyTree = \array_merge(
 				$this->buildDependencyTree($projectClass, $filenameIndex, $classInterfaceIndex),
 				$dependencyTree
 			);
@@ -86,7 +91,7 @@ class Autowiring
 					continue;
 				}
 
-				$dependencyTree = array_merge(
+				$dependencyTree = \array_merge(
 					$this->buildDependencyTree((string)$depClass, $filenameIndex, $classInterfaceIndex),
 					$dependencyTree
 				);
@@ -94,7 +99,7 @@ class Autowiring
 		}
 
 		// Convert dependency tree into PHP-DI's definition list.
-		return array_merge($this->convertDependencyTreeIntoDefinitionList($dependencyTree), $manuallyDefinedDependencies);
+		return \array_merge($this->convertDependencyTreeIntoDefinitionList($dependencyTree), $manuallyDefinedDependencies);
 	}
 
 	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
@@ -106,35 +111,35 @@ class Autowiring
 	 * @param array<string, mixed> $classInterfaceIndex Class interface index. Maps classes to interfaces they implement.
 	 *
 	 * @throws InvalidAutowireDependency If a primitive dependency is found.
-	 * @throws \ReflectionException If reflection exception happens.
-	 * @throws \Exception General exception.
+	 * @throws ReflectionException If reflection exception happens.
+	 * @throws Exception General exception.
 	 *
 	 * @return array<string, mixed>
 	 */
 	private function buildDependencyTree(string $relevantClass, array $filenameIndex, array $classInterfaceIndex): array
 	{
 		// Keeping PHPStan happy.
-		if (!class_exists($relevantClass, false)) {
+		if (!\class_exists($relevantClass, false)) {
 			return [];
 		}
 
 		// Ignore dependencies for autowire and main class.
-		$ignorePaths = array_flip([
+		$ignorePaths = \array_flip([
 			'psr4Prefixes',
 			'namespace',
 		]);
 
 		$dependencyTree = [];
-		$reflClass = new \ReflectionClass($relevantClass);
+		$reflClass = new ReflectionClass($relevantClass);
 		// If this class has dependencies, we need to figure those out. Otherwise,
 		// we just add it to the dependency tree as a class without dependencies.
 		if (!empty($reflClass->getConstructor()) && !empty($reflClass->getConstructor()->getParameters())) {
 			// Go through each constructor parameter.
 			foreach ($reflClass->getConstructor()->getParameters() as $reflParam) {
-				$type = $reflParam->getType();
+				$type = $reflParam->gettype();
 
 				// Skip parameters without type hints.
-				if ($type instanceof \ReflectionNamedType) {
+				if ($type instanceof ReflectionNamedType) {
 					$className = $type->getName();
 					$isBuiltin = $type->isBuiltin();
 				} else {
@@ -149,8 +154,8 @@ class Autowiring
 				}
 
 				// Keeping PHPStan happy.
-				if (class_exists($className, false) || interface_exists($className, false)) {
-					$reflClassForParam = new \ReflectionClass($className);
+				if (\class_exists($className, false) || \interface_exists($className, false)) {
+					$reflClassForParam = new ReflectionClass($className);
 
 					// If the expected type is interface, try guessing based on var name.
 					// Otherwise just inject that class.
@@ -194,17 +199,17 @@ class Autowiring
 		$namespaceWithSlash = "{$namespace}\\";
 		$pathToNamespace = $psr4Prefixes[$namespaceWithSlash][0] ?? '';
 
-		if (!is_dir($pathToNamespace)) {
+		if (!\is_dir($pathToNamespace)) {
 			return [];
 		}
 
-		$it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($pathToNamespace));
+		$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($pathToNamespace));
 		foreach ($it as $file) {
 			if ($file->isDir()) {
 				continue;
 			}
 
-			if (preg_match('/^[A-Z]{1}[A-Za-z0-9]+\.php/', $file->getFileName())) {
+			if (\preg_match('/^[A-Z]{1}[A-Za-z0-9]+\.php/', $file->getFileName())) {
 				$classes[] = $this->getNamespaceFromFilepath($file->getPathname(), $namespace, $pathToNamespace);
 			}
 		}
@@ -226,8 +231,8 @@ class Autowiring
 		string $rootNamespace,
 		string $rootNamespacePath
 	): string {
-		$pathNamespace = str_replace(
-			[$rootNamespacePath, DIRECTORY_SEPARATOR, '.php'],
+		$pathNamespace = \str_replace(
+			[$rootNamespacePath, \DIRECTORY_SEPARATOR, '.php'],
 			['', '\\', ''],
 			$filepath
 		);
@@ -245,7 +250,7 @@ class Autowiring
 	 * @param array<string, mixed> $classInterfaceIndex Class interface index. Maps classes to interfaces they implement.
 	 *
 	 * @throws InvalidAutowireDependency If we didn't find exactly 1 class when trying to inject interface-based dependencies.
-	 * @throws \Exception If things we're looking for are missing inside filename or classInterface index (which shouldn't happen).
+	 * @throws Exception If things we're looking for are missing inside filename or classInterface index (which shouldn't happen).
 	 *
 	 * @return string
 	 */
@@ -257,7 +262,7 @@ class Autowiring
 	): string {
 		// If there's no matches in filename index by variable, we need to throw an exception to let the user
 		// know they either need to provide the correct variable name OR manually define the dependencies for this class.
-		$className = ucfirst($filename);
+		$className = \ucfirst($filename);
 		if (!isset($filenameIndex[$filename])) {
 			throw InvalidAutowireDependency::throwUnableToFindClass($className, $interfaceName);
 		}
@@ -269,7 +274,7 @@ class Autowiring
 
 		foreach ($filenameIndex[$filename] as $classInFilename) {
 			if (!isset($classInterfaceIndex[$classInFilename])) {
-				throw new \Exception("Class {$classInFilename} not found in classInterfaceIndex, aborting.");
+				throw new Exception("Class {$classInFilename} not found in classInterfaceIndex, aborting.");
 			}
 
 			// If the current class implements the interface we're looking for, great!
@@ -297,7 +302,7 @@ class Autowiring
 	/**
 	 * Builds the PSR-4 filename index. Maps filenames to class names.
 	 *
-	 * @param array<string, \ReflectionClass<object>> $reflectionClasses Reflection classes of all relevant classes.
+	 * @param array<string, ReflectionClass<object>> $reflectionClasses Reflection classes of all relevant classes.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -316,7 +321,7 @@ class Autowiring
 	/**
 	 * Builds the PSR-4 class => [$interfaces] index. Maps classes to interfaces they implement.
 	 *
-	 * @param array<string, \ReflectionClass<object>> $reflectionClasses  Reflection classes of all relevant classes.
+	 * @param array<string, ReflectionClass<object>> $reflectionClasses  Reflection classes of all relevant classes.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -324,7 +329,7 @@ class Autowiring
 	{
 		$classInterfaceIndex = [];
 		foreach ($reflectionClasses as $projectClass => $reflectionClass) {
-			$interfaces = array_map(
+			$interfaces = \array_map(
 				function () {
 					return true;
 				},
@@ -348,7 +353,7 @@ class Autowiring
 	 */
 	private function getFilenameFromClass(string $className): string
 	{
-		return lcfirst(trim(substr($className, strrpos($className, '\\') + 1)));
+		return \lcfirst(\trim(\substr($className, \strrpos($className, '\\') + 1)));
 	}
 
 	/**
@@ -381,7 +386,7 @@ class Autowiring
 	 * @param array<string, mixed> $classNames FQCNs found in $this->namespace.
 	 * @param bool  $skipInvalid Skip invalid namespaces rather than throwing an exception. Used for tests.
 	 *
-	 * @return array<string, \ReflectionClass<object>>
+	 * @return array<string, ReflectionClass<object>>
 	 *
 	 * @throws NonPsr4CompliantClass When a found class/file doesn't match PSR-4 standards (and $skipInvalid is false).
 	 */
@@ -390,9 +395,9 @@ class Autowiring
 		$reflectionClasses = [];
 		foreach ($classNames as $className) {
 			try {
-				$reflClass = new \ReflectionClass($className);
+				$reflClass = new ReflectionClass($className);
 				$reflectionClasses[(string)$className] = $reflClass;
-			} catch (\Exception $e) {
+			} catch (Exception $e) {
 				if ($skipInvalid) {
 					continue;
 				} else {
@@ -414,7 +419,7 @@ class Autowiring
 	 */
 	private function filterManuallyDefinedDependencies(array $serviceClasses, array $manuallyDefinedDependencies): array
 	{
-		return array_filter($serviceClasses, function ($classNamespace) use ($manuallyDefinedDependencies) {
+		return \array_filter($serviceClasses, function ($classNamespace) use ($manuallyDefinedDependencies) {
 			return !isset($manuallyDefinedDependencies[$classNamespace]);
 		});
 	}

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -18,6 +18,8 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
 use ReflectionNamedType;
+// phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
+use ReflectionException;
 
 /**
  * The file that defines the autowiring process
@@ -44,7 +46,7 @@ class Autowiring
 	 * @param array<string, mixed> $manuallyDefinedDependencies Manually defined dependencies from Main.
 	 * @param bool $skipInvalid Skip invalid namespaces rather than throwing an exception. Used for tests.
 	 *
-	 * @throws \Exception Exception thrown in case class is missing.
+	 * @throws Exception Exception thrown in case class is missing.
 	 *
 	 * @return  array<string, mixed> Array of fully qualified class names.
 	 */
@@ -111,7 +113,7 @@ class Autowiring
 	 * @param array<string, mixed> $classInterfaceIndex Class interface index. Map classes to interface they implement.
 	 *
 	 * @throws InvalidAutowireDependency If a primitive dependency is found.
-	 * @throws \ReflectionException If reflection exception happens.
+	 * @throws ReflectionException If reflection exception happens.
 	 * @throws Exception General exception.
 	 *
 	 * @return array<string, mixed>

--- a/src/Main/MainCli.php
+++ b/src/Main/MainCli.php
@@ -20,7 +20,7 @@ class MainCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Main';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Main';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class MainCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Read the template contents, and replace the placeholders with provided variables.
 		$this->getExampleTemplate(__DIR__, $this->getClassShortName())

--- a/src/Manifest/AbstractManifest.php
+++ b/src/Manifest/AbstractManifest.php
@@ -37,23 +37,23 @@ abstract class AbstractManifest implements ServiceInterface, ManifestInterface
 	 */
 	public function setAssetsManifestRaw(): void
 	{
-		if (defined('WP_CLI') && !getenv('TEST')) {
+		if (\defined('WP_CLI') && !\getenv('TEST')) {
 			return;
 		}
 
 		$path = $this->getManifestFilePath();
 
-		if (!file_exists($path)) {
+		if (!\file_exists($path)) {
 			throw InvalidManifest::missingManifestException($path);
 		}
 
-		$data = json_decode(implode(' ', (array)file($path)), true);
+		$data = \json_decode(\implode(' ', (array)\file($path)), true);
 
 		if (empty($data)) {
 			return;
 		}
 
-		$this->manifest = array_map(
+		$this->manifest = \array_map(
 			function ($manifestItem) {
 				return "{$this->getAssetsManifestOutputPrefix()}{$manifestItem}";
 			},
@@ -73,7 +73,7 @@ abstract class AbstractManifest implements ServiceInterface, ManifestInterface
 	 */
 	public function getAssetsManifestItem(string $key): string
 	{
-		if (defined('WP_CLI') && !getenv('TEST')) {
+		if (\defined('WP_CLI') && !\getenv('TEST')) {
 			return '';
 		}
 

--- a/src/Manifest/ManifestCli.php
+++ b/src/Manifest/ManifestCli.php
@@ -20,7 +20,7 @@ class ManifestCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Manifest';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Manifest';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class ManifestCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/Media/MediaCli.php
+++ b/src/Media/MediaCli.php
@@ -20,7 +20,7 @@ class MediaCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Media';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Media';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class MediaCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/Menu/AbstractMenu.php
+++ b/src/Menu/AbstractMenu.php
@@ -63,9 +63,9 @@ abstract class AbstractMenu implements ServiceInterface, MenuPositionsInterface
 		$modifiers = '';
 
 		if (!empty($cssClassModifiers)) {
-			if (is_array($cssClassModifiers)) {
-				$modifiers = implode(' ', $cssClassModifiers);
-			} elseif (is_string($cssClassModifiers)) {
+			if (\is_array($cssClassModifiers)) {
+				$modifiers = \implode(' ', $cssClassModifiers);
+			} elseif (\is_string($cssClassModifiers)) {
 				$modifiers = $cssClassModifiers;
 			}
 		}

--- a/src/Menu/BemMenuWalker.php
+++ b/src/Menu/BemMenuWalker.php
@@ -113,7 +113,7 @@ class BemMenuWalker extends \Walker_Nav_Menu
 			$prefix . $suffix['sub_menu'] . '--' . $real_depth,
 		];
 
-		$classNames = implode(' ', $classes);
+		$classNames = \implode(' ', $classes);
 
 		// Add a ul wrapper to sub nav.
 		$output .= "\n" . $indent . '<ul class="' . $classNames . '">' . "\n";
@@ -149,9 +149,9 @@ class BemMenuWalker extends \Walker_Nav_Menu
 		$itemClasses = [];
 
 		if (!empty($item->classes)) {
-			$userClasses = array_map(
+			$userClasses = \array_map(
 				function ($className) use ($prefix) {
-					if (strpos($className, 'js-') !== false) {
+					if (\strpos($className, 'js-') !== false) {
 						$output = $className;
 					} else {
 						$output = $prefix . '__item--' . $className;
@@ -165,30 +165,30 @@ class BemMenuWalker extends \Walker_Nav_Menu
 			$itemClasses = [
 				'item_class' => 0 === $depth ? $prefix . $suffix['item'] : '',
 				'parent_class' => isset($args->has_children) && $args->has_children ? $parent_class : '',
-				'active_page_class' => in_array(
+				'active_page_class' => \in_array(
 					'current-menu-item',
 					$item->classes,
 					true
 				) ? $prefix . $suffix['active_item'] : '',
-				'active_parent_class' => in_array(
+				'active_parent_class' => \in_array(
 					'current-menu-parent',
 					$item->classes,
 					true
 				) ? $prefix . $suffix['parent_of_active_item'] : '',
-				'active_ancestor_class' => in_array(
+				'active_ancestor_class' => \in_array(
 					'current-page-ancestor',
 					$item->classes,
 					true
 				) ? $prefix . $suffix['ancestor_of_active_item'] : '',
 				'depth_class' => $depth >= 1 ? $prefix . $suffix['sub_menu_item'] . ' ' . $prefix . $suffix['sub_menu'] . '--' . $depth . '__item' : '',
 				'item_id_class' => $prefix . '__item--' . $item->object_id,
-				'user_class' => !empty($userClasses) ? implode(' ', $userClasses) : '',
+				'user_class' => !empty($userClasses) ? \implode(' ', $userClasses) : '',
 			];
 		}
 
 		// Convert array to string excluding any empty values.
 		$itemClasses = \apply_filters('walker_nav_menu_item_classes', $itemClasses, $item, $depth, $args);
-		$class_string = !empty($itemClasses) ? implode('  ', array_filter($itemClasses)) : '';
+		$class_string = !empty($itemClasses) ? \implode('  ', \array_filter($itemClasses)) : '';
 
 		// Add the classes to the wrapping <li>.
 		$output .= $indent . '<li class="' . $class_string . '">';
@@ -199,7 +199,7 @@ class BemMenuWalker extends \Walker_Nav_Menu
 			'depth_class' => $depth >= 1 ? $prefix . $suffix['sub_menu'] . $suffix['link'] . '  ' . $prefix . $suffix['sub_menu'] . '--' . $depth . $suffix['link'] : '',
 		];
 
-		$link_class_string = implode('  ', array_filter($link_classes));
+		$link_class_string = \implode('  ', \array_filter($link_classes));
 
 		$link_class_output = 'class="' . $link_class_string . ' "';
 
@@ -208,7 +208,7 @@ class BemMenuWalker extends \Walker_Nav_Menu
 			'depth_class' => $depth >= 1 ? $prefix . $suffix['sub_menu'] . $suffix['link'] . '-text ' . $prefix . $suffix['sub_menu'] . '--' . $depth . $suffix['link'] . '-text' : '',
 		];
 
-		$link_text_class_string = implode('  ', array_filter($link_text_classes));
+		$link_text_class_string = \implode('  ', \array_filter($link_text_classes));
 		$link_text_class_output = 'class="' . $link_text_class_string . '"';
 
 		// link attributes.

--- a/src/Menu/MenuCli.php
+++ b/src/Menu/MenuCli.php
@@ -20,7 +20,7 @@ class MenuCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Menu';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Menu';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class MenuCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/ModifyAdminAppearance/ModifyAdminAppearanceCli.php
+++ b/src/ModifyAdminAppearance/ModifyAdminAppearanceCli.php
@@ -20,7 +20,7 @@ class ModifyAdminAppearanceCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'ModifyAdminAppearance';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'ModifyAdminAppearance';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class ModifyAdminAppearanceCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/Readme/ReadmeCli.php
+++ b/src/Readme/ReadmeCli.php
@@ -22,7 +22,7 @@ class ReadmeCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+	public const OUTPUT_DIR = '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR;
 
 	/**
 	 * Get WPCLI command name
@@ -69,7 +69,7 @@ class ReadmeCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$root = $assocArgs['root'] ?? static::OUTPUT_DIR;

--- a/src/Rest/CallableRouteInterface.php
+++ b/src/Rest/CallableRouteInterface.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Rest;
 
+use WP_REST_Request;
+
 /**
  * Interface for route callbacks
  */
@@ -18,11 +20,11 @@ interface CallableRouteInterface
 	/**
 	 * Method that returns rest response
 	 *
-	 * @param \WP_REST_Request $request Data got from endpoint url.
+	 * @param WP_REST_Request $request Data got from endpoint url.
 	 *
-	 * @return \WP_REST_Response|mixed If response generated an error, WP_Error, if response
+	 * @return WP_REST_Response|mixed If response generated an error, WP_Error, if response
 	 *                                is already an instance, WP_HTTP_Response, otherwise
 	 *                                returns a new WP_REST_Response instance.
 	 */
-	public function routeCallback(\WP_REST_Request $request);
+	public function routeCallback(WP_REST_Request $request);
 }

--- a/src/Rest/Fields/AbstractField.php
+++ b/src/Rest/Fields/AbstractField.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace EightshiftLibs\Rest\Fields;
 
 use EightshiftLibs\Services\ServiceInterface;
+use WP_REST_Server;
 
 /**
  * Abstract base field class
@@ -30,11 +31,11 @@ abstract class AbstractField implements ServiceInterface
 	/**
 	 * Method that register rest field that is used inside rest_api_init hook.
 	 *
-	 * @param \WP_REST_Server $wpRestServer Server object.
+	 * @param WP_REST_Server $wpRestServer Server object.
 	 *
 	 * @return void
 	 */
-	public function fieldRegisterCallback(\WP_REST_Server $wpRestServer): void
+	public function fieldRegisterCallback(WP_REST_Server $wpRestServer): void
 	{
 		\register_rest_field(
 			$this->getObjectType(),

--- a/src/Rest/Fields/FieldCli.php
+++ b/src/Rest/Fields/FieldCli.php
@@ -22,7 +22,7 @@ class FieldCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Rest' . DIRECTORY_SEPARATOR . 'Fields';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Rest' . \DIRECTORY_SEPARATOR . 'Fields';
 
 	/**
 	 * Get WPCLI command name
@@ -76,7 +76,7 @@ class FieldCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$fieldName = $this->prepareSlug($assocArgs['field_name'] ?? '');

--- a/src/Rest/Fields/FieldCli.php
+++ b/src/Rest/Fields/FieldCli.php
@@ -63,13 +63,13 @@ class FieldCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'field_name',
 					'description' => 'The name of the endpoint slug. Example: title.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'object_type',
 					'description' => 'Object(s) the field is being registered to. Example: post.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Rest/Fields/FieldCli.php
+++ b/src/Rest/Fields/FieldCli.php
@@ -63,13 +63,13 @@ class FieldCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'field_name',
 					'description' => 'The name of the endpoint slug. Example: title.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'object_type',
 					'description' => 'Object(s) the field is being registered to. Example: post.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Rest/Fields/FieldCli.php
+++ b/src/Rest/Fields/FieldCli.php
@@ -63,13 +63,13 @@ class FieldCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'field_name',
 					'description' => 'The name of the endpoint slug. Example: title.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : true
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'object_type',
 					'description' => 'Object(s) the field is being registered to. Example: post.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : true
 				],
 			],
 		];
@@ -79,8 +79,8 @@ class FieldCli extends AbstractCli
 	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
-		$fieldName = $this->prepareSlug($assocArgs['field_name'] ?? '');
-		$objectType = $this->prepareSlug($assocArgs['object_type'] ?? '');
+		$fieldName = $this->prepareSlug($assocArgs['field_name']);
+		$objectType = $this->prepareSlug($assocArgs['object_type']);
 
 		// Get full class name.
 		$className = $this->getFileName($fieldName);

--- a/src/Rest/Routes/AbstractRoute.php
+++ b/src/Rest/Routes/AbstractRoute.php
@@ -12,6 +12,7 @@ namespace EightshiftLibs\Rest\Routes;
 
 use EightshiftLibs\Services\ServiceInterface;
 use EightshiftLibs\Rest\RouteInterface;
+use WP_REST_Server;
 
 /**
  * Abstract base route class
@@ -31,11 +32,11 @@ abstract class AbstractRoute implements RouteInterface, ServiceInterface
 	/**
 	 * Method that registers rest route that is used inside rest_api_init hook
 	 *
-	 * @param \WP_REST_Server $wpRestServer Server object.
+	 * @param WP_REST_Server $wpRestServer Server object.
 	 *
 	 * @return void
 	 */
-	public function routeRegisterCallback(\WP_REST_Server $wpRestServer): void
+	public function routeRegisterCallback(WP_REST_Server $wpRestServer): void
 	{
 		\register_rest_route(
 			$this->getNamespace() . '/' . $this->getVersion(),

--- a/src/Rest/Routes/RouteCli.php
+++ b/src/Rest/Routes/RouteCli.php
@@ -85,13 +85,13 @@ class RouteCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'endpoint_slug',
 					'description' => 'The name of the endpoint slug. Example: test-route.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'method',
 					'description' => 'HTTP verb must be one of: GET, POST, PATCH, PUT, or DELETE.',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Rest/Routes/RouteCli.php
+++ b/src/Rest/Routes/RouteCli.php
@@ -11,7 +11,8 @@ declare(strict_types=1);
 namespace EightshiftLibs\Rest\Routes;
 
 use EightshiftLibs\Cli\AbstractCli;
-use EightshiftLibs\Rest\RouteInterface;
+
+use WP_CLI;
 
 /**
  * Class RouteCli
@@ -30,7 +31,7 @@ class RouteCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'Rest' . DIRECTORY_SEPARATOR . 'Routes';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'Rest' . \DIRECTORY_SEPARATOR . 'Routes';
 
 	/**
 	 * Route method enum.
@@ -97,11 +98,11 @@ class RouteCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
-		$endpointSlug = $this->prepareSlug($assocArgs['endpoint_slug'] ?? 'example-route');
-		$method = strtoupper($assocArgs['method'] ?? 'GET');
+		$endpointSlug = $this->prepareSlug($assocArgs['endpoint_slug']);
+		$method = \strtoupper($assocArgs['method']);
 
 		// Get full class name.
 		$className = $this->getFileName($endpointSlug);
@@ -109,12 +110,12 @@ class RouteCli extends AbstractCli
 
 		// If method is invalid throw error.
 		if (!isset(self::VERB_ENUM[$method])) {
-			\WP_CLI::error("Invalid method: $method, please use one of GET, POST, PATCH, PUT, or DELETE");
+			WP_CLI::error("Invalid method: $method, please use one of GET, POST, PATCH, PUT, or DELETE");
 		}
 
 		// If slug is empty throw error.
 		if (empty($endpointSlug)) {
-			\WP_CLI::error("Empty slug provided, please set the slug using --endpoint_slug=\"slug-name\"");
+			WP_CLI::error("Empty slug provided, please set the slug using --endpoint_slug=\"slug-name\"");
 		}
 
 		// Read the template contents, and replace the placeholders with provided variables.

--- a/src/Rest/Routes/RouteCli.php
+++ b/src/Rest/Routes/RouteCli.php
@@ -85,13 +85,13 @@ class RouteCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'endpoint_slug',
 					'description' => 'The name of the endpoint slug. Example: test-route.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'method',
 					'description' => 'HTTP verb must be one of: GET, POST, PATCH, PUT, or DELETE.',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Rest/Routes/RouteCli.php
+++ b/src/Rest/Routes/RouteCli.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace EightshiftLibs\Rest\Routes;
 
 use EightshiftLibs\Cli\AbstractCli;
-
 use WP_CLI;
 
 /**

--- a/src/Rest/Routes/RouteExample.php
+++ b/src/Rest/Routes/RouteExample.php
@@ -13,6 +13,7 @@ namespace EightshiftBoilerplate\Rest\Routes;
 use EightshiftBoilerplate\Config\Config;
 use EightshiftLibs\Rest\Routes\AbstractRoute;
 use EightshiftLibs\Rest\CallableRouteInterface;
+use WP_REST_Request;
 
 /**
  * Class RouteExample
@@ -66,15 +67,15 @@ class RouteExample extends AbstractRoute implements CallableRouteInterface
 	/**
 	 * Method that returns rest response
 	 *
-	 * @param \WP_REST_Request $request Data got from endpoint url.
+	 * @param WP_REST_Request $request Data got from endpoint url.
 	 *
-	 * @return \WP_REST_Response|mixed If response generated an error, WP_Error, if response
+	 * @return WP_REST_Response|mixed If response generated an error, WP_Error, if response
 	 *                                is already an instance, WP_HTTP_Response, otherwise
 	 *                                returns a new WP_REST_Response instance.
 	 */
-	public function routeCallback(\WP_REST_Request $request)
+	public function routeCallback(WP_REST_Request $request)
 	{
-		$response = json_decode($request->get_body(), true);
+		$response = \json_decode($request->get_body(), true);
 
 		return \rest_ensure_response($response);
 	}

--- a/src/Services/ServiceExampleCli.php
+++ b/src/Services/ServiceExampleCli.php
@@ -56,13 +56,13 @@ class ServiceExampleCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'folder',
 					'description' => 'The output folder path relative to src folder. Example: main or `main` or `config` or nested `main/config`',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'file_name',
 					'description' => 'The output file name. Example: Main',
-					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
+					'optional' => \defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Services/ServiceExampleCli.php
+++ b/src/Services/ServiceExampleCli.php
@@ -69,7 +69,7 @@ class ServiceExampleCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$folder = $assocArgs['folder'] ?? '';
@@ -78,17 +78,17 @@ class ServiceExampleCli extends AbstractCli
 		// Get full class name.
 		$className = $this->getClassShortName();
 		$classNameNew = $this->getFileName($fileName);
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 
 		// Create new namespace from the folder structure.
-		$folderParts = array_map(
+		$folderParts = \array_map(
 			function ($item) {
-				return ucfirst($item);
+				return \ucfirst($item);
 			},
-			explode($ds, $folder)
+			\explode($ds, $folder)
 		);
 
-		$newNamespace = '\\' . implode('\\', $folderParts);
+		$newNamespace = '\\' . \implode('\\', $folderParts);
 
 		// Read the template contents, and replace the placeholders with provided variables.
 		$this->getExampleTemplate(__DIR__, static::TEMPLATE)

--- a/src/Services/ServiceExampleCli.php
+++ b/src/Services/ServiceExampleCli.php
@@ -56,13 +56,13 @@ class ServiceExampleCli extends AbstractCli
 					'type' => 'assoc',
 					'name' => 'folder',
 					'description' => 'The output folder path relative to src folder. Example: main or `main` or `config` or nested `main/config`',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 				[
 					'type' => 'assoc',
 					'name' => 'file_name',
 					'description' => 'The output file name. Example: Main',
-					'optional' => \defined('ES_DEVELOP_MODE') ?? false
+					'optional' => \defined('ES_DEVELOP_MODE') ? ES_DEVELOP_MODE : false
 				],
 			],
 		];

--- a/src/Setup/SetupCli.php
+++ b/src/Setup/SetupCli.php
@@ -24,7 +24,7 @@ class SetupCli extends AbstractCli
 	 *
 	 * @var string
 	 */
-	public const OUTPUT_DIR = '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+	public const OUTPUT_DIR = '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR;
 
 	/**
 	 * Get WPCLI command name
@@ -71,7 +71,7 @@ class SetupCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		// Get Props.
 		$root = $assocArgs['root'] ?? static::OUTPUT_DIR;

--- a/src/Setup/UpdateCli.php
+++ b/src/Setup/UpdateCli.php
@@ -12,6 +12,7 @@ namespace EightshiftLibs\Setup;
 
 use EightshiftLibs\Cli\AbstractCli;
 use EightshiftLibs\Cli\CliHelpers;
+use WP_CLI;
 use WP_CLI\ExitException;
 
 /**
@@ -76,12 +77,12 @@ class UpdateCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 
 		$setupFilename = 'setup.json';
 
-		if (getenv('TEST') !== false) {
+		if (\getenv('TEST') !== false) {
 			$setupFilename = $this->getProjectConfigRootPath() . '/cliOutput/setup.json';
 		}
 
@@ -98,7 +99,7 @@ class UpdateCli extends AbstractCli
 				$setupFilename
 			);
 		} catch (ExitException $e) {
-			exit("{$e->getCode()}: {$e->getMessage()}"); // phpcs:ignore Eightshift.Security.CustomEscapeOutput.OutputNotEscaped
+			exit("{$e->getCode()}: {$e->getMessage()}"); // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped
 		}
 	}
 
@@ -122,19 +123,19 @@ class UpdateCli extends AbstractCli
 		$skipThemes = $args['skip_themes'] ?? false;
 
 		// Change execution folder.
-		if (!is_dir($projectRootPath)) {
+		if (!\is_dir($projectRootPath)) {
 			CliHelpers::cliError("Folder doesn't exist on this path: {$projectRootPath}.");
 		}
 
-		chdir($projectRootPath);
+		\chdir($projectRootPath);
 
 		// Check if setup exists.
-		if (!file_exists($setupFile)) {
+		if (!\file_exists($setupFile)) {
 			CliHelpers::cliError("setup.json is missing at this path: {$setupFile}.");
 		}
 
 		// Parse json file to array.
-		$data = json_decode(implode(' ', (array)file($setupFile)), true);
+		$data = \json_decode(\implode(' ', (array)\file($setupFile)), true);
 
 		if (empty($data)) {
 			CliHelpers::cliError("{$setupFile} is empty.");
@@ -146,10 +147,10 @@ class UpdateCli extends AbstractCli
 
 			// Install core version.
 			if (!empty($core)) {
-				\WP_CLI::runcommand("core update --version={$core} --force");
-				\WP_CLI::log('--------------------------------------------------');
+				WP_CLI::runcommand("core update --version={$core} --force");
+				WP_CLI::log('--------------------------------------------------');
 			} else {
-				\WP_CLI::warning('No core version is defined. Skipping.');
+				WP_CLI::warning('No core version is defined. Skipping.');
 			}
 		}
 
@@ -165,11 +166,11 @@ class UpdateCli extends AbstractCli
 					// Install core plugins.
 					if (!empty($pluginsCore)) {
 						foreach ($pluginsCore as $name => $version) {
-							\WP_CLI::runcommand("plugin install {$name} --version={$version} --force");
-							\WP_CLI::log('--------------------------------------------------');
+							WP_CLI::runcommand("plugin install {$name} --version={$version} --force");
+							WP_CLI::log('--------------------------------------------------');
 						}
 					} else {
-						\WP_CLI::warning('No core plugins are defined. Skipping.');
+						WP_CLI::warning('No core plugins are defined. Skipping.');
 					}
 				}
 
@@ -181,15 +182,15 @@ class UpdateCli extends AbstractCli
 					if (!empty($pluginsGithub)) {
 						foreach ($pluginsGithub as $name => $version) {
 							$shortName = CliHelpers::getGithubPluginName($name);
-							$filePath = getcwd() . "/{$shortName}.zip";
-							$releaseZip = file_get_contents("https://github.com/{$name}/releases/download/{$version}/release.zip"); // phpcs:ignore WordPress.WP.AlternativeFunctions
-							file_put_contents($filePath, $releaseZip); // phpcs:ignore WordPress.WP.AlternativeFunctions
-							\WP_CLI::runcommand("plugin install {$filePath} --force");
-							\WP_CLI::log('--------------------------------------------------');
-							unlink($filePath);
+							$filePath = \getcwd() . "/{$shortName}.zip";
+							$releaseZip = \file_get_contents("https://github.com/{$name}/releases/download/{$version}/release.zip"); // phpcs:ignore WordPress.WP.AlternativeFunctions
+							\file_put_contents($filePath, $releaseZip); // phpcs:ignore WordPress.WP.AlternativeFunctions
+							WP_CLI::runcommand("plugin install {$filePath} --force");
+							WP_CLI::log('--------------------------------------------------');
+							\unlink($filePath);
 						}
 					} else {
-						\WP_CLI::warning('No Github plugins are defined. Skipping.');
+						WP_CLI::warning('No Github plugins are defined. Skipping.');
 					}
 				}
 			}
@@ -202,15 +203,15 @@ class UpdateCli extends AbstractCli
 			// Install themes.
 			if (!empty($themes)) {
 				foreach ($themes as $name => $version) {
-					\WP_CLI::runcommand("theme install {$name} --version={$version} --force");
-					\WP_CLI::log('--------------------------------------------------');
+					WP_CLI::runcommand("theme install {$name} --version={$version} --force");
+					WP_CLI::log('--------------------------------------------------');
 				}
 			} else {
-				\WP_CLI::warning('No themes are defined. Skipping.');
+				WP_CLI::warning('No themes are defined. Skipping.');
 			}
 		}
 
-		\WP_CLI::success('All commands are finished.');
-		\WP_CLI::log('--------------------------------------------------');
+		WP_CLI::success('All commands are finished.');
+		WP_CLI::log('--------------------------------------------------');
 	}
 }

--- a/src/ThemeOptions/ThemeOptionsCli.php
+++ b/src/ThemeOptions/ThemeOptionsCli.php
@@ -20,7 +20,7 @@ class ThemeOptionsCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'ThemeOptions';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'ThemeOptions';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class ThemeOptionsCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/src/ThemeOptions/ThemeOptionsExample.php
+++ b/src/ThemeOptions/ThemeOptionsExample.php
@@ -35,12 +35,12 @@ class ThemeOptionsExample implements ServiceInterface
 	public function register(): void
 	{
 		// Silently exit if no ACF is installed.
-		if (!class_exists('ACF')) {
+		if (!\class_exists('ACF')) {
 			return;
 		}
 
-		add_action('acf/init', [$this, 'createThemeOptionsPage']);
-		add_action('acf/init', [$this, 'registerThemeOptions']);
+		\add_action('acf/init', [$this, 'createThemeOptionsPage']);
+		\add_action('acf/init', [$this, 'registerThemeOptions']);
 	}
 
 	/**
@@ -50,7 +50,7 @@ class ThemeOptionsExample implements ServiceInterface
 	 */
 	public function createThemeOptionsPage(): void
 	{
-		if (function_exists('acf_add_options_page')) {
+		if (\function_exists('acf_add_options_page')) {
 			\acf_add_options_page(
 				[
 					'page_title' => \esc_html__('General Settings', 'eightshift-libs'),
@@ -72,11 +72,11 @@ class ThemeOptionsExample implements ServiceInterface
 	 */
 	public function registerThemeOptions(): void
 	{
-		if (function_exists('acf_add_local_field_group')) {
-			acf_add_local_field_group(
+		if (\function_exists('acf_add_local_field_group')) {
+			\acf_add_local_field_group(
 				[
 					'key' => 'group_5fcab51c7138c',
-					'title' => esc_html__('Theme Options', 'eightshift-libs'),
+					'title' => \esc_html__('Theme Options', 'eightshift-libs'),
 					'fields' => [],
 					'location' => [
 						[

--- a/src/View/EscapedViewCli.php
+++ b/src/View/EscapedViewCli.php
@@ -20,7 +20,7 @@ class EscapedViewCli extends AbstractCli
 	/**
 	 * Output dir relative path.
 	 */
-	public const OUTPUT_DIR = 'src' . DIRECTORY_SEPARATOR . 'View';
+	public const OUTPUT_DIR = 'src' . \DIRECTORY_SEPARATOR . 'View';
 
 	/**
 	 * Get WPCLI command doc
@@ -35,7 +35,7 @@ class EscapedViewCli extends AbstractCli
 	}
 
 	/* @phpstan-ignore-next-line */
-	public function __invoke(array $args, array $assocArgs) // phpcs:ignore
+	public function __invoke(array $args, array $assocArgs)
 	{
 		$className = $this->getClassShortName();
 

--- a/tests/AdminMenus/AdminMenuCliTest.php
+++ b/tests/AdminMenus/AdminMenuCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Admin menu CLI command will correctly copy the admin menu example class wi
 	$cpt([], $cpt->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/AdminTitleAdminMenu.php');
+	$generatedCPT = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/AdminTitleAdminMenu.php');
 
 	$this->assertStringContainsString('class AdminTitleAdminMenu extends AbstractAdminMenu', $generatedCPT, 'Class name not correctly set');
 	$this->assertStringContainsString('Admin Title', $generatedCPT, 'Menu title not correctly replaced');
@@ -58,7 +58,7 @@ test('Admin menu CLI command will correctly copy the admin menu class with set a
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/ReusableBlocksAdminMenu.php');
+	$generatedCPT = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/ReusableBlocksAdminMenu.php');
 
 	$this->assertStringContainsString('class ReusableBlocksAdminMenu extends AbstractAdminMenu', $generatedCPT, 'Class name not correctly set');
 	$this->assertStringContainsString('Reusable Blocks', $generatedCPT, 'Menu title not correctly replaced');

--- a/tests/AdminMenus/AdminSubMenuCliTest.php
+++ b/tests/AdminMenus/AdminSubMenuCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Admin submenu CLI command will correctly copy the admin menu example class
 	$cpt([], $cpt->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/AdminTitleAdminSubMenu.php');
+	$generatedCPT = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/AdminTitleAdminSubMenu.php');
 
 	$this->assertStringContainsString('class AdminTitleAdminSubMenu extends AbstractAdminSubMenu', $generatedCPT, 'Class name not correctly set');
 	$this->assertStringContainsString('Admin Title', $generatedCPT, 'Menu title not correctly replaced');
@@ -58,7 +58,7 @@ test('Admin submenu CLI command will correctly copy the admin menu class with se
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/ReusableBlockOptionsAdminSubMenu.php');
+	$generatedCPT = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/AdminMenus/ReusableBlockOptionsAdminSubMenu.php');
 
 	$this->assertStringContainsString('class ReusableBlockOptionsAdminSubMenu extends AbstractAdminSubMenu', $generatedCPT, 'Class name not correctly set');
 	$this->assertStringContainsString('Options', $generatedCPT, 'Menu title not correctly replaced');

--- a/tests/BlockPatterns/BlockPatternCliTest.php
+++ b/tests/BlockPatterns/BlockPatternCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -40,7 +40,7 @@ test('Block pattern CLI command will correctly copy the Block Pattern class with
 	$blockPattern([], $developArgs);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedBlockPattern = file_get_contents(dirname(__FILE__, 3) . "/cliOutput/src/BlockPatterns/SomethingBlockPattern.php");
+	$generatedBlockPattern = \file_get_contents(\dirname(__FILE__, 3) . "/cliOutput/src/BlockPatterns/SomethingBlockPattern.php");
 
 	$this->assertStringContainsString('class SomethingBlockPattern extends AbstractBlockPattern', $generatedBlockPattern);
 
@@ -66,7 +66,7 @@ test('Block pattern CLI command will correctly copy the Block pattern class with
 	$blockPattern([], $cliArgs);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedBlockPattern = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/BlockPatterns/YourOwnThingBlockPattern.php');
+	$generatedBlockPattern = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/BlockPatterns/YourOwnThingBlockPattern.php');
 
 	$this->assertStringContainsString('class YourOwnThingBlockPattern extends AbstractBlockPattern', $generatedBlockPattern);
 	foreach ($cliArgs as $cliArg) {
@@ -89,7 +89,7 @@ test('Block pattern CLI command will generate a name from title if "name" argume
 	$blockPattern([], $cliArgs);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedBlockPattern = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/BlockPatterns/YourOwnThingBlockPattern.php');
+	$generatedBlockPattern = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/BlockPatterns/YourOwnThingBlockPattern.php');
 
 	$this->assertStringContainsString('eightshift-boilerplate/your-own-thing', $generatedBlockPattern);
 });

--- a/tests/BlockPatterns/BlockPatternExampleTest.php
+++ b/tests/BlockPatterns/BlockPatternExampleTest.php
@@ -35,7 +35,7 @@ test('Register block pattern method will be called', function() {
 
 	$this->example->registerBlockPattern();
 
-	$this->assertSame(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(\getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/Blocks/BlockCliTest.php
+++ b/tests/Blocks/BlockCliTest.php
@@ -37,7 +37,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -46,16 +46,16 @@ afterEach(function () {
 	$blockMock = mock(BlockCli::class)
 		->makePartial()
 		->shouldReceive('getFrontendLibsBlockPath')
-		->andReturn(dirname(__FILE__, 2) . '/data');
+		->andReturn(\dirname(__FILE__, 2) . '/data');
 
 	$mock = $blockMock->getMock();
 
 	$mock([], [$this->block->getDevelopArgs([])]);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/button/button.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/button/button.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedBlock = file_get_contents($outputPath);
+	$generatedBlock = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('Template for the Button Block view.', $generatedBlock);
 	$this->assertStringContainsString('@package EightshiftBoilerplate', $generatedBlock);
@@ -87,7 +87,7 @@ test('Block CLI command will fail if block doesn\'t exist', function () {
 	$blockMock = mock(BlockCli::class)
 		->makePartial()
 		->shouldReceive('getFrontendLibsBlockPath')
-		->andReturn(dirname(__FILE__, 2) . '/data');
+		->andReturn(\dirname(__FILE__, 2) . '/data');
 
 	$mock = $blockMock->getMock();
 

--- a/tests/Blocks/BlockComponentCliTest.php
+++ b/tests/Blocks/BlockComponentCliTest.php
@@ -37,7 +37,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -46,16 +46,16 @@ afterEach(function () {
 	$componentMock = mock(BlockComponentCli::class)
 		->makePartial()
 		->shouldReceive('getFrontendLibsBlockPath')
-		->andReturn(dirname(__FILE__, 2) . '/data');
+		->andReturn(\dirname(__FILE__, 2) . '/data');
 
 	$mock = $componentMock->getMock();
 
 	$mock([], [$this->component->getDevelopArgs([])]);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/button/button.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/button/button.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedComponent = file_get_contents($outputPath);
+	$generatedComponent = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('<div>Hello!</div>', $generatedComponent);
 	$this->assertFileExists($outputPath);
@@ -85,7 +85,7 @@ test('Component CLI command will fail if Component doesn\'t exist', function () 
 	$componentMock = mock(BlockComponentCli::class)
 		->makePartial()
 		->shouldReceive('getFrontendLibsBlockPath')
-		->andReturn(dirname(__FILE__, 2) . '/data');
+		->andReturn(\dirname(__FILE__, 2) . '/data');
 
 	$mock = $componentMock->getMock();
 

--- a/tests/Blocks/BlockVariationCliTest.php
+++ b/tests/Blocks/BlockVariationCliTest.php
@@ -36,7 +36,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -45,16 +45,16 @@ afterEach(function () {
 	$variationMock = mock(BlockVariationCli::class)
 		->makePartial()
 		->shouldReceive('getFrontendLibsBlockPath')
-		->andReturn(dirname(__FILE__, 2) . '/data');
+		->andReturn(\dirname(__FILE__, 2) . '/data');
 
 	$mock = $variationMock->getMock();
 
 	$mock([], [$this->variation->getDevelopArgs([])]);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/button-block/manifest.json';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/button-block/manifest.json';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedVariation = file_get_contents($outputPath);
+	$generatedVariation = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('"parentName": "button"', $generatedVariation);
 	$this->assertFileExists($outputPath);
@@ -85,7 +85,7 @@ test('Variation CLI command will fail if Variation doesn\'t exist', function () 
 	$variationMock = mock(BlockVariationCli::class)
 		->makePartial()
 		->shouldReceive('getFrontendLibsBlockPath')
-		->andReturn(dirname(__FILE__, 2) . '/data');
+		->andReturn(\dirname(__FILE__, 2) . '/data');
 
 	$mock = $variationMock->getMock();
 

--- a/tests/Blocks/BlockWrapperCliTest.php
+++ b/tests/Blocks/BlockWrapperCliTest.php
@@ -32,7 +32,7 @@ $this->wrapper = new BlockWrapperCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -41,16 +41,16 @@ afterEach(function () {
 	$wrapperMock = mock(BlockWrapperCli::class)
 		->makePartial()
 		->shouldReceive('getFrontendLibsBlockPath')
-		->andReturn(dirname(__FILE__, 2) . '/data');
+		->andReturn(\dirname(__FILE__, 2) . '/data');
 
 	$mock = $wrapperMock->getMock();
 
 	$mock([], [$this->wrapper->getDevelopArgs([])]);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/wrapper.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/wrapper.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedWrapper = file_get_contents($outputPath);
+	$generatedWrapper = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('<div>Wrapper!</div>', $generatedWrapper);
 	$this->assertFileExists($outputPath);
@@ -80,13 +80,13 @@ test('Wrapper CLI command will fail if Wrapper doesn\'t exist', function () {
 	$wrapperMock = mock(BlockWrapperCli::class)
 		->makePartial()
 		->shouldReceive('getFrontendLibsBlockPath')
-		->andReturn(dirname(__FILE__, 2) . '/data');
+		->andReturn(\dirname(__FILE__, 2) . '/data');
 
 	$mock = $wrapperMock->getMock();
 
 	$mock([], ['name' => 'testing']);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/testing/testing.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/testing/testing.php';
 
 	$this->assertFileDoesNotExist($outputPath);
 });

--- a/tests/Blocks/BlocksCliTest.php
+++ b/tests/Blocks/BlocksCliTest.php
@@ -29,7 +29,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -38,10 +38,10 @@ test('Blocks CLI command will correctly copy the Blocks class with defaults', fu
 	$blocks = $this->blocks;
 	$blocks([], []);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/src/Blocks/Blocks.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/src/Blocks/Blocks.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedBlocks = file_get_contents($outputPath);
+	$generatedBlocks = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('class Blocks extends AbstractBlocks', $generatedBlocks);
 	$this->assertStringContainsString('@package EightshiftLibs\Blocks', $generatedBlocks);
@@ -57,7 +57,7 @@ test('Blocks CLI command will correctly copy the Blocks class with set arguments
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedBlocks = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Blocks/Blocks.php');
+	$generatedBlocks = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Blocks/Blocks.php');
 
 	$this->assertStringContainsString('namespace CoolTheme\Blocks;', $generatedBlocks);
 });

--- a/tests/Blocks/BlocksExampleTest.php
+++ b/tests/Blocks/BlocksExampleTest.php
@@ -7,7 +7,7 @@ use Brain\Monkey\Functions;
 use EightshiftBoilerplate\Blocks\BlocksExample;
 use EightshiftLibs\Exception\InvalidBlock;
 
-use EightshiftLibs\Helpers\Components;
+use WP_Block_Editor_Context;
 
 use function Tests\mock;
 use function Tests\setupMocks;
@@ -71,7 +71,7 @@ test('addThemeSupport method will call add_theme_support() function with differe
 
 	$this->blocksExample->addThemeSupport();
 
-	$this->assertSame(getenv('ALIGN_WIDE'), 'true', "Method addThemeSupport() didn't add theme support for align-wide");
+	$this->assertSame(\getenv('ALIGN_WIDE'), 'true', "Method addThemeSupport() didn't add theme support for align-wide");
 
 });
 
@@ -146,7 +146,7 @@ test('Asserts that getAllBlocksList will return only projects blocks for older v
 
 test('Asserts that getAllBlocksList will return only projects blocks for WP 5.8.', function () {
 
-	$blockContext = mock(\WP_Block_Editor_Context::class);
+	$blockContext = mock(WP_Block_Editor_Context::class);
 	$blockContext->post = null;
 
 	$this->config
@@ -209,13 +209,13 @@ test('Asserts that render will throw error if wrapper view is missing.', functio
 
 test('Asserts that renderWrapperView will return a valid file.', function () {
 
-	$wrapperManifest = dirname(__FILE__, 2) . '/data/src/Blocks/wrapper/wrapper.php';
+	$wrapperManifest = \dirname(__FILE__, 2) . '/data/src/Blocks/wrapper/wrapper.php';
 
-	ob_start();
+	\ob_start();
 	$this->blocksExample->renderWrapperView($wrapperManifest, []);
-	$content = ob_get_clean();
+	$content = \ob_get_clean();
 
-	$this->assertSame('<div>Wrapper!</div>', trim($content));
+	$this->assertSame('<div>Wrapper!</div>', \trim($content));
 });
 
 test('Asserts that renderWrapperView will throw error if path is not valid.', function () {
@@ -254,7 +254,7 @@ test('changeEditorColorPalette method will call add_theme_support() function wit
 
 	$this->blocksExample->changeEditorColorPalette();
 
-	$this->assertSame(getenv('EDITOR_COLOR_PALETTE'), 'true', "Method addThemeSupport() didn't add theme support for editor-color-palette");
+	$this->assertSame(\getenv('EDITOR_COLOR_PALETTE'), 'true', "Method addThemeSupport() didn't add theme support for editor-color-palette");
 });
 
 test('registerBlocks method will register all blocks.', function () {
@@ -273,7 +273,7 @@ test('registerBlocks method will register all blocks.', function () {
 
 	$this->blocksExample->registerBlocks();
 
-	$this->assertSame(getenv('BLOCK_TYPE'), 'true', 'Calling void method register_block_type caused no side effects');
+	$this->assertSame(\getenv('BLOCK_TYPE'), 'true', 'Calling void method register_block_type caused no side effects');
 });
 
 test('getCustomCategoryOld method will return an array.', function () {

--- a/tests/Build/BuildCliTest.php
+++ b/tests/Build/BuildCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -40,7 +40,7 @@ test('Build CLI will correctly copy the build script with defaults', function ()
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedFile = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/bin/build.sh');
+	$generatedFile = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/bin/build.sh');
 	$this->assertStringNotContainsString('random string', $generatedFile);
 });
 
@@ -51,7 +51,7 @@ test('Build CLI will correctly copy the build script to a given folder', functio
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedFile = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/test/bin/build.sh');
+	$generatedFile = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/test/bin/build.sh');
 	$this->assertStringNotContainsString('random string', $generatedFile);
 });
 

--- a/tests/CiExclude/CiExcludeCliTest.php
+++ b/tests/CiExclude/CiExcludeCliTest.php
@@ -28,7 +28,7 @@ $this->ciexclude = new CiExcludeCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -37,10 +37,10 @@ test('CiExclude CLI command will correctly copy the ci-exclude text file with de
 	$ciexclude = $this->ciexclude;
 	$ciexclude([], $ciexclude->getDevelopArgs([]));
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/ci-exclude.txt';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/ci-exclude.txt';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedExclude = file_get_contents($outputPath);
+	$generatedExclude = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('eightshift-boilerplate', $generatedExclude);
 	$this->assertStringNotContainsString('footer.php', $generatedExclude);
@@ -60,7 +60,7 @@ test('CiExclude CLI command will correctly copy the ci-exclude file in the custo
 		'root' => './test',
 	]);
 
-	$this->assertFileExists(dirname(__FILE__, 3) . '/cliOutput/test/ci-exclude.txt');
+	$this->assertFileExists(\dirname(__FILE__, 3) . '/cliOutput/test/ci-exclude.txt');
 });
 
 test('CiExclude CLI command will correctly copy the ci-exclude file with set arguments', function () {
@@ -72,7 +72,7 @@ test('CiExclude CLI command will correctly copy the ci-exclude file with set arg
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedExclude = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/ci-exclude.txt');
+	$generatedExclude = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/ci-exclude.txt');
 
 	$this->assertStringContainsString('/wp-content/plugin/coolPlugin/node_modules', $generatedExclude);
 });

--- a/tests/Cli/AbstractCliTest.php
+++ b/tests/Cli/AbstractCliTest.php
@@ -11,7 +11,7 @@ use function Tests\deleteCliOutput;
 use function Tests\mock;
 
 class AbstractTest extends AbstractCli {
-	protected $fileContents = 'use EightshiftBoilerplateVendor\Service; use EightshiftBoilerplate\Test;';
+	protected string $fileContents = 'use EightshiftBoilerplateVendor\Service; use EightshiftBoilerplate\Test;';
 
 	public function __construct(string $commandParentName)
 	{

--- a/tests/Cli/AbstractCliTest.php
+++ b/tests/Cli/AbstractCliTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit\Cli;
 
 use Brain\Monkey;
 use EightshiftLibs\Cli\AbstractCli;
+use ReflectionClass;
+use RuntimeException;
 
 use function Tests\deleteCliOutput;
 use function Tests\mock;
@@ -61,7 +63,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 
@@ -103,7 +105,7 @@ test('Prepare command docs fails if shortdesc doesn\'t exist', function() {
 	$abstractMock = new AbstractTest('test');
 
 	$abstractMock->prepareCommandDocs([], []);
-})->throws(\RuntimeException::class, 'CLI Short description is missing.');
+})->throws(RuntimeException::class, 'CLI Short description is missing.');
 
 
 test('Prepare command docs returns correct doc', function() {
@@ -127,7 +129,7 @@ test('Prepare command docs returns correct doc', function() {
 	$this->assertArrayHasKey('shortdesc', $preparedDocs);
 	$this->assertArrayHasKey('synopsis', $preparedDocs);
 
-	$addedSynopsis = array_filter($preparedDocs['synopsis'], function($descArr) {
+	$addedSynopsis = \array_filter($preparedDocs['synopsis'], function($descArr) {
 		return $descArr['name'] === 'random';
 	});
 	// Check if the synopsis was added to the global one.
@@ -157,15 +159,15 @@ test('Block full file list helper works', function() {
 
 	$this->assertIsArray($output);
 
-	$this->assertTrue(array_key_exists('button.php', array_flip($output)), 'button.php is missing.');
-	$this->assertTrue(array_key_exists('button-block.js', array_flip($output)), 'button-block.js is missing.');
-	$this->assertTrue(array_key_exists('button-hooks.js', array_flip($output)), 'button-hooks.js is missing.');
-	$this->assertTrue(array_key_exists('button-transforms.js', array_flip($output)), 'button-transforms.js is missing.');
-	$this->assertTrue(array_key_exists('button.js', array_flip($output)), 'button.js is missing.');
-	$this->assertTrue(array_key_exists('docs/story.js', array_flip($output)), 'docs/story.js is missing.');
-	$this->assertTrue(array_key_exists('components/button-editor.js', array_flip($output)), 'components/button-editor.js is missing.');
-	$this->assertTrue(array_key_exists('components/button-toolbar.js', array_flip($output)), 'components/button-toolbar.js is missing.');
-	$this->assertTrue(array_key_exists('components/button-options.js', array_flip($output)), 'components/button-options.js is missing.');
+	$this->assertTrue(\array_key_exists('button.php', \array_flip($output)), 'button.php is missing.');
+	$this->assertTrue(\array_key_exists('button-block.js', \array_flip($output)), 'button-block.js is missing.');
+	$this->assertTrue(\array_key_exists('button-hooks.js', \array_flip($output)), 'button-hooks.js is missing.');
+	$this->assertTrue(\array_key_exists('button-transforms.js', \array_flip($output)), 'button-transforms.js is missing.');
+	$this->assertTrue(\array_key_exists('button.js', \array_flip($output)), 'button.js is missing.');
+	$this->assertTrue(\array_key_exists('docs/story.js', \array_flip($output)), 'docs/story.js is missing.');
+	$this->assertTrue(\array_key_exists('components/button-editor.js', \array_flip($output)), 'components/button-editor.js is missing.');
+	$this->assertTrue(\array_key_exists('components/button-toolbar.js', \array_flip($output)), 'components/button-toolbar.js is missing.');
+	$this->assertTrue(\array_key_exists('components/button-options.js', \array_flip($output)), 'components/button-options.js is missing.');
 });
 
 
@@ -231,8 +233,8 @@ test('Preparing slug works', function($slugs) {
 	$output = $abstractMock->prepareSlug($slugs);
 
 	$this->assertIsString($output);
-	$this->assertFalse(strpos($output, '_'), 'Prepared string contains _');
-	$this->assertFalse(strpos($output, ' '), 'Prepared string contains empty space');
+	$this->assertFalse(\strpos($output, '_'), 'Prepared string contains _');
+	$this->assertFalse(\strpos($output, ' '), 'Prepared string contains empty space');
 })->with('inputSlugs');
 
 
@@ -240,7 +242,7 @@ test('Register command fails if class doesn\'t exist', function() {
 	$abstractMock = new AbstractTest('nonexistent');
 
 	$abstractMock->registerCommand();
-})->throws(\RuntimeException::class);
+})->throws(RuntimeException::class);
 
 
 test('Getting vendor prefix works correctly if set', function() {
@@ -258,7 +260,7 @@ test('Replacing use in frontend libs views works', function() {
 
 	$abstractMock->renameUseFrontendLibs([]);
 
-	$reflection = new \ReflectionClass($abstractMock);
+	$reflection = new ReflectionClass($abstractMock);
 	$property = $reflection->getProperty('fileContents');
     $property->setAccessible(true);
     $contents = $property->getValue($abstractMock);

--- a/tests/Cli/CliHelpersTest.php
+++ b/tests/Cli/CliHelpersTest.php
@@ -43,7 +43,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 

--- a/tests/Cli/CliInitProjectTest.php
+++ b/tests/Cli/CliInitProjectTest.php
@@ -42,7 +42,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 
@@ -77,8 +77,8 @@ test('InitProject CLI command will correctly copy the project classes', function
 	$configProject = $this->cliInitProject;
 	$configProject([], []);
 
-	$this->assertSame('true', getenv('INIT_CALLED'));
-	$this->assertSame('All commands are finished.', getenv('SUCCESS'));
+	$this->assertSame('true', \getenv('INIT_CALLED'));
+	$this->assertSame('All commands are finished.', \getenv('SUCCESS'));
 });
 
 
@@ -89,5 +89,5 @@ test('InitProject CLI command runs in case WP is not installed', function () {
 	$configProject = $this->cliInitProject;
 	$configProject([], []);
 
-	$this->assertSame('true', getenv('INIT_CALLED'));
+	$this->assertSame('true', \getenv('INIT_CALLED'));
 });

--- a/tests/Cli/CliInitThemeTest.php
+++ b/tests/Cli/CliInitThemeTest.php
@@ -41,7 +41,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 
@@ -74,7 +74,7 @@ test('InitTheme CLI command will correctly copy the project classes', function (
 	$configProject = $this->cliInitTheme;
 	$configProject([], []);
 
-	$this->assertSame('true', getenv('THEME_INIT_CALLED'));
+	$this->assertSame('true', \getenv('THEME_INIT_CALLED'));
 });
 
 
@@ -85,5 +85,5 @@ test('InitTheme CLI command runs in case WP is not installed', function () {
 	$configProject = $this->cliInitTheme;
 	$configProject([], []);
 
-	$this->assertSame('true', getenv('THEME_INIT_CALLED'));
+	$this->assertSame('true', \getenv('THEME_INIT_CALLED'));
 });

--- a/tests/Cli/CliResetTest.php
+++ b/tests/Cli/CliResetTest.php
@@ -37,8 +37,8 @@ afterEach(function () {
 
 
 test('CliReset works', function () {
-	if (!is_dir($this->cliReset->getOutputDir(''))) {
-		mkdir($this->cliReset->getOutputDir(''));
+	if (!\is_dir($this->cliReset->getOutputDir(''))) {
+		\mkdir($this->cliReset->getOutputDir(''));
 	}
 
 	$cliReset = $this->cliReset;

--- a/tests/Cli/CliRunAllTest.php
+++ b/tests/Cli/CliRunAllTest.php
@@ -50,7 +50,7 @@ test('CliRunAll works', function () {
 	$cliRunAll = $this->cliRunAll;
 	$cliRunAll([], []);
 
-	$this->assertSame('All commands are finished.', getenv('SUCCESS'));
+	$this->assertSame('All commands are finished.', \getenv('SUCCESS'));
 });
 
 

--- a/tests/Cli/CliShowAllTest.php
+++ b/tests/Cli/CliShowAllTest.php
@@ -56,8 +56,8 @@ test('CliShowAll works', function () {
 	$cliShowAll = $this->cliShowAll;
 	$cliShowAll([], []);
 
-	$this->assertSame('All commands are outputted.', getenv('SUCCESS'));
-	$this->assertSame('%mCommands for project setup:%n', getenv('COLORIZE')); // Last colorize command.
+	$this->assertSame('All commands are outputted.', \getenv('SUCCESS'));
+	$this->assertSame('%mCommands for project setup:%n', \getenv('COLORIZE')); // Last colorize command.
 });
 
 

--- a/tests/Cli/CliTest.php
+++ b/tests/Cli/CliTest.php
@@ -68,31 +68,35 @@ afterEach(function () {
 test('Cli getDevelopClasses return correct class list', function () {
 	$developClasses = $this->cli->getDevelopClasses();
 
-	$numberOfDevClasses = 34;
+	expect($developClasses)
+		->toBeArray()
+		->not->toHaveKey(BlockComponentCli::class)
+		->not->toHaveKey(BlockWrapperCli::class)
+		->not->toHaveKey(BlockVariationCli::class)
+		->not->toHaveKey(BlockCli::class)
+		->not->toHaveKey(BlocksStorybookCli::class)
+		->not->toHaveKey(UpdateCli::class)
+		->not->toHaveKey(ExportCli::class)
+		->not->toHaveKey(ImportCli::class);
 
-	$this->assertIsArray($developClasses);
-	$this->assertTrue(\count($developClasses) === $numberOfDevClasses, 'Total number of classes is correct');
-	$this->assertArrayNotHasKey(BlockComponentCli::class, $developClasses, 'Public class found');
-	$this->assertArrayNotHasKey(BlockWrapperCli::class, $developClasses, 'Public class found');
-	$this->assertArrayNotHasKey(BlockVariationCli::class, $developClasses, 'Public class found');
-	$this->assertArrayNotHasKey(BlockCli::class, $developClasses, 'Public class found');
-	$this->assertArrayNotHasKey(BlocksStorybookCli::class, $developClasses, 'Public class found');
-	$this->assertArrayNotHasKey(UpdateCli::class, $developClasses, 'Public class found');
-	$this->assertArrayNotHasKey(ExportCli::class, $developClasses, 'Public class found');
-	$this->assertArrayNotHasKey(ImportCli::class, $developClasses, 'Public class found');
+	expect(\count($developClasses))
+		->toBeInt()
+		->toBe(35); // Dev classes count.
 });
 
 
 test('Cli getPublicClasses return correct class list', function () {
 	$publicClasses = $this->cli->getPublicClasses();
 
-	$numberOfPublicClasses = 40;
+	expect($publicClasses)
+		->toBeArray()
+		->not->toHaveKey(CliReset::class)
+		->not->toHaveKey(CliRunAll::class)
+		->not->toHaveKey(CliShowAll::class);
 
-	$this->assertIsArray($publicClasses);
-	$this->assertTrue(\count($publicClasses) === $numberOfPublicClasses, 'Total number of classes is correct');
-	$this->assertArrayNotHasKey(CliReset::class, $publicClasses, 'Development class found');
-	$this->assertArrayNotHasKey(CliRunAll::class, $publicClasses, 'Development class found');
-	$this->assertArrayNotHasKey(CliShowAll::class, $publicClasses, 'Development class found');
+	expect(\count($publicClasses))
+		->toBeInt()
+		->toBe(41); // Public classes count.
 });
 
 

--- a/tests/Cli/CliTest.php
+++ b/tests/Cli/CliTest.php
@@ -54,7 +54,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 
@@ -71,7 +71,7 @@ test('Cli getDevelopClasses return correct class list', function () {
 	$numberOfDevClasses = 34;
 
 	$this->assertIsArray($developClasses);
-	$this->assertTrue(count($developClasses) === $numberOfDevClasses, 'Total number of classes is correct');
+	$this->assertTrue(\count($developClasses) === $numberOfDevClasses, 'Total number of classes is correct');
 	$this->assertArrayNotHasKey(BlockComponentCli::class, $developClasses, 'Public class found');
 	$this->assertArrayNotHasKey(BlockWrapperCli::class, $developClasses, 'Public class found');
 	$this->assertArrayNotHasKey(BlockVariationCli::class, $developClasses, 'Public class found');
@@ -89,7 +89,7 @@ test('Cli getPublicClasses return correct class list', function () {
 	$numberOfPublicClasses = 40;
 
 	$this->assertIsArray($publicClasses);
-	$this->assertTrue(count($publicClasses) === $numberOfPublicClasses, 'Total number of classes is correct');
+	$this->assertTrue(\count($publicClasses) === $numberOfPublicClasses, 'Total number of classes is correct');
 	$this->assertArrayNotHasKey(CliReset::class, $publicClasses, 'Development class found');
 	$this->assertArrayNotHasKey(CliRunAll::class, $publicClasses, 'Development class found');
 	$this->assertArrayNotHasKey(CliShowAll::class, $publicClasses, 'Development class found');
@@ -99,14 +99,14 @@ test('Cli getPublicClasses return correct class list', function () {
 test('Running develop commands throws error if command name is not specified', function() {
 	$this->cli->loadDevelop();
 
-	$this->assertSame('First argument must be a valid command name.', getenv('ERROR_HAPPENED'));
+	$this->assertSame('First argument must be a valid command name.', \getenv('ERROR_HAPPENED'));
 });
 
 test('Running develop commands runs a particular command successfully', function() {
 	$this->cli->loadDevelop(['create_menu']);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedMenu = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Menu/Menu.php');
+	$generatedMenu = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Menu/Menu.php');
 	$this->assertStringContainsString('class Menu extends AbstractMenu', $generatedMenu);
 	$this->assertStringContainsString('header_main_nav', $generatedMenu);
 	$this->assertStringNotContainsString('footer_main_nav', $generatedMenu);

--- a/tests/CliCommands/CustomCommandExampleTest.php
+++ b/tests/CliCommands/CustomCommandExampleTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit\CliCommands;
 use EightshiftBoilerplate\CliCommands\CustomCommandExample;
 
 use EightshiftLibs\CliCommands\AbstractCustomCommand;
+use RuntimeException;
+
 use function Tests\deleteCliOutput;
 use function Tests\mock;
 
@@ -41,7 +43,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -58,7 +60,7 @@ test('Prepare command docs fails if shortdesc doesn\'t exist', function() {
 	$customCommand = $this->customCommand;
 
 	$customCommand->prepareCommandDocs([], []);
-})->throws(\RuntimeException::class, 'CLI Short description is missing.');
+})->throws(RuntimeException::class, 'CLI Short description is missing.');
 
 
 test('Prepare command docs returns correct doc', function() {
@@ -82,7 +84,7 @@ test('Prepare command docs returns correct doc', function() {
 	$this->assertArrayHasKey('shortdesc', $preparedDocs);
 	$this->assertArrayHasKey('synopsis', $preparedDocs);
 
-	$addedSynopsis = array_filter($preparedDocs['synopsis'], function($descArr) {
+	$addedSynopsis = \array_filter($preparedDocs['synopsis'], function($descArr) {
 		return $descArr['name'] === 'random';
 	});
 	// Check if the synopsis was added to the global one.
@@ -104,7 +106,7 @@ test('Register command fails if class doesn\'t exist', function() {
 	$abstractMock = new AbstractTest();
 
 	$abstractMock->registerCommand();
-})->throws(\RuntimeException::class);
+})->throws(RuntimeException::class);
 
 
 test('Custom command class is callable', function() {

--- a/tests/CliCommands/CustomCommandTest.php
+++ b/tests/CliCommands/CustomCommandTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Custom command CLI command will correctly copy the Custom command class wi
 	$customCommand([], $customCommand->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$customCommand = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/CliCommands/TestCustomCommand.php');
+	$customCommand = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/CliCommands/TestCustomCommand.php');
 
 	$this->assertStringContainsString('class TestCustomCommand extends AbstractCustomCommand', $customCommand);
 	$this->assertStringContainsString('function getCommandName', $customCommand);

--- a/tests/Config/ConfigCliTest.php
+++ b/tests/Config/ConfigCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Custom acf meta CLI command will correctly copy the Config class with defa
 	$config([], $config->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedConfig = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Config/Config.php');
+	$generatedConfig = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Config/Config.php');
 
 	$this->assertStringContainsString('class Config extends AbstractConfigData', $generatedConfig);
 	$this->assertStringContainsString('getProjectName', $generatedConfig);

--- a/tests/Config/ConfigExampleTest.php
+++ b/tests/Config/ConfigExampleTest.php
@@ -20,23 +20,23 @@ afterEach(function() {
 
 test('Is project name defined and a string', function () {
 	$this->assertNotEmpty($this->example::getProjectName());
-	$this->assertIsString(gettype($this->example::getProjectName()));
+	$this->assertIsString(\gettype($this->example::getProjectName()));
 });
 
 test('Is project version defined and a string', function () {
 	$this->assertNotEmpty($this->example::getProjectVersion());
-	$this->assertIsString(gettype($this->example::getProjectVersion()));
+	$this->assertIsString(\gettype($this->example::getProjectVersion()));
 });
 
 test('Is project REST namespace defined, a string and same as project name', function () {
 	$this->assertNotEmpty($this->example::getProjectRoutesNamespace());
-	$this->assertIsString(gettype($this->example::getProjectRoutesNamespace()));
+	$this->assertIsString(\gettype($this->example::getProjectRoutesNamespace()));
 	$this->assertSame($this->example::getProjectName(), $this->example::getProjectRoutesNamespace());
 });
 
 test('Is project REST route version defined and a string', function () {
 	$this->assertNotEmpty($this->example::getProjectRoutesVersion());
-	$this->assertIsString(gettype($this->example::getProjectRoutesVersion()));
+	$this->assertIsString(\gettype($this->example::getProjectRoutesVersion()));
 	$this->assertStringContainsString('v', $this->example::getProjectRoutesVersion());
 });
 

--- a/tests/ConfigProject/ConfigProjectCliTest.php
+++ b/tests/ConfigProject/ConfigProjectCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -37,12 +37,12 @@ test('ConfigProject CLI command will correctly copy the ConfigProject class with
 	$configProject = $this->configProject;
 	$configProject([], $configProject->getDevelopArgs([]));
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/wp-config-project.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/wp-config-project.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedConfigProject = file_get_contents($outputPath);
+	$generatedConfigProject = \file_get_contents($outputPath);
 
-	$this->assertStringContainsString('!defined(\'WP_ENVIRONMENT_TYPE\')', $generatedConfigProject);
+	$this->assertStringContainsString('!\defined(\'WP_ENVIRONMENT_TYPE\')', $generatedConfigProject);
 	$this->assertStringContainsString('@package EightshiftLibs', $generatedConfigProject);
 	$this->assertStringNotContainsString('footer.php', $generatedConfigProject);
 	$this->assertFileExists($outputPath);
@@ -62,9 +62,9 @@ test('ConfigProject CLI command will correctly copy the ConfigProject class with
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedConfigProject = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/test/wp-config-project.php');
+	$generatedConfigProject = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/test/wp-config-project.php');
 
-	$this->assertStringContainsString('!defined(\'WP_ENVIRONMENT_TYPE\')', $generatedConfigProject);
+	$this->assertStringContainsString('!\defined(\'WP_ENVIRONMENT_TYPE\')', $generatedConfigProject);
 });
 
 test('ConfigProject CLI documentation is correct', function () {

--- a/tests/CustomMeta/CustomMetaCliTest.php
+++ b/tests/CustomMeta/CustomMetaCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Custom acf meta CLI command will correctly copy the ACF meta class with de
 	$meta([], $meta->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedMeta = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/CustomMeta/TitleAcfMeta.php');
+	$generatedMeta = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/CustomMeta/TitleAcfMeta.php');
 
 	$this->assertStringContainsString('class TitleAcfMeta extends AbstractAcfMeta', $generatedMeta);
 	$this->assertStringContainsString('acf_add_local_field_group', $generatedMeta);

--- a/tests/CustomPostType/CustomPostTypeCliTest.php
+++ b/tests/CustomPostType/CustomPostTypeCliTest.php
@@ -32,7 +32,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -43,7 +43,7 @@ test('Custom post type CLI command will correctly copy the Custom post type clas
 	$cpt([], $cpt->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/ProductPostType.php');
+	$generatedCPT = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/ProductPostType.php');
 
 	$this->assertStringContainsString('class ProductPostType extends AbstractPostType', $generatedCPT);
 	$this->assertStringContainsString('admin-settings', $generatedCPT);
@@ -64,7 +64,7 @@ test('Custom post type CLI command will correctly copy the Custom post type clas
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php');
+	$generatedCPT = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php');
 
 	$this->assertStringContainsString('class BookPostType extends AbstractPostType', $generatedCPT);
 	$this->assertStringContainsString('Book', $generatedCPT);
@@ -107,7 +107,7 @@ test('Registered post type will have properly created labels', function() {
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php');
+	$generatedCPT = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php');
 
 	$this->assertStringContainsString('book', $generatedCPT);
 	$this->assertStringContainsString('books', $generatedCPT);
@@ -132,7 +132,7 @@ test('Registered post type will have properly created plural label if the plural
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php');
+	$generatedCPT = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php');
 
 	$this->assertStringContainsString('book', $generatedCPT);
 	$this->assertStringContainsString('books', $generatedCPT);
@@ -154,11 +154,11 @@ test('Missing required noun will trigger the invalid nouns exception', function(
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedCPT = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php');
+	$generatedCPT = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php');
 
 	preg_match_all('/\$nouns\s=\s([^]]+)\]/m', $generatedCPT, $matches);
 
-	$newClass = str_replace($matches[0][0]. ';', '', $generatedCPT);
+	$newClass = \str_replace($matches[0][0]. ';', '', $generatedCPT);
 
 	/**
 	 * This part is a bit of a dirty hack.
@@ -173,7 +173,7 @@ test('Missing required noun will trigger the invalid nouns exception', function(
 	 *
 	 * So we need to make sure that the error will indeed be thrown.
 	 */
-	require_once dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php';
+	require_once \dirname(__FILE__, 3) . '/cliOutput/src/CustomPostType/BookPostType.php';
 
 	$cptInstance = new \EightshiftLibs\CustomPostType\BookPostType();
 

--- a/tests/CustomPostType/CustomPostTypeExampleTest.php
+++ b/tests/CustomPostType/CustomPostTypeExampleTest.php
@@ -41,7 +41,7 @@ test('Register post type method will be called', function() {
 
 	$this->example->postTypeRegisterCallback();
 
-	$this->assertSame(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(\getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/CustomTaxonomy/TaxonomyCliTest.php
+++ b/tests/CustomTaxonomy/TaxonomyCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Custom taxonomy CLI command will correctly copy the Taxonomy class', funct
 	$taxonomyCli([], $taxonomyCli->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedTaxonomy = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/CustomTaxonomy/LocationTaxonomy.php');
+	$generatedTaxonomy = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/CustomTaxonomy/LocationTaxonomy.php');
 
 	$this->assertStringContainsString('The LocationTaxonomy specific functionality.', $generatedTaxonomy);
 	$this->assertStringContainsString('class LocationTaxonomy extends AbstractTaxonomy', $generatedTaxonomy);

--- a/tests/CustomTaxonomy/TaxonomyExampleTest.php
+++ b/tests/CustomTaxonomy/TaxonomyExampleTest.php
@@ -32,7 +32,7 @@ test('if taxonomy is registered', function () {
 
 	$this->example->taxonomyRegisterCallback();
 
-	$this->assertSame(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(\getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/Datasets/Autowiring/Invalid/ServiceWithInvalidNamespace.php
+++ b/tests/Datasets/Autowiring/Invalid/ServiceWithInvalidNamespace.php
@@ -6,7 +6,7 @@ namespace Tests\Datasets\Autowiring\Invalid\DoesNotExist;
 
 use EightshiftLibs\Services\ServiceInterface;
 
-if ( ! class_exists( ServiceWithInvalidNamespace::class ) ) {
+if ( ! \class_exists( ServiceWithInvalidNamespace::class ) ) {
 	class ServiceWithInvalidNamespace implements ServiceInterface
 	{
 		/**

--- a/tests/Db/DbExportTest.php
+++ b/tests/Db/DbExportTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\CustomPostType;
 
 use EightshiftLibs\Db\ExportCli;
 use Brain\Monkey\Functions;
+use Exception;
 
 use function Tests\setupMocks;
 use function Tests\mock;
@@ -27,7 +28,7 @@ beforeEach(function() {
 		->shouldReceive('error')
 		->andReturnUsing(
             function ($errorMessage) {
-                throw new \Exception($errorMessage);
+                throw new Exception($errorMessage);
             }
 	);
 
@@ -43,5 +44,5 @@ test('Exporting DB functionality fails if --skip_db parameter is not specified',
 
 	$dbExport([], []);
 
-	$this->assertSame('true', getenv('INIT_CALLED'));
+	$this->assertSame('true', \getenv('INIT_CALLED'));
 });

--- a/tests/Db/DbImportTest.php
+++ b/tests/Db/DbImportTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\CustomPostType;
 
 use EightshiftLibs\Db\ImportCli;
+use Exception;
 
 use function Tests\setupMocks;
 use function Tests\mock;
@@ -18,7 +19,7 @@ beforeEach(function() {
 		->shouldReceive('error')
 		->andReturnUsing(
             function ($errorMessage) {
-                throw new \Exception($errorMessage);
+                throw new Exception($errorMessage);
             }
 	);
 
@@ -32,7 +33,7 @@ test('Importing DB functionality fails if --from parameter is not specified', fu
 	$dbImport = $this->import;
 
 	$dbImport([], []);
-})->throws(\Exception::class, '--from parameter is mandatory. Please provide one url key from setup.json file.');
+})->throws(Exception::class, '--from parameter is mandatory. Please provide one url key from setup.json file.');
 
 
 test('Importing DB functionality fails if --to parameter is not specified', function () {
@@ -41,7 +42,7 @@ test('Importing DB functionality fails if --to parameter is not specified', func
 	$dbImport([], [
 		'from' => 'staging'
 	]);
-})->throws(\Exception::class, '--to parameter is mandatory. Please provide one url key from setup.json file.');
+})->throws(Exception::class, '--to parameter is mandatory. Please provide one url key from setup.json file.');
 
 
 test('Importing DB functionality fails if setup.json is missing', function () {
@@ -51,4 +52,4 @@ test('Importing DB functionality fails if setup.json is missing', function () {
 		'from' => 'staging',
 		'to' => 'production'
 	]);
-})->throws(\Exception::class, 'setup.json is missing at this path: setup.json');
+})->throws(Exception::class, 'setup.json is missing at this path: setup.json');

--- a/tests/Enqueue/Admin/EnqueueAdminCliTest.php
+++ b/tests/Enqueue/Admin/EnqueueAdminCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 4) . '/cliOutput';
+	$output = \dirname(__FILE__, 4) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -38,7 +38,7 @@ test('Custom Enqueue Admin CLI command will correctly copy the Enqueue Admin cla
 	$admin([], $admin->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedAdmin = file_get_contents(dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Admin/EnqueueAdmin.php');
+	$generatedAdmin = \file_get_contents(\dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Admin/EnqueueAdmin.php');
 
 	$this->assertStringContainsString('class EnqueueAdmin extends AbstractEnqueueAdmin', $generatedAdmin);
 	$this->assertStringContainsString('admin_enqueue_scripts', $generatedAdmin);

--- a/tests/Enqueue/Admin/EnqueueAdminExampleTest.php
+++ b/tests/Enqueue/Admin/EnqueueAdminExampleTest.php
@@ -113,16 +113,16 @@ test('enqueueStyles method enqueue styles in WP Admin', function () {
 
 	$this->adminEnqueue->enqueueStyles($this->hookSuffix);
 
-	$this->assertSame(getenv('REGISTER_STYLE'), 'MyProject-styles', 'Method enqueueStyles() failed to register style');
-	$this->assertSame(getenv('ENQUEUE_STYLE'), 'MyProject-styles', 'Method enqueueStyles() failed to enqueue style');
+	$this->assertSame(\getenv('REGISTER_STYLE'), 'MyProject-styles', 'Method enqueueStyles() failed to register style');
+	$this->assertSame(\getenv('ENQUEUE_STYLE'), 'MyProject-styles', 'Method enqueueStyles() failed to enqueue style');
 });
 
 test('enqueueScripts method enqueue scripts in WP Admin', function () {
 	$this->adminEnqueue->enqueueScripts($this->hookSuffix);
 
-	$this->assertSame(getenv('REGISTER_SCRIPT'), 'MyProject-scripts', 'Method enqueueStyles() failed to register style');
-	$this->assertSame(getenv('ENQUEUE_SCRIPT'), 'MyProject-scripts', 'Method enqueueScripts() failed to enqueue style');
-	$this->assertSame(getenv('SIDEAFFECT'), 'localize', 'Method wp_localize_script() failed');
+	$this->assertSame(\getenv('REGISTER_SCRIPT'), 'MyProject-scripts', 'Method enqueueStyles() failed to register style');
+	$this->assertSame(\getenv('ENQUEUE_SCRIPT'), 'MyProject-scripts', 'Method enqueueScripts() failed to enqueue style');
+	$this->assertSame(\getenv('SIDEAFFECT'), 'localize', 'Method wp_localize_script() failed');
 });
 
 test('Localization will return empty array if not initialized', function() {

--- a/tests/Enqueue/Blocks/EnqueueBlockCliTest.php
+++ b/tests/Enqueue/Blocks/EnqueueBlockCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 4) . '/cliOutput';
+	$output = \dirname(__FILE__, 4) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -40,7 +40,7 @@ test('Enqueue Block CLI command will make appropriate class.', function () {
 	$ebc = $this->ebc;
 	$ebc([], []);
 
-	$generatedEBC = file_get_contents(dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Blocks/EnqueueBlocks.php');
+	$generatedEBC = \file_get_contents(\dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Blocks/EnqueueBlocks.php');
 	$this->assertStringContainsString('class EnqueueBlocks extends AbstractEnqueueBlocks', $generatedEBC);
 
 	$this->assertStringContainsString('enqueue_block_editor_assets', $generatedEBC);
@@ -65,7 +65,7 @@ test('Enqueue Block CLI command will set correct namespace.', function () {
 		'namespace' => 'NewTheme',
 	]);
 
-	$generatedEBC = file_get_contents(dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Blocks/EnqueueBlocks.php');
+	$generatedEBC = \file_get_contents(\dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Blocks/EnqueueBlocks.php');
 
 	$this->assertStringContainsString('namespace NewTheme\Enqueue\Blocks;', $generatedEBC);
 });
@@ -77,7 +77,7 @@ test('Enqueue Block CLI command will set correct functions.', function () {
 	$ebc = $this->ebc;
 	$ebc([], []);
 
-	$generatedEBC = file_get_contents(dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Blocks/EnqueueBlocks.php');
+	$generatedEBC = \file_get_contents(\dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Blocks/EnqueueBlocks.php');
 
 	$this->assertStringContainsString('getAssetsPrefix', $generatedEBC);
 	$this->assertStringContainsString('getAssetsVersion', $generatedEBC);

--- a/tests/Enqueue/Blocks/EnqueueBlockExampleTest.php
+++ b/tests/Enqueue/Blocks/EnqueueBlockExampleTest.php
@@ -132,29 +132,29 @@ test('Enqueue Blocks will get assets version.', function () {
 test('enqueueBlockEditorScript method will enqueue scripts for block editor', function () {
 	$this->blockEnqueue->enqueueBlockEditorScript();
 
-	$this->assertSame(getenv('REGISTER_SCRIPT'), "{$this->projectName}-block-editor-scripts", 'Method enqueueStyles() failed to register style');
-	$this->assertSame(getenv('ENQUEUE_SCRIPT'), "{$this->projectName}-block-editor-scripts", 'Method enqueueScripts() failed to enqueue style');
-	$this->assertSame(getenv('SIDEAFFECT'), 'localize', "Method wp_localize_script() failed");
+	$this->assertSame(\getenv('REGISTER_SCRIPT'), "{$this->projectName}-block-editor-scripts", 'Method enqueueStyles() failed to register style');
+	$this->assertSame(\getenv('ENQUEUE_SCRIPT'), "{$this->projectName}-block-editor-scripts", 'Method enqueueScripts() failed to enqueue style');
+	$this->assertSame(\getenv('SIDEAFFECT'), 'localize', "Method wp_localize_script() failed");
 });
 
 test('enqueueBlockEditorStyle method will enqueue styles for block editor', function () {
 	$this->blockEnqueue->enqueueBlockEditorStyle();
 
-	$this->assertSame(getenv('REGISTER_STYLE'), "{$this->projectName}-block-editor-style", 'Method enqueueStyles() failed to register style');
-	$this->assertSame(getenv('ENQUEUE_STYLE'), "{$this->projectName}-block-editor-style", 'Method enqueueStyles() failed to enqueue style');
+	$this->assertSame(\getenv('REGISTER_STYLE'), "{$this->projectName}-block-editor-style", 'Method enqueueStyles() failed to register style');
+	$this->assertSame(\getenv('ENQUEUE_STYLE'), "{$this->projectName}-block-editor-style", 'Method enqueueStyles() failed to enqueue style');
 });
 
 test('enqueueBlockStyle method will enqueue styles for a block', function () {
 	$this->blockEnqueue->enqueueBlockStyle();
 
-	$this->assertSame(getenv('REGISTER_STYLE'), "{$this->projectName}-block-style", 'Method enqueueStyles() failed to register style');
-	$this->assertSame(getenv('ENQUEUE_STYLE'), "{$this->projectName}-block-style", 'Method enqueueStyles() failed to enqueue style');
+	$this->assertSame(\getenv('REGISTER_STYLE'), "{$this->projectName}-block-style", 'Method enqueueStyles() failed to register style');
+	$this->assertSame(\getenv('ENQUEUE_STYLE'), "{$this->projectName}-block-style", 'Method enqueueStyles() failed to enqueue style');
 });
 
 test('enqueueBlockScript method will enqueue scripts for a block', function () {
 	$this->blockEnqueue->enqueueBlockScript();
 
-	$this->assertSame(getenv('REGISTER_SCRIPT'), "{$this->projectName}-block-scripts", 'Method enqueueStyles() failed to register style');
-	$this->assertSame(getenv('ENQUEUE_SCRIPT'), "{$this->projectName}-block-scripts", 'Method enqueueScripts() failed to enqueue style');
-	$this->assertSame(getenv('SIDEAFFECT'), 'localize', 'Method wp_localize_script() failed');
+	$this->assertSame(\getenv('REGISTER_SCRIPT'), "{$this->projectName}-block-scripts", 'Method enqueueStyles() failed to register style');
+	$this->assertSame(\getenv('ENQUEUE_SCRIPT'), "{$this->projectName}-block-scripts", 'Method enqueueScripts() failed to enqueue style');
+	$this->assertSame(\getenv('SIDEAFFECT'), 'localize', 'Method wp_localize_script() failed');
 });

--- a/tests/Enqueue/Theme/EnqueueThemeCliTest.php
+++ b/tests/Enqueue/Theme/EnqueueThemeCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 4) . '/cliOutput';
+	$output = \dirname(__FILE__, 4) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -38,7 +38,7 @@ test('Custom enqueue theme CLI command will correctly copy the Enqueue Theme cla
 	$theme([], $theme->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedTheme = file_get_contents(dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Theme/EnqueueTheme.php');
+	$generatedTheme = \file_get_contents(\dirname(__FILE__, 4) . '/cliOutput/src/Enqueue/Theme/EnqueueTheme.php');
 
 	$this->assertStringContainsString('class EnqueueTheme extends AbstractEnqueueTheme', $generatedTheme);
 	$this->assertStringContainsString('wp_enqueue_scripts', $generatedTheme);

--- a/tests/Enqueue/Theme/EnqueueThemeExampleTest.php
+++ b/tests/Enqueue/Theme/EnqueueThemeExampleTest.php
@@ -98,14 +98,14 @@ test('getAssetsVersion method will return string', function () {
 
 test('enqueueStyles method will enqueue styles in a theme', function () {
 	$this->themeEnqueue->enqueueStyles();
-	$this->assertSame(getenv('REGISTER_STYLE'), 'MyProject-theme-styles', 'Method enqueueStyles() failed to register style');
-	$this->assertSame(getenv('ENQUEUE_STYLE'), 'MyProject-theme-styles', 'Method enqueueStyles() failed to enqueue style');
+	$this->assertSame(\getenv('REGISTER_STYLE'), 'MyProject-theme-styles', 'Method enqueueStyles() failed to register style');
+	$this->assertSame(\getenv('ENQUEUE_STYLE'), 'MyProject-theme-styles', 'Method enqueueStyles() failed to enqueue style');
 });
 
 test('enqueueScripts method will enqueue scripts in a theme', function () {
 
 	$this->themeEnqueue->enqueueScripts();
-	$this->assertSame(getenv('REGISTER_SCRIPT'), 'MyProject-scripts', 'Method enqueueStyles() failed to register style');
-	$this->assertSame(getenv('ENQUEUE_SCRIPT'), 'MyProject-scripts', 'Method enqueueScripts() failed to enqueue style');
-	$this->assertSame(getenv('SIDEAFFECT'), 'localize', 'Method wp_localize_script() failed');
+	$this->assertSame(\getenv('REGISTER_SCRIPT'), 'MyProject-scripts', 'Method enqueueStyles() failed to register style');
+	$this->assertSame(\getenv('ENQUEUE_SCRIPT'), 'MyProject-scripts', 'Method enqueueScripts() failed to enqueue style');
+	$this->assertSame(\getenv('SIDEAFFECT'), 'localize', 'Method wp_localize_script() failed');
 });

--- a/tests/Exception/ComponentExceptionTest.php
+++ b/tests/Exception/ComponentExceptionTest.php
@@ -21,7 +21,7 @@ afterAll(function() {
 test('Checks if the throwNotStringOrArray method functions correctly.',
 	function ($argument) {
 		$exceptionObject = ComponentException::throwNotStringOrArray($argument);
-		$type = gettype($argument);
+		$type = \gettype($argument);
 
 		$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of ComponentException class");
 		$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");

--- a/tests/Exception/FailedToLoadViewTest.php
+++ b/tests/Exception/FailedToLoadViewTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Exception;
 use EightshiftLibs\Exception\FailedToLoadView;
 
 use Brain\Monkey;
+use Exception;
 
 use function Tests\setupMocks;
 
@@ -20,7 +21,7 @@ afterAll(function() {
 test('Checks if the viewException method will return correct response.', function () {
 
 	$uri = 'https://random.uri';
-	$exception = new \Exception('Error message');
+	$exception = new Exception('Error message');
 
 	$exceptionObject = FailedToLoadView::viewException($uri, $exception);
 

--- a/tests/GitIgnore/GitIgnoreCliTest.php
+++ b/tests/GitIgnore/GitIgnoreCliTest.php
@@ -28,7 +28,7 @@ $this->gitignore = new GitIgnoreCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -37,10 +37,10 @@ test('GitIgnore CLI command will correctly copy the .gitignore file with default
 	$gitignore = $this->gitignore;
 	$gitignore([], $gitignore->getDevelopArgs([]));
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/.gitignore';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/.gitignore';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedIgnore = file_get_contents($outputPath);
+	$generatedIgnore = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('wp-admin', $generatedIgnore);
 	$this->assertStringNotContainsString('footer.php', $generatedIgnore);
@@ -60,7 +60,7 @@ test('GitIgnore CLI command will correctly copy the .gitignore file in the custo
 		'root' => './test',
 	]);
 
-	$this->assertFileExists(dirname(__FILE__, 3) . '/cliOutput/test/.gitignore');
+	$this->assertFileExists(\dirname(__FILE__, 3) . '/cliOutput/test/.gitignore');
 });
 
 

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -5,6 +5,8 @@ namespace Tests;
 use Brain\Monkey\Functions;
 use Mockery;
 use Mockery\MockInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * Helper function that will setup some repeating mocks in every tests.
@@ -18,10 +20,10 @@ function setupMocks() {
 	Functions\stubEscapeFunctions();
 
 	// Mock the template dir location.
-	Functions\when('get_template_directory')->justReturn(dirname(__FILE__) . '/data');
+	Functions\when('get_template_directory')->justReturn(\dirname(__FILE__) . '/data');
 
 	// Mock the template dir location.
-	Functions\when('get_stylesheet_directory')->justReturn(dirname(__FILE__) . '/');
+	Functions\when('get_stylesheet_directory')->justReturn(\dirname(__FILE__) . '/');
 
 	// Mock escaping function.
 	Functions\when('wp_kses_post')->returnArg();
@@ -66,12 +68,12 @@ function setupMocks() {
  */
 function deleteCliOutput(string $dir) : void
 {
-	if (!is_dir($dir)) {
+	if (!\is_dir($dir)) {
 		return;
 	}
 
-	$iterator = new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS);
-	$files = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::CHILD_FIRST);
+	$iterator = new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS);
+	$files = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::CHILD_FIRST);
 
 	foreach ($files as $file) {
 		if ($file->isDir()) {
@@ -86,5 +88,5 @@ function deleteCliOutput(string $dir) : void
 
 function mock(string $class): MockInterface
 {
-    return Mockery::mock($class);
+	return Mockery::mock($class);
 }

--- a/tests/Helpers/ComponentHelpersTest.php
+++ b/tests/Helpers/ComponentHelpersTest.php
@@ -9,6 +9,7 @@ use EightshiftLibs\Helpers\Components;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use EightshiftBoilerplate\Blocks\BlocksExample;
+use Exception;
 
 use function Tests\setupMocks;
 use function Tests\mock;
@@ -55,7 +56,7 @@ test('Throws type exception if wrong argument type is passed to classnames', fun
 
 
 test('Asserts that reading manifest.json using getManifest will return an array', function () {
-	$results = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button');
+	$results = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button');
 
 	expect($results)
 		->toBeArray()
@@ -64,7 +65,7 @@ test('Asserts that reading manifest.json using getManifest will return an array'
 
 
 test('Asserts that not specifying the path in getManifest will throw an exception', function () {
-	Components::getManifest(dirname(__FILE__));
+	Components::getManifest(\dirname(__FILE__));
 })->throws(ComponentException::class);
 
 
@@ -128,7 +129,7 @@ test('Asserts that using responsive selectors will work', function () {
 
 
 test('Asserts that checkAttr works in case attribute is string', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['buttonAlign'] = 'right';
 
 	$results = Components::checkAttr('buttonAlign', $attributes, $manifest);
@@ -140,15 +141,15 @@ test('Asserts that checkAttr works in case attribute is string', function () {
 
 
 test('checkAttr will throw an exception in the case that the block name is missing in the manifest', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/custom/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/custom/button/');
 	$attributes['buttonText'] = 'left';
 
 	Components::checkAttr('buttonAlign', $attributes, $manifest);
-})->throws(\Exception::class, 'buttonAlign key does not exist in the button block manifest. Please check your implementation.');
+})->throws(Exception::class, 'buttonAlign key does not exist in the button block manifest. Please check your implementation.');
 
 
 test('Asserts that checkAttr works in case attribute is boolean', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['buttonIsAnchor'] = true;
 
 	$results = Components::checkAttr('buttonIsAnchor', $attributes, $manifest);
@@ -160,7 +161,7 @@ test('Asserts that checkAttr works in case attribute is boolean', function () {
 
 
 test('Asserts that checkAttr returns false in case attribute is boolean and default is not set', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['buttonIsAnchor'] = true;
 
 	$results = Components::checkAttr('buttonIsNewTab', $attributes, $manifest);
@@ -172,7 +173,7 @@ test('Asserts that checkAttr returns false in case attribute is boolean and defa
 
 
 test('Asserts that checkAttr returns null in case attribute is boolean, default is not set and undefined is allowed', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['buttonIsAnchor'] = true;
 
 	$results = Components::checkAttr('buttonIsNewTab', $attributes, $manifest, true);
@@ -184,7 +185,7 @@ test('Asserts that checkAttr returns null in case attribute is boolean, default 
 
 
 test('Asserts that checkAttr works in case attribute is array', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['buttonAttrs'] = ['attr 1', 'attr 2'];
 
 	$results = Components::checkAttr('buttonAttrs', $attributes, $manifest);
@@ -200,7 +201,7 @@ test('Asserts that checkAttr works in case attribute is array', function () {
 
 
 test('Asserts that checkAttr returns empty array in case attribute is array or object and default is not set', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['buttonSize'] = 'large';
 
 	$results = Components::checkAttr('buttonAttrs', $attributes, $manifest);
@@ -213,7 +214,7 @@ test('Asserts that checkAttr returns empty array in case attribute is array or o
 
 
 test('Asserts that checkAttr returns null in case attribute is array or object, default is not set, and undefined is allowed', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['buttonSize'] = 'large';
 
 	$results = Components::checkAttr('buttonAttrs', $attributes, $manifest, true);
@@ -225,7 +226,7 @@ test('Asserts that checkAttr returns null in case attribute is array or object, 
 
 
 test('Asserts that checkAttr returns default value', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['title'] = 'Some attribute';
 
 	$results = Components::checkAttr('buttonAlign', $attributes, $manifest, 'button');
@@ -237,15 +238,15 @@ test('Asserts that checkAttr returns default value', function () {
 
 
 test('Asserts that checkAttr throws exception if manifest key is not set', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes['title'] = 'Some attribute';
 
 	Components::checkAttr('bla', $attributes, $manifest, 'button');
-})->throws(\Exception::class, "bla key does not exist in the button component manifest. Please check your implementation.");
+})->throws(Exception::class, "bla key does not exist in the button component manifest. Please check your implementation.");
 
 
 test('Asserts that checkAttr returns attribute based on prefix if set', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes = [
 		'prefix' => 'prefixedMultipleTimesButton',
 		'prefixedMultipleTimesButtonAlign' => 'right'
@@ -260,7 +261,7 @@ test('Asserts that checkAttr returns attribute based on prefix if set', function
 
 
 test('Asserts that checkAttrResponsive returns the correct output.', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
 	$attributes = [
 		'headingContentSpacingLarge' => '10',
 		'headingContentSpacingDesktop' => '5',
@@ -280,7 +281,7 @@ test('Asserts that checkAttrResponsive returns the correct output.', function ()
 
 
 test('Asserts that checkAttrResponsive returns empty values if attribute is not provided.', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
 	$attributes = [];
 
 	$results = Components::checkAttrResponsive('headingContentSpacing', $attributes, $manifest);
@@ -295,7 +296,7 @@ test('Asserts that checkAttrResponsive returns empty values if attribute is not 
 
 
 test('Asserts that checkAttrResponsive returns null if default is not set and undefined is allowed.', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
 	$attributes = [
 		'headingContentSpacingDesktop' => '2'
 	];
@@ -318,27 +319,27 @@ test('Asserts that checkAttrResponsive returns null if default is not set and un
 
 
 test('Asserts that checkAttrResponsive throws error if responsiveAttribute key is missing', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/button/');
 	$attributes = [];
 
 	Components::checkAttrResponsive('headingContentSpacing', $attributes, $manifest, 'button');
-})->throws(\Exception::class, 'It looks like you are missing responsiveAttributes key in your button component manifest.');
+})->throws(Exception::class, 'It looks like you are missing responsiveAttributes key in your button component manifest.');
 
 
 test('Asserts that checkAttrResponsive throws error if keyName key is missing responsiveAttributes array', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/heading/');
 	$attributes = [];
 
 	Components::checkAttrResponsive('testAttribute', $attributes, $manifest, 'button');
-})->throws(\Exception::class, 'It looks like you are missing the testAttribute key in your manifest responsiveAttributes array.');
+})->throws(Exception::class, 'It looks like you are missing the testAttribute key in your manifest responsiveAttributes array.');
 
 
 test('Asserts that checkAttrResponsive throws error if keyName key is missing responsiveAttributes array for blockName', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/custom/heading/');
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/custom/heading/');
 	$attributes = [];
 
 	Components::checkAttrResponsive('bla', $attributes, $manifest, 'button');
-})->throws(\Exception::class, 'It looks like you are missing responsiveAttributes key in your heading block manifest.');
+})->throws(Exception::class, 'It looks like you are missing responsiveAttributes key in your heading block manifest.');
 
 
 test('Asserts that selectorBlock returns the correct class when attributes are set', function () {
@@ -369,7 +370,7 @@ test('Asserts that selector returns the correct class when element is an empty s
 
 
 test('Asserts that outputCssVariablesGlobal returns the correct CSS variables from global manifest', function () {
-	$globalManifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks');
+	$globalManifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks');
 
 	$output = Components::outputCssVariablesGlobal($globalManifest);
 
@@ -391,19 +392,34 @@ test('Asserts that outputCssVariablesGlobal returns empty string if global manif
 		->not->toContain('<style>');
 });
 
+test('Asserts that outputCssVariables throws exception if the global block details aren\'t set', function () {
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks/components/variables');
+	$globalManifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src/Blocks');
+
+	$attributes = [
+		'variableValue' => 'value3',
+	];
+
+	Components::outputCssVariables(
+		$attributes,
+		$manifest,
+		'uniqueString',
+		$globalManifest
+	);
+})->throws(InvalidBlock::class);
 
 test('Asserts that getManifest throws exception for paths in case the global details aren\'t set', function ($path) {
 	Components::getManifest($path, false);
 })->throws(InvalidBlock::class)->with([
-	dirname(__FILE__, 2) . '/data/src/Blocks',
-	dirname(__FILE__, 2) . '/data/src/Blocks/wrapper',
-	dirname(__FILE__, 2) . '/data/src/Blocks/components/button',
-	dirname(__FILE__, 2) . '/data/src/Blocks/custom/button',
+	\dirname(__FILE__, 2) . '/data/src/Blocks',
+	\dirname(__FILE__, 2) . '/data/src/Blocks/wrapper',
+	\dirname(__FILE__, 2) . '/data/src/Blocks/components/button',
+	\dirname(__FILE__, 2) . '/data/src/Blocks/custom/button',
 ]);
 
 
 test('Asserts that getManifest returns empty array in case of a wrong path', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src', false);
+	$manifest = Components::getManifest(\dirname(__FILE__, 2) . '/data/src', false);
 
 	expect($manifest)
 		->toBeArray()
@@ -715,23 +731,6 @@ test('Props will include the correct attribute in the manual case', function () 
 		->toHaveKey('selectorClass')
 		->toHaveKey('componentJsClass');
 });
-
-
-test('Asserts that outputCssVariables throws exception if the global block details aren\'t set', function () {
-	$manifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks/components/variables');
-	$globalManifest = Components::getManifest(dirname(__FILE__, 2) . '/data/src/Blocks');
-
-	$attributes = [
-		'variableValue' => 'value3',
-	];
-
-	Components::outputCssVariables(
-		$attributes,
-		$manifest,
-		'uniqueString',
-		$globalManifest
-	);
-})->throws(InvalidBlock::class);
 
 
 test('outputCssVariables returns empty string if global breakpoints are missing', function () {

--- a/tests/Helpers/PostHelperTest.php
+++ b/tests/Helpers/PostHelperTest.php
@@ -61,7 +61,7 @@ test('Correct get reading time function', function ($posts) {
 
     $wordCount = 0;
     foreach($postContent[0] as $block => $blockContent) {
-      $wordCount = $wordCount + str_word_count($blockContent);
+      $wordCount = $wordCount + str_word_\count($blockContent);
     }
 
     $testReadingTime = (int) ceil( $wordCount / Post::AVERAGE_WORD_COUNT);

--- a/tests/Helpers/PostHelperTest.php
+++ b/tests/Helpers/PostHelperTest.php
@@ -61,7 +61,7 @@ test('Correct get reading time function', function ($posts) {
 
     $wordCount = 0;
     foreach($postContent[0] as $block => $blockContent) {
-      $wordCount = $wordCount + str_word_\count($blockContent);
+      $wordCount = $wordCount + \str_word_count($blockContent);
     }
 
     $testReadingTime = (int) ceil( $wordCount / Post::AVERAGE_WORD_COUNT);

--- a/tests/Helpers/ShortcodeHelperTest.php
+++ b/tests/Helpers/ShortcodeHelperTest.php
@@ -17,9 +17,9 @@ test('Shortcode helper will call the shortcode callback', function() {
 		echo "Hello {$args['name']}!";
 	}
 	
-	ob_start();
+	\ob_start();
 	$this->shortcode->getShortcode('sayHello', ['name' => 'John']);
-	$result = ob_get_clean();
+	$result = \ob_get_clean();
 
 	$this->assertSame('Hello John!', $result);
 });

--- a/tests/I18n/I18nCliTest.php
+++ b/tests/I18n/I18nCliTest.php
@@ -28,7 +28,7 @@ $this->i18n = new I18nCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -37,10 +37,10 @@ test('I18n CLI command will correctly copy the I18n class with defaults', functi
 	$i18n = $this->i18n;
 	$i18n([], []);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/src/I18n/I18n.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/src/I18n/I18n.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedI18n = file_get_contents($outputPath);
+	$generatedI18n = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('class I18n implements ServiceInterface', $generatedI18n);
 	$this->assertStringContainsString('@package EightshiftLibs\I18n', $generatedI18n);
@@ -56,7 +56,7 @@ test('I18n CLI command will correctly copy the I18n class with set arguments', f
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedI18n = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/I18n/I18n.php');
+	$generatedI18n = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/I18n/I18n.php');
 
 	$this->assertStringContainsString('namespace CoolTheme\I18n;', $generatedI18n);
 });

--- a/tests/I18n/I18nExampleTest.php
+++ b/tests/I18n/I18nExampleTest.php
@@ -42,7 +42,7 @@ test('Registering load_theme_textdomain works', function () {
 
 	$this->i18n->loadThemeTextdomain();
 
-	$this->assertSame(getenv('I18N_ABSTRACTED'), 'true', 'Calling void method loadThemeTextdomain caused no side effects');
+	$this->assertSame(\getenv('I18N_ABSTRACTED'), 'true', 'Calling void method loadThemeTextdomain caused no side effects');
 });
 
 test('Registering wp_set_script_translations works', function () {
@@ -64,5 +64,5 @@ test('Registering wp_set_script_translations works', function () {
 
 	$this->i18n->setScriptTranslations();
 
-	$this->assertSame(getenv('I18N_ABSTRACTED'), 'true', 'Calling void method setScriptTranslations caused no side effects');
+	$this->assertSame(\getenv('I18N_ABSTRACTED'), 'true', 'Calling void method setScriptTranslations caused no side effects');
 });

--- a/tests/Login/LoginCliTest.php
+++ b/tests/Login/LoginCliTest.php
@@ -28,7 +28,7 @@ $this->login = new LoginCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -37,10 +37,10 @@ test('Login CLI command will correctly copy the Login class with defaults', func
 	$login = $this->login;
 	$login([], []);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/src/Login/Login.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/src/Login/Login.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedLogin = file_get_contents($outputPath);
+	$generatedLogin = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('class Login implements ServiceInterface', $generatedLogin);
 	$this->assertStringContainsString('@package EightshiftLibs\Login', $generatedLogin);
@@ -56,7 +56,7 @@ test('Login CLI command will correctly copy the Login class with set arguments',
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedLogin = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Login/Login.php');
+	$generatedLogin = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Login/Login.php');
 
 	$this->assertStringContainsString('namespace CoolTheme\Login;', $generatedLogin);
 });

--- a/tests/Main/AbstractMainTest.php
+++ b/tests/Main/AbstractMainTest.php
@@ -29,7 +29,7 @@ $this->main = new MainCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -42,7 +42,7 @@ test('Abstract main will instantiate services', function () {
 		}
 	};
 
-	$loader = require dirname(__DIR__, 2). '/vendor/autoload.php';
+	$loader = require \dirname(__DIR__, 2). '/vendor/autoload.php';
 
 	$mainClass = new MainTest($loader->getPrefixesPsr4(), 'Tests\data\src');
 
@@ -50,7 +50,7 @@ test('Abstract main will instantiate services', function () {
 	$container = $mainClass->buildDiContainer();
 
 	$this->assertIsObject($container);
-	$this->assertSame('DI\Container', get_class($container));
+	$this->assertSame('DI\Container', \get_class($container));
 });
 
 test('Caching compiled services works', function() {
@@ -64,7 +64,7 @@ test('Caching compiled services works', function() {
 		}
 	};
 
-	$loader = require dirname(__DIR__, 2). '/vendor/autoload.php';
+	$loader = require \dirname(__DIR__, 2). '/vendor/autoload.php';
 
 	$mainClass = new MainCompiledTest($loader->getPrefixesPsr4(), 'Tests\data\src');
 
@@ -72,8 +72,8 @@ test('Caching compiled services works', function() {
 	$mainClass->buildDiContainer();
 
 	// Check if compiled container was created.
-	$this->assertFileExists(dirname(__FILE__, 3) . '/src/Main/Cache/TestsCompiledContainer.php', 'Compiled container was not created');
+	$this->assertFileExists(\dirname(__FILE__, 3) . '/src/Main/Cache/TestsCompiledContainer.php', 'Compiled container was not created');
 	// Delete it if it has been created. Because it will be created in the code, and we do not want to commit it.
-	unlink(dirname(__FILE__, 3) . '/src/Main/Cache/TestsCompiledContainer.php');
-	rmdir(dirname(__FILE__, 3) . '/src/Main/Cache');
+	unlink(\dirname(__FILE__, 3) . '/src/Main/Cache/TestsCompiledContainer.php');
+	rmdir(\dirname(__FILE__, 3) . '/src/Main/Cache');
 });

--- a/tests/Main/AutowiringTest.php
+++ b/tests/Main/AutowiringTest.php
@@ -35,7 +35,7 @@ beforeEach(function() {
 
 	$this->main = new MainExample([
 		'Tests\\Datasets\\Autowiring\\' => [
-			dirname( __FILE__, 2 ) . '/Datasets/Autowiring',
+			\dirname( __FILE__, 2 ) . '/Datasets/Autowiring',
 		],
 	], 'Tests\Datasets\Autowiring');
 
@@ -79,7 +79,7 @@ beforeEach(function() {
 test('Building service classes works', function () {
 	$dependencyTree = $this->main->buildServiceClasses($this->manuallyDefinedDependencies, true);
 	$this->assertIsArray($dependencyTree);
-	$this->assertGreaterThan(0, count($dependencyTree));
+	$this->assertGreaterThan(0, \count($dependencyTree));
 });
 
 test('Service classes are correctly included in the list', function () {

--- a/tests/Main/MainCliTest.php
+++ b/tests/Main/MainCliTest.php
@@ -28,7 +28,7 @@ $this->main = new MainCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -37,10 +37,10 @@ test('Main CLI command will correctly copy the Main class with defaults', functi
 	$main = $this->main;
 	$main([], []);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/src/Main/Main.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/src/Main/Main.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedMain = file_get_contents($outputPath);
+	$generatedMain = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('class Main extends AbstractMain', $generatedMain);
 	$this->assertStringContainsString('@package EightshiftLibs\Main', $generatedMain);
@@ -56,7 +56,7 @@ test('Main CLI command will correctly copy the Main class with set arguments', f
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedMain = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Main/Main.php');
+	$generatedMain = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Main/Main.php');
 
 	$this->assertStringContainsString('namespace CoolTheme\Main', $generatedMain);
 	$this->assertStringNotContainsString('namespace EightshiftLibs\Main', $generatedMain);

--- a/tests/Manifest/ManifestCliTest.php
+++ b/tests/Manifest/ManifestCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -38,7 +38,7 @@ test('Manifest CLI command will correctly copy the Manifest class with defaults'
 	$manifest([], []);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedManifest = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Manifest/Manifest.php');
+	$generatedManifest = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Manifest/Manifest.php');
 	$this->assertStringContainsString('class Manifest extends AbstractManifest', $generatedManifest);
 	$this->assertStringContainsString('setAssetsManifestRaw', $generatedManifest);
 	$this->assertStringContainsString('manifest-item', $generatedManifest);
@@ -52,7 +52,7 @@ test('Manifest CLI command will correctly copy the Manifest class with set argum
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedManifest = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Manifest/Manifest.php');
+	$generatedManifest = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Manifest/Manifest.php');
 
 	$this->assertStringContainsString('namespace MyTheme\Manifest;', $generatedManifest);
 });

--- a/tests/Manifest/ManifestExampleTest.php
+++ b/tests/Manifest/ManifestExampleTest.php
@@ -36,7 +36,7 @@ test('Register method will call init hook', function () {
 test('Manifest example contains correct manifest file path', function () {
 	$manifestFilePath = $this->example->getManifestFilePath();
 
-	$manifestData = json_decode(file_get_contents($manifestFilePath), true);
+	$manifestData = \json_decode(\file_get_contents($manifestFilePath), true);
 
 	$this->assertStringContainsString('tests/data/public/manifest.json', $manifestFilePath);
 	$this->assertIsArray($manifestData);

--- a/tests/Media/MediaCliTest.php
+++ b/tests/Media/MediaCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Media CLI command will correctly copy the Media class with defaults', func
 	$media([], $media->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedMedia = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Media/Media.php');
+	$generatedMedia = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Media/Media.php');
 
 	$this->assertStringContainsString('class Media implements ServiceInterface', $generatedMedia);
 	$this->assertStringContainsString('after_setup_theme', $generatedMedia, 'Created class does not contain after_setup_theme hook');

--- a/tests/Media/MediaExampleTest.php
+++ b/tests/Media/MediaExampleTest.php
@@ -34,8 +34,8 @@ test('addThemeSupport method will call add_theme_support() function with differe
 
 	$this->media->addThemeSupport();
 
-	$this->assertSame(getenv('TITLE_TAG'), 'true', "Method addThemeSupport() didn't add theme support for title-tag");
-	$this->assertSame(getenv('HTML5'), 'true', "Method addThemeSupport() didn't add theme support for html5");
-	$this->assertSame(getenv('POST_THUMBNAILS'), 'true', "Method addThemeSupport() didn't add theme support for post-thumbnails");
+	$this->assertSame(\getenv('TITLE_TAG'), 'true', "Method addThemeSupport() didn't add theme support for title-tag");
+	$this->assertSame(\getenv('HTML5'), 'true', "Method addThemeSupport() didn't add theme support for html5");
+	$this->assertSame(\getenv('POST_THUMBNAILS'), 'true', "Method addThemeSupport() didn't add theme support for post-thumbnails");
 
 });

--- a/tests/Menu/MenuCliTest.php
+++ b/tests/Menu/MenuCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Menu CLI command will correctly copy the Menu class with defaults', functi
 	$menu([], []);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedMenu = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Menu/Menu.php');
+	$generatedMenu = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Menu/Menu.php');
 	$this->assertStringContainsString('class Menu extends AbstractMenu', $generatedMenu);
 	$this->assertStringContainsString('header_main_nav', $generatedMenu);
 	$this->assertStringNotContainsString('rendom string', $generatedMenu);
@@ -53,7 +53,7 @@ test('Menu CLI command will correctly copy the Menu class with set arguments', f
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedMenu = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/Menu/Menu.php');
+	$generatedMenu = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/Menu/Menu.php');
 
 	$this->assertStringContainsString('class Menu extends AbstractMenu', $generatedMenu);
 	$this->assertStringContainsString('namespace CoolTheme\Menu;', $generatedMenu);

--- a/tests/Menu/MenuExampleTest.php
+++ b/tests/Menu/MenuExampleTest.php
@@ -18,7 +18,7 @@ beforeEach(function() {
 	mock('Walker_Nav_Menu');
 
 	Functions\when('register_nav_menus')->alias(function($args) {
-		$position = array_key_first($args);
+		$position = \array_key_first($args);
 
 		putenv("REGISTERED_MENU={$position}");
 	});
@@ -55,7 +55,7 @@ test('Menu example contains correct menu position', function () {
 test('Register menu positions will work', function () {
 	$this->example->registerMenuPositions();
 
-	$this->assertSame(getenv('REGISTERED_MENU'), 'header_main_nav');
+	$this->assertSame(\getenv('REGISTERED_MENU'), 'header_main_nav');
 });
 
 
@@ -70,7 +70,7 @@ test('Bem menu will output menu', function () {
 	$this->assertArrayHasKey('items_wrap', $menu, 'Menu arguments is missing the items_wrap key');
 	$this->assertArrayHasKey('echo', $menu, 'Menu arguments is missing the echo key');
 	$this->assertArrayHasKey('walker', $menu, 'Menu arguments is missing the walker key');
-	$this->assertSame('EightshiftLibs\Menu\BemMenuWalker', get_class($menu['walker']));
+	$this->assertSame('EightshiftLibs\Menu\BemMenuWalker', \get_class($menu['walker']));
 });
 
 

--- a/tests/ModifyAdminAppearance/ModifyAdminAppearanceCliTest.php
+++ b/tests/ModifyAdminAppearance/ModifyAdminAppearanceCliTest.php
@@ -28,7 +28,7 @@ $this->modifyAdminAppearance = new ModifyAdminAppearanceCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -37,10 +37,10 @@ test('ModifyAdminAppearance CLI command will correctly copy the ModifyAdminAppea
 	$modifyAdminAppearance = $this->modifyAdminAppearance;
 	$modifyAdminAppearance([], []);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/src/ModifyAdminAppearance/ModifyAdminAppearance.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/src/ModifyAdminAppearance/ModifyAdminAppearance.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedModifyAdminAppearance = file_get_contents($outputPath);
+	$generatedModifyAdminAppearance = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('class ModifyAdminAppearance implements ServiceInterface', $generatedModifyAdminAppearance);
 	$this->assertStringContainsString('@package EightshiftLibs\ModifyAdminAppearance', $generatedModifyAdminAppearance);
@@ -56,7 +56,7 @@ test('ModifyAdminAppearance CLI command will correctly copy the ModifyAdminAppea
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedModifyAdminAppearance = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/ModifyAdminAppearance/ModifyAdminAppearance.php');
+	$generatedModifyAdminAppearance = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/ModifyAdminAppearance/ModifyAdminAppearance.php');
 
 	$this->assertStringContainsString('namespace CoolTheme\ModifyAdminAppearance;', $generatedModifyAdminAppearance);
 });

--- a/tests/Readme/ReadmeCliTest.php
+++ b/tests/Readme/ReadmeCliTest.php
@@ -28,7 +28,7 @@ $this->readme = new ReadmeCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -37,10 +37,10 @@ test('Readme CLI command will correctly copy the readme file with defaults', fun
 	$readme = $this->readme;
 	$readme([], $readme->getDevelopArgs([]));
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/README.md';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/README.md';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedReadme = file_get_contents($outputPath);
+	$generatedReadme = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('This is the official repository of the {Project name}.', $generatedReadme);
 	$this->assertStringNotContainsString('footer.php', $generatedReadme);
@@ -60,7 +60,7 @@ test('Readme CLI command will correctly copy the readme in the custom folder wit
 		'root' => './test',
 	]);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/test/README.md';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/test/README.md';
 
 	$this->assertFileExists($outputPath);
 });

--- a/tests/Rest/Fields/FieldCliTest.php
+++ b/tests/Rest/Fields/FieldCliTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\CustomPostType;
 
 use EightshiftLibs\Rest\Fields\FieldCli;
+use Exception;
 
 use function Tests\deleteCliOutput;
 use function Tests\mock;
@@ -28,7 +29,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +40,7 @@ test('REST field CLI command will correctly copy the field class with defaults',
 	$field([], $field->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedField = file_get_contents(dirname(__FILE__, 4) . '/cliOutput/src/Rest/Fields/TitleField.php');
+	$generatedField = \file_get_contents(\dirname(__FILE__, 4) . '/cliOutput/src/Rest/Fields/TitleField.php');
 
 	$this->assertStringContainsString('class TitleField extends AbstractField implements CallableFieldInterface', $generatedField);
 	$this->assertStringContainsString('return \'title\';', $generatedField);
@@ -56,7 +57,7 @@ test('REST field CLI command will correctly copy the field class with arguments'
 	$objectType = $fieldNameArguments['object_type'];
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedField = file_get_contents(dirname(__FILE__, 4) . "/cliOutput/src/Rest/Fields/{$fullFieldName}.php");
+	$generatedField = \file_get_contents(\dirname(__FILE__, 4) . "/cliOutput/src/Rest/Fields/{$fullFieldName}.php");
 
 	$this->assertStringContainsString("class {$fullFieldName} extends AbstractField implements CallableFieldInterface", $generatedField);
 	$this->assertStringContainsString("return '{$objectType}';", $generatedField);
@@ -67,4 +68,4 @@ test('REST field CLI command will correctly copy the field class with arguments'
 test('REST field CLI command will throw error on missing / invalid arguments', function ($fieldNameArguments) {
 	$field = $this->field;
 	$field([], $fieldNameArguments);
-})->with('errorFieldNameArguments')->throws(\Exception::class);
+})->with('errorFieldNameArguments')->throws(Exception::class);

--- a/tests/Rest/Fields/FieldExampleTest.php
+++ b/tests/Rest/Fields/FieldExampleTest.php
@@ -41,7 +41,7 @@ test('Field registers the callback properly', function () {
 
 	$this->field->fieldRegisterCallback($this->wpRestServer, 'attr', new class{}, 'post');
 
-	$this->assertSame(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(\getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/Rest/Routes/RouteCliTest.php
+++ b/tests/Rest/Routes/RouteCliTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Unit\CustomPostType;
 
 use EightshiftLibs\Rest\Routes\RouteCli;
+use Exception;
+use InvalidArgumentException;
 
 use function Tests\deleteCliOutput;
 use function Tests\mock;
@@ -20,7 +22,7 @@ beforeEach(function () {
 		->shouldReceive('error')
 		->andReturnUsing(
 			function ($errorMessage) {
-					throw new \InvalidArgumentException($errorMessage);
+					throw new InvalidArgumentException($errorMessage);
 			}
 	);
 
@@ -31,7 +33,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 4) . '/cliOutput';
+	$output = \dirname(__FILE__, 4) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -42,7 +44,7 @@ test('REST route CLI command will correctly copy the field class with defaults',
 	$route([], $route->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedField = file_get_contents(dirname(__FILE__, 4) . '/cliOutput/src/Rest/Routes/TestRoute.php');
+	$generatedField = \file_get_contents(\dirname(__FILE__, 4) . '/cliOutput/src/Rest/Routes/TestRoute.php');
 
 	$this->assertStringContainsString('class TestRoute extends AbstractRoute implements CallableRouteInterface', $generatedField);
 	$this->assertStringContainsString('\'methods\' => ', $generatedField);
@@ -58,10 +60,10 @@ test('REST route CLI command will correctly copy the field class with arguments'
 	$route([], $routeArguments);
 
 	$full_route_name = "{$this->route->getFileName($routeArguments['endpoint_slug'])}Route";
-	$method_to_const = RouteCli::VERB_ENUM[strtolower($routeArguments['method'])] ?? '';
+	$method_to_const = RouteCli::VERB_ENUM[\strtolower($routeArguments['method'])] ?? '';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedField = file_get_contents(dirname(__FILE__, 4) . "/cliOutput/src/Rest/Routes/{$full_route_name}.php");
+	$generatedField = \file_get_contents(\dirname(__FILE__, 4) . "/cliOutput/src/Rest/Routes/{$full_route_name}.php");
 
 	$this->assertStringContainsString("class {$full_route_name} extends AbstractRoute implements CallableRouteInterface", $generatedField);
 	$this->assertStringContainsString("'methods' => {$method_to_const}", $generatedField);
@@ -71,10 +73,10 @@ test('REST route CLI command will correctly copy the field class with arguments'
 test('REST route CLI command will throw error on missing / invalid arguments', function ($routeArguments) {
 	$route = $this->route;
 	$route([], $routeArguments);
-})->with('errorRouteArguments')->throws(\Exception::class);
+})->with('errorRouteArguments')->throws(Exception::class);
 
 
 test('REST CLI command will throw WP_Error when arguments fail validation', function ($routeArguments) {
 	$route = $this->route;
 	$route([], $routeArguments);
-})->with('invalidRouteArguments')->throws(\InvalidArgumentException::class);
+})->with('invalidRouteArguments')->throws(InvalidArgumentException::class);

--- a/tests/Rest/Routes/RouteExampleTest.php
+++ b/tests/Rest/Routes/RouteExampleTest.php
@@ -66,7 +66,7 @@ test('Route registers the callback properly', function () {
 
 	$this->route->routeRegisterCallback($this->wpRestServer);
 
-	$this->assertSame(getenv('SIDEAFFECT'), $action);
+	$this->assertSame(\getenv('SIDEAFFECT'), $action);
 
 	// Cleanup.
 	putenv('SIDEAFFECT=');

--- a/tests/Services/ServiceExampleCliTest.php
+++ b/tests/Services/ServiceExampleCliTest.php
@@ -28,7 +28,7 @@ $this->services = new ServiceExampleCli('boilerplate');
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -37,10 +37,10 @@ test('Services CLI command will correctly copy the Services class with defaults'
 	$services = $this->services;
 	$services([], $services->getDevelopArgs([]));
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/src/TestFolder/TMP/TestTest.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/src/TestFolder/TMP/TestTest.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedService = file_get_contents($outputPath);
+	$generatedService = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('class TestTest implements ServiceInterface', $generatedService);
 	$this->assertStringContainsString('namespace EightshiftLibs\TestFolder\TMP', $generatedService);
@@ -57,10 +57,10 @@ test('Services CLI command will correctly copy the Services class with set argum
 		'file_name' => 'FileName',
 	]);
 
-	$outputPath = dirname(__FILE__, 3) . '/cliOutput/src/FolderName/FileName.php';
+	$outputPath = \dirname(__FILE__, 3) . '/cliOutput/src/FolderName/FileName.php';
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedService = file_get_contents($outputPath);
+	$generatedService = \file_get_contents($outputPath);
 
 	$this->assertStringContainsString('class FileName implements ServiceInterface', $generatedService);
 	$this->assertStringContainsString('namespace CoolTheme\FolderName', $generatedService);

--- a/tests/Services/ServiceExampleTest.php
+++ b/tests/Services/ServiceExampleTest.php
@@ -24,5 +24,5 @@ test('Service Example test register method', function () {
 });
 
 test('Service Example contains register method', function () {
-	$this->assertTrue(method_exists($this->service, 'register'));
+	$this->assertTrue(\method_exists($this->service, 'register'));
 });

--- a/tests/Setup/SetupCliTest.php
+++ b/tests/Setup/SetupCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -38,7 +38,7 @@ test('Setup CLI command will correctly copy the Setup class with defaults', func
 	$setup([], $setup->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedFile = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/setup.json');
+	$generatedFile = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/setup.json');
 	$this->assertStringContainsString('twentytwentyone', $generatedFile);
 	$this->assertStringNotContainsString('random string', $generatedFile);
 });
@@ -50,7 +50,7 @@ test('Setup CLI command will correctly copy the Setup class with set parameters'
 	]);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedFile = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/test/setup.json');
+	$generatedFile = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/test/setup.json');
 	$this->assertStringContainsString('twentytwentyone', $generatedFile);
 	$this->assertStringNotContainsString('random string', $generatedFile);
 });

--- a/tests/Setup/UpdateCliTest.php
+++ b/tests/Setup/UpdateCliTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Setup;
 
 use EightshiftLibs\Setup\UpdateCli;
+use Exception;
 
 use function Brain\Monkey\Functions\when;
 use function Tests\deleteCliOutput;
@@ -39,7 +40,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -48,7 +49,7 @@ afterEach(function () {
 test('Update CLI command will correctly throw an exception if setup.json does not exist or has the wrong filename', function () {
 	$update = $this->update;
 	$update([], []);
-})->throws(\Exception::class);
+})->throws(Exception::class);
 
 test('Update CLI documentation is correct', function () {
 	$update = $this->update;

--- a/tests/ThemeOptions/ThemeOptionsCliTest.php
+++ b/tests/ThemeOptions/ThemeOptionsCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Custom theme options CLI command will correctly copy the theme options cla
 	$themeOptions([], []);
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedMeta = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/ThemeOptions/ThemeOptions.php');
+	$generatedMeta = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/ThemeOptions/ThemeOptions.php');
 
 	$this->assertStringContainsString('class ThemeOptions implements ServiceInterface', $generatedMeta);
 	$this->assertStringContainsString('acf_add_options_page', $generatedMeta);

--- a/tests/View/EscapedViewCliTest.php
+++ b/tests/View/EscapedViewCliTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
  * Cleanup after tests.
  */
 afterEach(function () {
-	$output = dirname(__FILE__, 3) . '/cliOutput';
+	$output = \dirname(__FILE__, 3) . '/cliOutput';
 
 	deleteCliOutput($output);
 });
@@ -39,7 +39,7 @@ test('Escaped view command will correctly copy the EscapedView class with defaul
 	$escapedView([], $escapedView->getDevelopArgs([]));
 
 	// Check the output dir if the generated method is correctly generated.
-	$generatedEscapedView = file_get_contents(dirname(__FILE__, 3) . '/cliOutput/src/View/EscapedView.php');
+	$generatedEscapedView = \file_get_contents(\dirname(__FILE__, 3) . '/cliOutput/src/View/EscapedView.php');
 
 	$this->assertNotEmpty($generatedEscapedView);
 	$this->assertStringContainsString('class EscapedView extends AbstractEscapedView implements ServiceInterface', $generatedEscapedView);

--- a/tests/View/EscapedViewExampleTest.php
+++ b/tests/View/EscapedViewExampleTest.php
@@ -20,6 +20,6 @@ afterEach(function() {
 
 
 test('Escaped view class has register method', function () {
-	$this->assertTrue(method_exists($this->example, 'register'));
+	$this->assertTrue(\method_exists($this->example, 'register'));
 	$this->assertEmpty($this->example->register());
 });


### PR DESCRIPTION
# Description

Fixing linter issues - phpcs and phpstan are fixed, but tests seem to be failing. 

This needs to be addressed.

I think that adding the `\defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : false` to the parameters caused issues.

TBH not sure why this was added in the first place, but all of those should be checked, so that we see which are optional, and which are not optional arguments, because I think in some cases this should be 

```
\defined('ES_DEVELOP_MODE') ? \ES_DEVELOP_MODE : true
```

### EDIT:

Fixed the failing tests except the Components one. For some reason the 

```php	
	private static function getManifestDirect(string $path): array
	{
		$sep = \DIRECTORY_SEPARATOR;
		$path = \trim($path, $sep);

		$manifest = "{$path}{$sep}manifest.json";

		if (!\file_exists($manifest)) {
			throw ComponentException::throwUnableToLocateComponent($manifest);
		}

		return \json_decode(\implode(' ', (array)\file($manifest)), true);
	}```

method throws an error that the manifest is missing, but the path is correct and exists when I stop debbug the path 🤷🏼‍♂️ 