### PR TITLE
Boolean logic allowed blocks -- fix allowed_block_types_all filter callback

### DIFF
--- a/src/Blocks/AbstractBlocks.php
+++ b/src/Blocks/AbstractBlocks.php
@@ -88,18 +88,20 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 	}
 
 	/**
-	 * Get all blocks with full block name.
+	 * Get all allowed blocks with the full block name.
 	 *
-	 * Used to limit what blocks are going to be used in your project using allowed_block_types_all filter.
+	 * Used to define blocks that are going to be used in your project using allowed_block_types_all filter.
+	 * The function behaves similar to the native function except that it appends all the project blocks to
+	 * the array of block type slugs sent as the first attribute.
 	 *
 	 * @hook allowed_block_types_all Available from WP 5.8.
 	 *
 	 * @param bool|string[] $allowedBlockTypes Array of block type slugs, or boolean to enable/disable all.
 	 * @param WP_Block_Editor_Context $blockEditorContext The current block editor context.
 	 *
-	 * @return bool|string[] Boolean if you want to disallow or allow all blocks, or a list of allowed blocks.
+	 * @return bool|string[] Boolean if you want to disallow or allow all blocks, or a list of all allowed blocks.
 	 */
-	public function getAllBlocksList($allowedBlockTypes, WP_Block_Editor_Context $blockEditorContext)
+	public function getAllAllowedBlocksList($allowedBlockTypes, WP_Block_Editor_Context $blockEditorContext)
 	{
 		// Allow forms to be used correctly.
 		if (
@@ -129,6 +131,25 @@ abstract class AbstractBlocks implements ServiceInterface, RenderableBlockInterf
 		$allowedBlockTypes[] = 'core/template';
 
 		return $allowedBlockTypes;
+	}
+
+	/**
+	 * Get the default list of blocks with the full block name attribute that are defined in the project.
+	 *
+	 * Used to limit what blocks are going to be used in your project using allowed_block_types_all filter.
+	 * It is most commonly used directly as a callback for allowed_block_types_all filter.
+	 * The first parameter doesn't have any influence on what the function returns.
+	 *
+	 * @hook allowed_block_types_all Available from WP 5.8.
+	 *
+	 * @param bool|string[] $allowedBlockTypes Doesn't have any influence on what function returns.
+	 * @param WP_Block_Editor_Context $blockEditorContext The current block editor context.
+	 *
+	 * @return string[] The default list of blocks defined in the project.
+	 */
+	public function getAllBlocksList($allowedBlockTypes, WP_Block_Editor_Context $blockEditorContext)
+	{
+		return $this->getAllAllowedBlocksList([], $blockEditorContext);
 	}
 
 	/**

--- a/tests/Datasets/Arguments.php
+++ b/tests/Datasets/Arguments.php
@@ -9,7 +9,7 @@ dataset('errorStringArguments', [
 	new class{}
 ]);
 
-dataset('getAllBlocksListAllTypesArguments', [
+dataset('getAllAllowedBlocksListAllTypesArguments', [
 	true,
 	false,
 	[[]],

--- a/tests/Unit/Blocks/BlocksExampleTest.php
+++ b/tests/Unit/Blocks/BlocksExampleTest.php
@@ -70,50 +70,9 @@ test('Asserts that getAllBlocksListOld will return only projects blocks for olde
 	expect($list)
 		->toBeArray()
 		->not->toContain('core/paragraph')
-		->toContain('eightshift-boilerplate/button')
-		->toContain('core/block')
-		->toContain('core/template');
+		->toContain('eightshift-boilerplate/button', 'core/block', 'core/template');
 });
 
-test('Asserts that getAllBlocksList will return true if post type is eightshift-forms for WP 5.8.', function () {
-
-	$blockContext = mock('WP_Block_Editor_Context');
-	$blockContext->post = mock('WP_Post');
-	$blockContext->post->post_type = 'eightshift-forms';
-
-	$blocks = $this->mock->getAllBlocksList([], $blockContext);
-
-	expect($blocks)
-		->toBeTrue();
-});
-
-test('Asserts that getAllBlocksList first argument is bool and return first argument for WP 5.8.', function () {
-
-	$blockContext = mock('WP_Block_Editor_Context');
-	$blockContext->post = mock('WP_Post');
-	$blockContext->post->post_type = 'post';
-
-	$blocks = $this->mock->getAllBlocksList(true, $blockContext);
-
-	expect($blocks)->toBeTrue();
-
-	$blocks = $this->mock->getAllBlocksList(false, $blockContext);
-
-	expect($blocks)->toBeFalse();
-});
-
-test('Asserts that getAllBlocksList first argument is not bool and return first argument for WP 5.8.', function () {
-
-	$blockContext = mock('WP_Block_Editor_Context');
-	$blockContext->post = mock('WP_Post');
-	$blockContext->post->post_type = 'post';
-
-	$blocks = $this->mock->getAllBlocksList(['test'], $blockContext);
-
-	expect($blocks)
-		->toBeArray()
-		->toContain('test');
-});
 
 test('Asserts that getAllBlocksList with all types of arguments throw error for older WP versions.', function ($argument) {
 
@@ -123,9 +82,10 @@ test('Asserts that getAllBlocksList with all types of arguments throw error for 
 
 	$this->mock->getAllBlocksList($argument, $post);
 })->throws(\TypeError::class)
-->with('getAllBlocksListAllTypesArguments');
+->with('getAllAllowedBlocksListAllTypesArguments');
 
-test('Asserts that getAllBlocksList will return projects blocks and passed blocks for WP 5.8.', function () {
+test('Asserts that getAllBlocksList is not influence by the first parameter', function ($argument) {
+
 	$blockContext = mock(WP_Block_Editor_Context::class);
 	$blockContext->post = null;
 
@@ -133,14 +93,85 @@ test('Asserts that getAllBlocksList will return projects blocks and passed block
 
 	Components::setConfigFlags();
 
-	$blocks = $this->mock->getAllBlocksList(['test'], $blockContext);
+	$blocks = $this->mock->getAllBlocksList($argument, $blockContext);
+
+	expect($blocks)
+		->toBeArray()
+		->not->toContain('core/paragraph')
+		->not->toContain('test')
+		->toContain('eightshift-boilerplate/button', 'eightshift-boilerplate/heading', 'core/block', 'core/template');
+
+})->with('getAllAllowedBlocksListAllTypesArguments');
+
+test('Asserts that getAllAllowedBlocksList will return true if post type is eightshift-forms for WP 5.8.', function () {
+
+	$blockContext = mock('WP_Block_Editor_Context');
+	$blockContext->post = mock('WP_Post');
+	$blockContext->post->post_type = 'eightshift-forms';
+
+	$blocks = $this->mock->getAllAllowedBlocksList([], $blockContext);
+
+	expect($blocks)
+		->toBeTrue();
+});
+
+test('Asserts that getAllAllowedBlocksList first argument is bool and return first argument for WP 5.8.', function () {
+
+	$blockContext = mock('WP_Block_Editor_Context');
+	$blockContext->post = mock('WP_Post');
+	$blockContext->post->post_type = 'post';
+
+	$blocks = $this->mock->getAllAllowedBlocksList(true, $blockContext);
+
+	expect($blocks)->toBeTrue();
+
+	$blocks = $this->mock->getAllAllowedBlocksList(false, $blockContext);
+
+	expect($blocks)->toBeFalse();
+});
+
+test('Asserts that getAllAllowedBlocksList first argument is not bool and returns list with appended project blocks to the first argument', function () {
+
+	$blockContext = mock('WP_Block_Editor_Context');
+	$blockContext->post = mock('WP_Post');
+	$blockContext->post->post_type = 'post';
+
+	buildTestBlocks();
+
+	$blocks = $this->mock->getAllAllowedBlocksList(['test'], $blockContext);
+
+	expect($blocks)
+		->toBeArray()
+		->not->toContain('core/paragraph')
+		->toContain('test', 'eightshift-boilerplate/button', 'core/block', 'core/template');
+});
+
+test('Asserts that getAllAllowedBlocksList with all types of arguments throw error for older WP versions.', function ($argument) {
+
+	Functions\when('is_wp_version_compatible')->justReturn(false);
+
+	$post = mock('WP_Post');
+
+	$this->mock->getAllAllowedBlocksList($argument, $post);
+})->throws(\TypeError::class)
+->with('getAllAllowedBlocksListAllTypesArguments');
+
+test('Asserts that getAllAllowedBlocksList will return projects blocks and passed blocks for WP 5.8.', function () {
+	$blockContext = mock(WP_Block_Editor_Context::class);
+	$blockContext->post = null;
+
+	buildTestBlocks();
+
+	Components::setConfigFlags();
+
+	$blocks = $this->mock->getAllAllowedBlocksList(['test'], $blockContext);
 
 	expect($blocks)
 		->toBeArray()
 		->toContain('eightshift-boilerplate/button', 'eightshift-boilerplate/heading', 'core/block', 'core/template', 'test');
 });
 
-test('Asserts that getAllBlocksList will return only projects blocks for WP 5.8.', function () {
+test('Asserts that getAllAllowedBlocksList will return only projects blocks for WP 5.8.', function () {
 	$blockContext = mock(WP_Block_Editor_Context::class);
 	$blockContext->post = null;
 
@@ -148,7 +179,7 @@ test('Asserts that getAllBlocksList will return only projects blocks for WP 5.8.
 
 	Components::setConfigFlags();
 
-	$blocks = $this->mock->getAllBlocksList([], $blockContext);
+	$blocks = $this->mock->getAllAllowedBlocksList([], $blockContext);
 
 	expect($blocks)
 		->toBeArray()


### PR DESCRIPTION
# Description
- adjusted the getAllBlocksList so that it can be used directly with the allowed_block_types_all filter
- added the main functionality to getAllAllowedBlocksList
- adjust the tests accordingly
