### PR TITLE
Fix for ACF is admin showing fields

### DIFF
--- a/src/CustomMeta/AbstractAcfMeta.php
+++ b/src/CustomMeta/AbstractAcfMeta.php
@@ -29,10 +29,6 @@ abstract class AbstractAcfMeta implements ServiceInterface
 			return;
 		}
 
-		if (!\is_admin()) {
-			return;
-		}
-
 		\add_action('acf/init', [$this, 'fields']);
 	}
 


### PR DESCRIPTION
# Description
- removed ACF is_admin early exit due to not serving ACF fields on the frontend

# Screenshots / Videos
<img width="435" alt="is admin blocking acf fields" src="https://user-images.githubusercontent.com/46056662/159895234-9ef1a332-8d80-476e-8bb9-42fdbf43932c.png">
<img width="266" alt="without is_adminacf" src="https://user-images.githubusercontent.com/46056662/159898816-2d9772bd-6e8c-493a-9532-d8ea57cf8fe4.png">


Note:
This was causing the user image not to be shown on frontend.
@goranalkovic-infinum, @iobrado 