### PR TITLE
Return empty string in tests in getAssetsManifestItem

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           dependency-versions: highest
 
       - name: Run coverage generation
-        run: composer test:coverage -q # We don't need an output for coverage, codecov will do that.
+        run: composer test:coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/src/Manifest/AbstractManifest.php
+++ b/src/Manifest/AbstractManifest.php
@@ -73,7 +73,7 @@ abstract class AbstractManifest implements ServiceInterface, ManifestInterface
 	 */
 	public function getAssetsManifestItem(string $key): string
 	{
-		if (\defined('WP_CLI')) {
+		if (\defined('WP_CLI') || getenv('ES_TEST')) {
 			return '';
 		}
 

--- a/tests/Unit/Columns/TaxonomyColumnsTest.php
+++ b/tests/Unit/Columns/TaxonomyColumnsTest.php
@@ -13,7 +13,7 @@ test('Hooks are registered for the custom taxonomy columns', function() {
 			return [];
 		}
 
-		public function renderColumnContent(string $columnName, int $termId): string
+		public function renderColumnContent(string $columnOutput, string $columnName, int $termId): string
 		{
 			return 'content';
 		}

--- a/tests/Unit/Manifest/ManifestExampleTest.php
+++ b/tests/Unit/Manifest/ManifestExampleTest.php
@@ -42,10 +42,16 @@ test('Manifest example contains correct manifest file path', function () {
 });
 
 test('Setting manifest data manually works', function() {
+	/** getAssetsManifestItem returns an empty string when ES_TEST is set, to prevent issues with automatically parsing manifest data
+	*	during tests. However, when setting manifest data manually, these issues aren't present, so the ES_TEST environment variable
+	*	is temporarily unset during this test.
+	*/
+	putenv('ES_TEST');
 	$this->example->setAssetsManifestRaw();
 
 	$item = $this->example->getAssetsManifestItem('application.css');
 
 	$this->assertIsString($item);
 	$this->assertSame('https://example.com/wp-content/themes/eightshift-boilerplate/public/application.css', $item);
+	putenv('ES_TEST=true');
 });


### PR DESCRIPTION
# Description

Fixes conditions for testing in `getAssetsManifestItem`.
