### PR TITLE
Rename method arguments that are using reserved keywords

### DIFF
--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -759,17 +759,17 @@ abstract class AbstractCli implements CliInterface
 	 * Convert _ to -, empty space to - and convert everything to lowercase
 	 * if the string contains empty space.
 	 *
-	 * @param string $convert String to convert.
+	 * @param string $stringToConvert String to convert.
 	 *
 	 * @return string
 	 */
-	public function prepareSlug(string $convert): string
+	public function prepareSlug(string $stringToConvert): string
 	{
-		if (\strpos($convert, ' ') !== false) {
-			$convert = \strtolower($convert);
+		if (\strpos($stringToConvert, ' ') !== false) {
+			$stringToConvert = \strtolower($stringToConvert);
 		}
 
-		return \str_replace('_', '-', \str_replace(' ', '-', $convert));
+		return \str_replace('_', '-', \str_replace(' ', '-', $stringToConvert));
 	}
 
 	/**

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -305,13 +305,13 @@ abstract class AbstractCli implements CliInterface
 	/**
 	 * Generate example template file/class name
 	 *
-	 * @param string $string File name.
+	 * @param string $filename File name.
 	 *
 	 * @return string
 	 */
-	public function getExampleFileName(string $string): string
+	public function getExampleFileName(string $filename): string
 	{
-		return "{$string}Example";
+		return "{$filename}Example";
 	}
 
 	/**
@@ -759,14 +759,14 @@ abstract class AbstractCli implements CliInterface
 	 * Convert _ to -, empty space to - and convert everything to lowercase
 	 * if the string contains empty space.
 	 *
-	 * @param string $string String to convert.
+	 * @param string $convert String to convert.
 	 *
 	 * @return string
 	 */
-	public function prepareSlug(string $string): string
+	public function prepareSlug(string $convert): string
 	{
-		if (\strpos($string, ' ') !== false) {
-			$string = \strtolower($string);
+		if (\strpos($convert, ' ') !== false) {
+			$string = \strtolower($convert);
 		}
 
 		return \str_replace('_', '-', \str_replace(' ', '-', $string));

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -766,10 +766,10 @@ abstract class AbstractCli implements CliInterface
 	public function prepareSlug(string $convert): string
 	{
 		if (\strpos($convert, ' ') !== false) {
-			$string = \strtolower($convert);
+			$convert = \strtolower($convert);
 		}
 
-		return \str_replace('_', '-', \str_replace(' ', '-', $string));
+		return \str_replace('_', '-', \str_replace(' ', '-', $convert));
 	}
 
 	/**

--- a/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
+++ b/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
@@ -46,13 +46,13 @@ abstract class AbstractTaxonomyColumns implements ServiceInterface
 	/**
 	 * Render the taxonomy column content in the custom taxonomy column
 	 *
-	 * @param string $string Blank string.
+	 * @param string $_string Blank string.
 	 * @param string $columnName Name of the column.
 	 * @param int    $termId Term ID.
 	 *
 	 * @return string The content to display in the custom column.
 	 */
-	abstract public function renderColumnContent(string $string, string $columnName, int $termId): string;
+	abstract public function renderColumnContent(string $_string, string $columnName, int $termId): string;
 
 	/**
 	 * Get the array of slugs of the taxonomies where the additional column should appear.

--- a/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
+++ b/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
@@ -46,12 +46,13 @@ abstract class AbstractTaxonomyColumns implements ServiceInterface
 	/**
 	 * Render the taxonomy column content in the custom taxonomy column
 	 *
+	 * @param string $columnOutput Column output.
 	 * @param string $columnName Name of the column.
 	 * @param int    $termId Term ID.
 	 *
 	 * @return string The content to display in the custom column.
 	 */
-	abstract public function renderColumnContent(string $columnName, int $termId): string;
+	abstract public function renderColumnContent(string $columnOutput, string $columnName, int $termId): string;
 
 	/**
 	 * Get the array of slugs of the taxonomies where the additional column should appear.

--- a/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
+++ b/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
@@ -44,7 +44,7 @@ abstract class AbstractTaxonomyColumns implements ServiceInterface
 	abstract public function addColumnName(array $columns): array;
 
 	/**
-	 * Render the taxonomy column content in the custom taxonomy column
+	 * Render the taxonomy column content in the custom taxonomy column.
 	 *
 	 * @param string $columnOutput Column output.
 	 * @param string $columnName Name of the column.

--- a/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
+++ b/src/Columns/Taxonomy/AbstractTaxonomyColumns.php
@@ -46,13 +46,12 @@ abstract class AbstractTaxonomyColumns implements ServiceInterface
 	/**
 	 * Render the taxonomy column content in the custom taxonomy column
 	 *
-	 * @param string $_string Blank string.
 	 * @param string $columnName Name of the column.
 	 * @param int    $termId Term ID.
 	 *
 	 * @return string The content to display in the custom column.
 	 */
-	abstract public function renderColumnContent(string $_string, string $columnName, int $termId): string;
+	abstract public function renderColumnContent(string $columnName, int $termId): string;
 
 	/**
 	 * Get the array of slugs of the taxonomies where the additional column should appear.

--- a/src/Helpers/ObjectHelperTrait.php
+++ b/src/Helpers/ObjectHelperTrait.php
@@ -133,7 +133,7 @@ trait ObjectHelperTrait
 	}
 
 	/**
-	 * Convert string from kebab to camel case
+	 * Convert string from kebab to camel case.
 	 *
 	 * @param string $stringToConvert    String to convert.
 	 * @param string $separator Separator to use for conversion.

--- a/src/Helpers/ObjectHelperTrait.php
+++ b/src/Helpers/ObjectHelperTrait.php
@@ -38,29 +38,29 @@ trait ObjectHelperTrait
 	/**
 	 * Check if json is valid
 	 *
-	 * @param string $check String to check.
+	 * @param string $jsonString String to check.
 	 *
 	 * @return bool
 	 */
-	public static function isJson(string $check): bool
+	public static function isJson(string $jsonString): bool
 	{
-		\json_decode($check);
+		\json_decode($jsonString);
 		return (\json_last_error() === \JSON_ERROR_NONE);
 	}
 
 	/**
 	 * Flatten multidimensional array.
 	 *
-	 * @param array<mixed> $flatten Multidimensional array to flatten.
+	 * @param array<mixed> $arrayToFlatten Multidimensional array to flatten.
 	 *
 	 * @return array<mixed>
 	 */
-	public static function flattenArray(array $flatten): array
+	public static function flattenArray(array $arrayToFlatten): array
 	{
 		$output = [];
 
 		\array_walk_recursive(
-			$flatten,
+			$arrayToFlatten,
 			function ($a) use (&$output) {
 				if (!empty($a)) {
 					$output[] = $a;
@@ -76,16 +76,16 @@ trait ObjectHelperTrait
 	 *
 	 * @link https://developer.wordpress.org/themes/theme-security/data-sanitization-escaping/
 	 *
-	 * @param array<mixed> $array Provided array.
+	 * @param array<mixed> $arrayToSanitize Provided array.
 	 * @param string $sanitizationFunction WordPress function used for sanitization purposes.
 	 *
 	 * @return array<mixed>
 	 */
-	public static function sanitizeArray(array $array, string $sanitizationFunction): array
+	public static function sanitizeArray(array $arrayToSanitize, string $sanitizationFunction): array
 	{
 		$sanitized = [];
 
-		foreach ($array as $key => $value) {
+		foreach ($arrayToSanitize as $key => $value) {
 			if (\is_array($value)) {
 				$sanitizedValue = self::sanitizeArray($value, $sanitizationFunction);
 				$sanitized[$key] = $sanitizedValue;
@@ -135,14 +135,14 @@ trait ObjectHelperTrait
 	/**
 	 * Convert string from kebab to camel case
 	 *
-	 * @param string $convert    String to convert.
+	 * @param string $stringToConvert    String to convert.
 	 * @param string $separator Separator to use for conversion.
 	 *
 	 * @return string
 	 */
-	public static function kebabToCamelCase(string $convert, string $separator = '-'): string
+	public static function kebabToCamelCase(string $stringToConvert, string $separator = '-'): string
 	{
-		return \lcfirst(\str_replace($separator, '', \ucwords($convert, $separator)));
+		return \lcfirst(\str_replace($separator, '', \ucwords($stringToConvert, $separator)));
 	}
 
 	/**

--- a/src/Helpers/ObjectHelperTrait.php
+++ b/src/Helpers/ObjectHelperTrait.php
@@ -38,29 +38,29 @@ trait ObjectHelperTrait
 	/**
 	 * Check if json is valid
 	 *
-	 * @param string $string String to check.
+	 * @param string $check String to check.
 	 *
 	 * @return bool
 	 */
-	public static function isJson(string $string): bool
+	public static function isJson(string $check): bool
 	{
-		\json_decode($string);
+		\json_decode($check);
 		return (\json_last_error() === \JSON_ERROR_NONE);
 	}
 
 	/**
 	 * Flatten multidimensional array.
 	 *
-	 * @param array<mixed> $array Multidimensional array.
+	 * @param array<mixed> $flatten Multidimensional array to flatten.
 	 *
 	 * @return array<mixed>
 	 */
-	public static function flattenArray(array $array): array
+	public static function flattenArray(array $flatten): array
 	{
 		$output = [];
 
 		\array_walk_recursive(
-			$array,
+			$flatten,
 			function ($a) use (&$output) {
 				if (!empty($a)) {
 					$output[] = $a;
@@ -121,13 +121,13 @@ trait ObjectHelperTrait
 	/**
 	 * Convert string from camel to kebab case
 	 *
-	 * @param string $string String to convert.
+	 * @param string $convert String to convert.
 	 *
 	 * @return string
 	 */
-	public static function camelToKebabCase(string $string): string
+	public static function camelToKebabCase(string $convert): string
 	{
-		$output = \ltrim(\mb_strtolower((string)\preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $string)), '-');
+		$output = \ltrim(\mb_strtolower((string)\preg_replace('/[A-Z]([A-Z](?![a-z]))*/', '-$0', $convert)), '-');
 		$output = \str_replace(['_', ' '], '-', $output);
 		return \str_replace('--', '-', $output);
 	}
@@ -135,14 +135,14 @@ trait ObjectHelperTrait
 	/**
 	 * Convert string from kebab to camel case
 	 *
-	 * @param string $string    String to convert.
+	 * @param string $convert    String to convert.
 	 * @param string $separator Separator to use for conversion.
 	 *
 	 * @return string
 	 */
-	public static function kebabToCamelCase(string $string, string $separator = '-'): string
+	public static function kebabToCamelCase(string $convert, string $separator = '-'): string
 	{
-		return \lcfirst(\str_replace($separator, '', \ucwords($string, $separator)));
+		return \lcfirst(\str_replace($separator, '', \ucwords($convert, $separator)));
 	}
 
 	/**
@@ -170,15 +170,15 @@ trait ObjectHelperTrait
 	 *
 	 * @link https://stackoverflow.com/a/15198925/629127
 	 *
-	 * @param string $string JSON string to validate.
+	 * @param string $manifest JSON string to validate.
 	 *
 	 * @throws InvalidManifest Error in the case json file has errors.
 	 *
 	 * @return array<string, mixed> Parsed JSON string into an array.
 	 */
-	public static function parseManifest(string $string): array
+	public static function parseManifest(string $manifest): array
 	{
-		$result = \json_decode($string, true);
+		$result = \json_decode($manifest, true);
 
 		switch (\json_last_error()) {
 			case \JSON_ERROR_NONE:

--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -44,12 +44,12 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 * Constructs object and inserts prefixes from composer.
 	 *
 	 * @param array<string, mixed> $psr4Prefixes Composer's ClassLoader psr4Prefixes. $ClassLoader->getPsr4Prefixes().
-	 * @param string $namespace Projects namespace.
+	 * @param string $projectNamespace Projects namespace.
 	 */
-	public function __construct(array $psr4Prefixes, string $namespace)
+	public function __construct(array $psr4Prefixes, string $projectNamespace)
 	{
 		$this->psr4Prefixes = $psr4Prefixes;
-		$this->namespace = $namespace;
+		$this->namespace = $projectNamespace;
 	}
 
 	/**

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -191,15 +191,15 @@ class Autowiring
 	/**
 	 * Returns all classes in namespace.
 	 *
-	 * @param string $namespace Name of namespace.
+	 * @param string $namespaceName Name of namespace.
 	 * @param array<string, mixed> $psr4Prefixes Array of psr-4 compliant namespaces and their accompanying folders.
 	 *
 	 * @return string[]
 	 */
-	private function getClassesInNamespace(string $namespace, array $psr4Prefixes): array
+	private function getClassesInNamespace(string $namespaceName, array $psr4Prefixes): array
 	{
 		$classes = [];
-		$namespaceWithSlash = "{$namespace}\\";
+		$namespaceWithSlash = "{$namespaceName}\\";
 		$pathToNamespace = $psr4Prefixes[$namespaceWithSlash][0] ?? '';
 
 		if (!\is_dir($pathToNamespace)) {
@@ -213,7 +213,7 @@ class Autowiring
 			}
 
 			if (\preg_match('/^[A-Z]{1}[A-Za-z0-9]+\.php/', $file->getFileName())) {
-				$classes[] = $this->getNamespaceFromFilepath($file->getPathname(), $namespace, $pathToNamespace);
+				$classes[] = $this->getNamespaceFromFilepath($file->getPathname(), $namespaceName, $pathToNamespace);
 			}
 		}
 

--- a/src/Menu/AbstractMenu.php
+++ b/src/Menu/AbstractMenu.php
@@ -59,7 +59,7 @@ abstract class AbstractMenu implements ServiceInterface, MenuPositionsInterface
 		$cssClassModifiers = '',
 		bool $outputMenu = true
 	) {
-		// Check to see if any css modifiers were supplied.
+		// Check to see if any CSS modifiers were supplied.
 		$modifiers = '';
 
 		if (!empty($cssClassModifiers)) {

--- a/src/Menu/AbstractMenu.php
+++ b/src/Menu/AbstractMenu.php
@@ -48,16 +48,16 @@ abstract class AbstractMenu implements ServiceInterface, MenuPositionsInterface
 	 * @param string $parentClass This string will add class to only top level list element.
 	 * @param string $cssClassModifiers Provide either a string or array of values to apply extra classes
 	 *                                   to the <ul> but not the <li's>.
-	 * @param bool   $echo Echo the menu.
+	 * @param bool   $outputMenu Echo the menu.
 	 *
-	 * @return string|false|void Menu output if $echo is false, false if there are no items or no menu was found.
+	 * @return string|false|void Menu output if $outputMenu is false, false if there are no items or no menu was found.
 	 */
 	public static function bemMenu(
 		string $location = 'main_menu',
 		string $cssClassPrefix = 'main-menu',
 		string $parentClass = '',
 		$cssClassModifiers = '',
-		bool $echo = true
+		bool $outputMenu = true
 	) {
 		// Check to see if any css modifiers were supplied.
 		$modifiers = '';
@@ -74,7 +74,7 @@ abstract class AbstractMenu implements ServiceInterface, MenuPositionsInterface
 			'theme_location' => $location,
 			'container' => false,
 			'items_wrap' => '<ul class="' . $parentClass . ' ' . $cssClassPrefix . ' ' . $modifiers . '">%3$s</ul>',
-			'echo' => $echo,
+			'echo' => $outputMenu,
 			'walker' => new BemMenuWalker($cssClassPrefix),
 		];
 

--- a/src/Rest/CallableFieldInterface.php
+++ b/src/Rest/CallableFieldInterface.php
@@ -18,7 +18,7 @@ interface CallableFieldInterface
 	/**
 	 * Method that returns rest response for custom fields get_callback callable
 	 *
-	 * @param object|array<string, mixed> $object Post or custom post type object of the request.
+	 * @param object|array<string, mixed> $postObject Post or custom post type object of the request.
 	 * @param string       $attr Rest field/attr string identifier from the second parameter
 	 *                           of your register_rest_field() declaration.
 	 * @param object       $request Full request payload - as a WP_REST_Request object.
@@ -29,5 +29,5 @@ interface CallableFieldInterface
 	 *               is already an instance, WP_HTTP_Response, otherwise
 	 *               returns a new WP_REST_Response instance.
 	 */
-	public function fieldCallback($object, string $attr, object $request, string $objectType);
+	public function fieldCallback($postObject, string $attr, object $request, string $objectType);
 }

--- a/src/Rest/Fields/FieldExample.php
+++ b/src/Rest/Fields/FieldExample.php
@@ -55,7 +55,7 @@ class FieldExample extends AbstractField implements CallableFieldInterface
 	/**
 	 * Method that returns rest response
 	 *
-	 * @param object|array $object Post or custom post type object of the request.
+	 * @param object|array $postObject Post or custom post type object of the request.
 	 * @param string       $attr Rest field/attr string identifier from the second parameter
 	 *                           of your register_rest_field() declaration.
 	 * @param object       $request Full request payload – as a WP_REST_Request object.
@@ -66,7 +66,7 @@ class FieldExample extends AbstractField implements CallableFieldInterface
 	 *               is already an instance, WP_HTTP_Response, otherwise
 	 *               returns a new WP_REST_Response instance.
 	 */
-	public function fieldCallback($object, string $attr, object $request, string $objectType)
+	public function fieldCallback($postObject, string $attr, object $request, string $objectType)
 	{
 		return \rest_ensure_response('output data');
 	}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -25,7 +25,7 @@ function buildTestBlocks() {
  *
  * @return MockInterface
  */
-function mock(string $class): MockInterface
+function mock(string $classname): MockInterface
 {
-	return Mockery::mock($class);
+	return Mockery::mock($classname);
 }

--- a/tests/Unit/Columns/TaxonomyColumnsTest.php
+++ b/tests/Unit/Columns/TaxonomyColumnsTest.php
@@ -13,7 +13,7 @@ test('Hooks are registered for the custom taxonomy columns', function() {
 			return [];
 		}
 
-		public function renderColumnContent(string $_string, string $columnName, int $termId): string
+		public function renderColumnContent(string $columnName, int $termId): string
 		{
 			return 'content';
 		}

--- a/tests/Unit/Columns/TaxonomyColumnsTest.php
+++ b/tests/Unit/Columns/TaxonomyColumnsTest.php
@@ -13,7 +13,7 @@ test('Hooks are registered for the custom taxonomy columns', function() {
 			return [];
 		}
 
-		public function renderColumnContent(string $string, string $columnName, int $termId): string
+		public function renderColumnContent(string $_string, string $columnName, int $termId): string
 		{
 			return 'content';
 		}


### PR DESCRIPTION
# Description

Fixes #281 in all methods in Eightshift Libs, public, private and protected alike.

Note that in AbstractTaxonomyColumns and TaxonomyColumnsTest the variable is renamed to _string as there is no useful documentation about what that parameter is, and no implementation of this method exists in Eightshift Libs, so I can't check what's an appropriate name.

Also note that I have renamed them more aggressively than actually required, e.g. I renamed `$array`, which theoretically isn't reserved as a variable name.

# Linked documentation PR

https://www.php.net/manual/en/reserved.keywords.php
https://www.php.net/manual/en/reserved.other-reserved-words.php
