### PR TITLE
Add lock false to composer json config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
+    "lock": false,
     "sort-packages": true,
     "optimize-autoloader": true,
     "process-timeout": 2000,


### PR DESCRIPTION
# Description

Add `lock: false` to composer.json config to prevent composer.lock from creating.


Closes #283