### PR TITLE
Improve developer experience on Windows

### DIFF
--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -38,7 +38,8 @@ abstract class AbstractBlocksCli extends AbstractCli
 		$root = $this->getProjectRootPath();
 		$rootNode = $this->getFrontendLibsBlockPath();
 
-		$sourcePathFolder = "{$rootNode}/{$outputDir}/";
+		$ds = DIRECTORY_SEPARATOR;
+		$sourcePathFolder = "{$rootNode}{$ds}{$outputDir}{$ds}";
 
 		$blocks = \scandir($sourcePathFolder);
 		$blocksFullList = \array_diff((array)$blocks, ['..', '.']);
@@ -53,13 +54,13 @@ abstract class AbstractBlocksCli extends AbstractCli
 
 		// Iterate blocks/components.
 		foreach ($blocks as $block) {
-			$path = "{$outputDir}/{$block}";
+			$path = "{$outputDir}{$ds}{$block}";
 			$sourcePath = "{$sourcePathFolder}{$block}";
 
 			if (!\getenv('TEST')) {
-				$destinationPath = $root . \DIRECTORY_SEPARATOR . $path;
+				$destinationPath = "{$root}{$ds}{$path}";
 			} else {
-				$destinationPath = $this->getProjectRootPath(true) . '/cliOutput';
+				$destinationPath = "{$this->getProjectRootPath(true)}{$ds}cliOutput";
 			}
 
 			$typePlural = !$isComponents ?  'blocks' : 'components';
@@ -115,11 +116,12 @@ abstract class AbstractBlocksCli extends AbstractCli
 	 */
 	private function moveBlock(string $destinationPath, string $sourcePath, string $name, array $assocArgs, string $path, string $typeSingular): void
 	{
+		$ds = DIRECTORY_SEPARATOR;
 		// Create folder in project if missing.
-		\mkdir("{$destinationPath}/");
+		\mkdir("{$destinationPath}{$ds}");
 
 		// Move block/component to project folder.
-		$this->copyRecursively($sourcePath, "{$destinationPath}/");
+		$this->copyRecursively($sourcePath, "{$destinationPath}{$ds}");
 
 		$typeSingular = \ucfirst($typeSingular);
 

--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -38,7 +38,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 		$root = $this->getProjectRootPath();
 		$rootNode = $this->getFrontendLibsBlockPath();
 
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 		$sourcePathFolder = "{$rootNode}{$ds}{$outputDir}{$ds}";
 
 		$blocks = \scandir($sourcePathFolder);
@@ -116,7 +116,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 	 */
 	private function moveBlock(string $destinationPath, string $sourcePath, string $name, array $assocArgs, string $path, string $typeSingular): void
 	{
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 		// Create folder in project if missing.
 		\mkdir("{$destinationPath}{$ds}");
 

--- a/src/Blocks/BlocksCli.php
+++ b/src/Blocks/BlocksCli.php
@@ -144,11 +144,11 @@ class BlocksCli extends AbstractCli
 		WP_CLI::runcommand("{$this->commandParentName} use_wrapper {$this->prepareArgsManual($args)}");
 
 		foreach (static::COMPONENTS as $component) {
-			WP_CLI::runcommand("{$this->commandParentName} use_component --name='{$component}' {$this->prepareArgsManual($args)}");
+			WP_CLI::runcommand("{$this->commandParentName} use_component --name={$component} {$this->prepareArgsManual($args)}");
 		}
 
 		foreach (static::BLOCKS as $block) {
-			WP_CLI::runcommand("{$this->commandParentName} use_block --name='{$block}' {$this->prepareArgsManual($args)}");
+			WP_CLI::runcommand("{$this->commandParentName} use_block --name={$block} {$this->prepareArgsManual($args)}");
 		}
 
 		WP_CLI::success('Blocks successfully set.');

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -361,6 +361,10 @@ abstract class AbstractCli implements CliInterface
 		$path = \rtrim($path, $ds);
 		$path = \trim($path, $ds);
 
+		if ($ds === '/') {
+			return "{$ds}{$root}{$ds}{$path}";
+		}
+		
 		return "{$root}{$ds}{$path}";
 	}
 

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -246,7 +246,7 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getExampleTemplate(string $currentDir, string $fileName, bool $skipMissing = false): self
 	{
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 		$path = "{$currentDir}{$ds}{$this->getExampleFileName( $fileName )}.php";
 
 		// If you pass file name with extension the version will be used.
@@ -346,7 +346,7 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getOutputDir(string $path = ''): string
 	{
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 		if (\function_exists('\add_action') && !\getenv('TEST')) {
 			$root = $this->getProjectRootPath();
 		} else {
@@ -364,7 +364,7 @@ abstract class AbstractCli implements CliInterface
 		if ($ds === '/') {
 			return "{$ds}{$root}{$ds}{$path}";
 		}
-		
+
 		return "{$root}{$ds}{$path}";
 	}
 
@@ -663,7 +663,7 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getComposer(array $args = []): array
 	{
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 		if (!isset($args['config_path'])) {
 			if (\function_exists('\add_action')) {
 				$composerPath = "{$this->getProjectRootPath()}{$ds}composer.json";
@@ -841,7 +841,7 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getFrontendLibsPath(string $path = ''): string
 	{
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 		return "{$this->getProjectRootPath()}{$ds}node_modules{$ds}@eightshift{$ds}frontend-libs{$ds}{$path}";
 	}
 
@@ -854,7 +854,7 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getLibsPath(string $path = ''): string
 	{
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 		if (\getenv('TEST')) {
 			return "{$this->getProjectRootPath()}{$ds}{$path}";
 		}
@@ -869,7 +869,7 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getFrontendLibsBlockPath(): string
 	{
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 		return $this->getFrontendLibsPath("blocks{$ds}init");
 	}
 
@@ -882,7 +882,7 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getFullBlocksFiles(string $name): array
 	{
-		$ds = DIRECTORY_SEPARATOR;
+		$ds = \DIRECTORY_SEPARATOR;
 		return [
 			"{$name}.php",
 			"{$name}-block.js",

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -246,11 +246,12 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getExampleTemplate(string $currentDir, string $fileName, bool $skipMissing = false): self
 	{
-		$path = "{$currentDir}/{$this->getExampleFileName( $fileName )}.php";
+		$ds = DIRECTORY_SEPARATOR;
+		$path = "{$currentDir}{$ds}{$this->getExampleFileName( $fileName )}.php";
 
 		// If you pass file name with extension the version will be used.
 		if (\strpos($fileName, '.') !== false) {
-			$path = "{$currentDir}/{$fileName}";
+			$path = "{$currentDir}{$ds}{$fileName}";
 		}
 
 		$templateFile = '';
@@ -345,10 +346,11 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getOutputDir(string $path = ''): string
 	{
+		$ds = DIRECTORY_SEPARATOR;
 		if (\function_exists('\add_action') && !\getenv('TEST')) {
 			$root = $this->getProjectRootPath();
 		} else {
-			$root = $this->getProjectRootPath(true) . '/cliOutput';
+			$root = "{$this->getProjectRootPath(true)}{$ds}cliOutput";
 		}
 
 		$ds = \DIRECTORY_SEPARATOR;
@@ -657,11 +659,12 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getComposer(array $args = []): array
 	{
+		$ds = DIRECTORY_SEPARATOR;
 		if (!isset($args['config_path'])) {
 			if (\function_exists('\add_action')) {
-				$composerPath = $this->getProjectRootPath() . '/composer.json';
+				$composerPath = "{$this->getProjectRootPath()}{$ds}composer.json";
 			} else {
-				$composerPath = $this->getProjectRootPath(true) . '/composer.json';
+				$composerPath = "{$this->getProjectRootPath(true)}{$ds}composer.json";
 			}
 		} else {
 			$composerPath = $args['config_path'];
@@ -834,7 +837,8 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getFrontendLibsPath(string $path = ''): string
 	{
-		return "{$this->getProjectRootPath()}/node_modules/@eightshift/frontend-libs/{$path}";
+		$ds = DIRECTORY_SEPARATOR;
+		return "{$this->getProjectRootPath()}{$ds}node_modules{$ds}@eightshift{$ds}frontend-libs{$ds}{$path}";
 	}
 
 	/**
@@ -846,11 +850,12 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getLibsPath(string $path = ''): string
 	{
+		$ds = DIRECTORY_SEPARATOR;
 		if (\getenv('TEST')) {
-			return "{$this->getProjectRootPath()}/{$path}";
+			return "{$this->getProjectRootPath()}{$ds}{$path}";
 		}
 
-		return "{$this->getProjectRootPath()}/vendor/infinum/eightshift-libs/{$path}";
+		return "{$this->getProjectRootPath()}{$ds}vendor{$ds}infinum{$ds}eightshift-libs{$ds}{$path}";
 	}
 
 	/**
@@ -860,7 +865,8 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getFrontendLibsBlockPath(): string
 	{
-		return $this->getFrontendLibsPath('blocks/init');
+		$ds = DIRECTORY_SEPARATOR;
+		return $this->getFrontendLibsPath("blocks{$ds}init");
 	}
 
 	/**
@@ -872,16 +878,17 @@ abstract class AbstractCli implements CliInterface
 	 */
 	public function getFullBlocksFiles(string $name): array
 	{
+		$ds = DIRECTORY_SEPARATOR;
 		return [
 			"{$name}.php",
 			"{$name}-block.js",
 			"{$name}-hooks.js",
 			"{$name}-transforms.js",
 			"{$name}.js",
-			"docs/story.js",
-			"components/{$name}-editor.js",
-			"components/{$name}-toolbar.js",
-			"components/{$name}-options.js",
+			"docs{$ds}story.js",
+			"components{$ds}{$name}-editor.js",
+			"components{$ds}{$name}-toolbar.js",
+			"components{$ds}{$name}-options.js",
 		];
 	}
 

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -361,7 +361,7 @@ abstract class AbstractCli implements CliInterface
 		$path = \rtrim($path, $ds);
 		$path = \trim($path, $ds);
 
-		return "{$ds}{$root}{$ds}{$path}";
+		return "{$root}{$ds}{$path}";
 	}
 
 	/**

--- a/src/Cli/CliInitAll.php
+++ b/src/Cli/CliInitAll.php
@@ -42,8 +42,9 @@ class CliInitAll extends AbstractCli
 	public function getDoc(): array
 	{
 		return [
-			'shortdesc' => 'Generates initial setup for all service classes in the WordPress theme project.
-			This command is used only in develop mode. For this to work you must set global constant ES_DEVELOP_MODE to true.',
+			'shortdesc' =>
+				'Generates initial setup for all service classes in the WordPress theme project.
+				This command is used only in develop mode. For this to work you must set global constant ES_DEVELOP_MODE to true.',
 		];
 	}
 

--- a/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
+++ b/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
@@ -29,7 +29,7 @@ abstract class AbstractEnqueueBlocks extends AbstractAssets
 	/**
 	 * Instance variable of manifest data.
 	 *
-	 * @var ManifestInterface
+	 * @var \EightshiftLibs\Manifest\ManifestInterface
 	 */
 	protected ManifestInterface $manifest;
 

--- a/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
+++ b/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Enqueue\Blocks;
 
-use EightshiftLibs\Manifest\ManifestInterface; // phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use EightshiftLibs\Enqueue\AbstractAssets;
 use EightshiftLibs\Manifest\ManifestInterface;
 

--- a/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
+++ b/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace EightshiftLibs\Enqueue\Blocks;
 
+use EightshiftLibs\Manifest\ManifestInterface; // phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use EightshiftLibs\Enqueue\AbstractAssets;
 use EightshiftLibs\Manifest\ManifestInterface;
 
@@ -29,7 +30,7 @@ abstract class AbstractEnqueueBlocks extends AbstractAssets
 	/**
 	 * Instance variable of manifest data.
 	 *
-	 * @var \EightshiftLibs\Manifest\ManifestInterface
+	 * @var ManifestInterface
 	 */
 	protected ManifestInterface $manifest;
 

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -216,7 +216,7 @@ class Components
 		$path = \trim($path, $sep);
 
 		$manifest = "{$path}{$sep}manifest.json";
-		
+
 		if ($sep === '/') {
 			$manifest = "{$sep}{$manifest}";
 		}

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -215,7 +215,7 @@ class Components
 		$sep = \DIRECTORY_SEPARATOR;
 		$path = \trim($path, $sep);
 
-		$manifest = "{$sep}{$path}{$sep}manifest.json";
+		$manifest = "{$path}{$sep}manifest.json";
 
 		if (!\file_exists($manifest)) {
 			throw ComponentException::throwUnableToLocateComponent($manifest);

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -216,6 +216,10 @@ class Components
 		$path = \trim($path, $sep);
 
 		$manifest = "{$path}{$sep}manifest.json";
+		
+		if ($sep === '/') {
+			$manifest = "{$sep}{$manifest}";
+		}
 
 		if (!\file_exists($manifest)) {
 			throw ComponentException::throwUnableToLocateComponent($manifest);

--- a/src/Helpers/CssVariablesTrait.php
+++ b/src/Helpers/CssVariablesTrait.php
@@ -151,104 +151,102 @@ trait CssVariablesTrait
 			return '';
 		}
 
-		$styles = Components::getStyles();
-
-		// Bailout if styles are missing.
-		if (!$styles) {
-			return '';
-		}
-
-		// Define variables from globalManifest.
-		$breakpointsData = self::getSettingsGlobalVariablesBreakpoints();
-
-		// Sort breakpoints in ascending order.
-		\asort($breakpointsData);
-
-		// Populate min values.
-		$breakpointsMin = \array_map(
-			static function ($item) {
-				return "min---{$item}";
-			},
-			\array_values($breakpointsData)
-		);
-		// Append 0 value.
-		\array_unshift($breakpointsMin, 'min---0');
-
-		// Populate max values.
-		$breakpointsMax = \array_map(
-			static function ($item) {
-				return "max---{$item}";
-			},
-			\array_reverse(\array_values($breakpointsData))
-		);
-		// Append 0 value.
-		\array_unshift($breakpointsMax, 'max---0');
-
-		// Return empty array of items.
-		$breakpoints = \array_map(
-			static function () {
-				return '';
-			},
-			\array_flip(\array_values(\array_merge($breakpointsMin, $breakpointsMax)))
-		);
-
-		// Loop styles.
-		foreach ($styles as $style) {
-			$name = $style['name'] ?? '';
-			$unique = $style['unique'] ?? '';
-			$variables = $style['variables'] ?? [];
-
-			// Bailout if variables are missing.
-			if (!$variables) {
-				continue;
-			}
-
-			$uniqueSelector = "[data-id='{$unique}']";
-
-			if (!$unique) {
-				$uniqueSelector = '';
-			}
-
-			foreach ($variables as $data) {
-				$type = $data['type'] ?? '';
-				$value = $data['value'] ?? '';
-				$variable = $data['variable'] ?? '';
-
-				// Bailout if variable is missing.
-				if (!$variable) {
-					continue;
-				}
-
-				// Bailout if breakpont is missing.
-				if (!isset($breakpoints["{$type}---{$value}"])) {
-					continue;
-				}
-
-				// Populate breakpoint.
-				$breakpoints["{$type}---{$value}"] .= "\n.{$name}{$uniqueSelector}{\n{$variable}\n} ";
-			}
-		}
-
 		// Prepare final output.
 		$output = '';
 
-		// Loop breakpoints in correct order.
-		foreach ($breakpoints as $breakpointKey => $breakpointValue) {
-			$breakpointKey = \explode('---', $breakpointKey);
+		$styles = Components::getStyles();
 
-			$type = $breakpointKey[0] ?? '';
-			$value = $breakpointKey[1] ?? '';
+		// Bailout if styles are missing.
+		if ($styles) {
+			// Define variables from globalManifest.
+			$breakpointsData = self::getSettingsGlobalVariablesBreakpoints();
 
-			// Bailout if empty value.
-			if (!$breakpointValue) {
-				continue;
+			// Sort breakpoints in ascending order.
+			\asort($breakpointsData);
+
+			// Populate min values.
+			$breakpointsMin = \array_map(
+				static function ($item) {
+					return "min---{$item}";
+				},
+				\array_values($breakpointsData)
+			);
+			// Append 0 value.
+			\array_unshift($breakpointsMin, 'min---0');
+
+			// Populate max values.
+			$breakpointsMax = \array_map(
+				static function ($item) {
+					return "max---{$item}";
+				},
+				\array_reverse(\array_values($breakpointsData))
+			);
+			// Append 0 value.
+			\array_unshift($breakpointsMax, 'max---0');
+
+			// Return empty array of items.
+			$breakpoints = \array_map(
+				static function () {
+					return '';
+				},
+				\array_flip(\array_values(\array_merge($breakpointsMin, $breakpointsMax)))
+			);
+
+			// Loop styles.
+			foreach ($styles as $style) {
+				$name = $style['name'] ?? '';
+				$unique = $style['unique'] ?? '';
+				$variables = $style['variables'] ?? [];
+
+				// Bailout if variables are missing.
+				if (!$variables) {
+					continue;
+				}
+
+				$uniqueSelector = "[data-id='{$unique}']";
+
+				if (!$unique) {
+					$uniqueSelector = '';
+				}
+
+				foreach ($variables as $data) {
+					$type = $data['type'] ?? '';
+					$value = $data['value'] ?? '';
+					$variable = $data['variable'] ?? '';
+
+					// Bailout if variable is missing.
+					if (!$variable) {
+						continue;
+					}
+
+					// Bailout if breakpont is missing.
+					if (!isset($breakpoints["{$type}---{$value}"])) {
+						continue;
+					}
+
+					// Populate breakpoint.
+					$breakpoints["{$type}---{$value}"] .= "\n.{$name}{$uniqueSelector}{\n{$variable}\n} ";
+				}
 			}
 
-			// If value is 0 then this breakpoint has no media query.
-			if ($value === '0') {
-				$output .= "{$breakpointValue}\n";
-			} else {
-				$output .= "\n@media ({$type}-width:{$value}px){{$breakpointValue}}\n ";
+			// Loop breakpoints in correct order.
+			foreach ($breakpoints as $breakpointKey => $breakpointValue) {
+				$breakpointKey = \explode('---', $breakpointKey);
+
+				$type = $breakpointKey[0] ?? '';
+				$value = $breakpointKey[1] ?? '';
+
+				// Bailout if empty value.
+				if (!$breakpointValue) {
+					continue;
+				}
+
+				// If value is 0 then this breakpoint has no media query.
+				if ($value === '0') {
+					$output .= "{$breakpointValue}\n";
+				} else {
+					$output .= "\n@media ({$type}-width:{$value}px){{$breakpointValue}}\n ";
+				}
 			}
 		}
 


### PR DESCRIPTION
# Description

This PR:
* replaces instances in which `wp boilerplate setup_theme` uses `/` instead of `DIRECTORY_SEPARATOR`
* stops prepending `DIRECTORY_SEPARATOR` to absolute paths on Windows
  * this caused `\C:\Users\...` paths on Windows, which were failing
  * the Windows check is based upon checking whether `\` is the directory separator, as we only care what's the filesystem structure like 
* stops quoting arguments when calling `wp boilerplate use_block` and `use_component` from `setup_theme`, as this these quotes for some reason aren't stripped on Windows
  * I can see that there were some similar bugs in WP-CLI regarding this, but WP-CLI doesn't officially support Windows so I didn't report this additionally
* includes changes from #270 

Using this, I was able to set up a theme (under Windows 11, using XAMPP) in the same way as I would on Unix systems.


