### PR TITLE
Fix the check that should allow only custom blocks to be added

### DIFF
--- a/src/Blocks/AbstractBlocks.php
+++ b/src/Blocks/AbstractBlocks.php
@@ -143,7 +143,7 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 			return true;
 		}
 
-		if (\gettype($allowedBlockTypes) === 'boolean') {
+		if (!\is_bool($allowedBlockTypes)) {
 			return $allowedBlockTypes;
 		}
 


### PR DESCRIPTION
Currently when you add 

```php
\add_filter('allowed_block_types_all', [ $this, 'getAllBlocksList' ], 10, 2);
```

All the blocks will be shown (core and es ones).

This PR attempts to fix this.

I'd love it if people could just test this and see if this will affect their projects in any way.