### PR TITLE
Fix logic for copying global manifest

### DIFF
--- a/src/Blocks/BlocksCli.php
+++ b/src/Blocks/BlocksCli.php
@@ -158,7 +158,7 @@ class BlocksCli extends AbstractCli
 		$this->copyRecursively("{$rootNode}/assets/", "{$folders['assetsGlobal']}/");
 		$this->copyRecursively("{$rootNode}/src/Blocks/assets/", "{$folders['assets']}/");
 		$this->copyRecursively("{$rootNode}/src/Blocks/variations/", "{$folders['variations']}/");
-		$this->copyRecursively("{$rootNode}/src/Blocks/", "{$folders['blocks']}/");
+		copy("{$rootNode}/src/Blocks/manifest.json", "{$folders['blocks']}/manifest.json");
 
 		WP_CLI::runcommand("{$this->commandParentName} use_wrapper {$this->prepareArgsManual($args)}");
 

--- a/src/Blocks/BlocksCli.php
+++ b/src/Blocks/BlocksCli.php
@@ -158,7 +158,7 @@ class BlocksCli extends AbstractCli
 		$this->copyRecursively("{$rootNode}/assets/", "{$folders['assetsGlobal']}/");
 		$this->copyRecursively("{$rootNode}/src/Blocks/assets/", "{$folders['assets']}/");
 		$this->copyRecursively("{$rootNode}/src/Blocks/variations/", "{$folders['variations']}/");
-		copy("{$rootNode}/src/Blocks/manifest.json", "{$folders['blocks']}/manifest.json");
+		\copy("{$rootNode}/src/Blocks/manifest.json", "{$folders['blocks']}/manifest.json");
 
 		WP_CLI::runcommand("{$this->commandParentName} use_wrapper {$this->prepareArgsManual($args)}");
 


### PR DESCRIPTION
# Description

This PR changes `blocksInit` logic to copy the global manifest file and set up blocks using relevant boilerplate commands instead of the whole block folder, which was causing #267.

Discussed https://github.com/infinum/eightshift-libs/commit/2fcc29d300cf4f3f169ede451c24a22e8d7e2f55 with @iruzevic, and the intended purpose of the change was to copy the global manifest. This didn't work with the `copyRecursively` method as it sets up a `RecursiveDirectoryIterator`, so it expects a path to a folder, not a file.