### PR TITLE
updating fix for php8 param naming

### DIFF
--- a/src/Exception/InvalidAutowireDependency.php
+++ b/src/Exception/InvalidAutowireDependency.php
@@ -80,10 +80,11 @@ final class InvalidAutowireDependency extends InvalidArgumentException implement
 		return new InvalidAutowireDependency(
 			\sprintf(
 				/* translators: %s is replaced with the className and interfaceName. */
-				"Found a primitive dependency for %s. Autowire is unable to figure out what value needs to be injected here.
+				"Found a primitive dependency for %s with param %s. Autowire is unable to figure out what value needs to be injected here.
 				Please define the dependency tree for this class manually using \$main->getServiceClasses().
 				See: https://infinum.github.io/eightshift-docs/docs/basics/autowiring#what-if-my-class-has-a-primitive-parameter-string-int-etc-inside-a-constructor-method",
-				$className
+				$className,
+				$param
 			)
 		);
 	}

--- a/src/Exception/InvalidAutowireDependency.php
+++ b/src/Exception/InvalidAutowireDependency.php
@@ -72,10 +72,11 @@ final class InvalidAutowireDependency extends InvalidArgumentException implement
 	 * Throws an exception if we find a primitive dependency on a class that's not been manually built.
 	 *
 	 * @param string $className Class name we're looking for.
+	 * @param string $param Parameter name that is causing the issue.
 	 *
 	 * @return static
 	 */
-	public static function throwPrimitiveDependencyFound(string $className): InvalidAutowireDependency
+	public static function throwPrimitiveDependencyFound(string $className, string $param): InvalidAutowireDependency
 	{
 		return new InvalidAutowireDependency(
 			\sprintf(

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -129,7 +129,7 @@ class Autowiring
 		// Ignore dependencies for autowire and main class.
 		$ignorePaths = \array_flip([
 			'psr4Prefixes',
-			'namespace',
+			'projectNamespace',
 		]);
 
 		$dependencyTree = [];
@@ -153,7 +153,7 @@ class Autowiring
 				// to check if this parameter has a default value or not (so we need to throw an exception regardless).
 				// See: https://www.php.net/manual/en/class.reflectionnamedtype.php.
 				if ($isBuiltin && !isset($ignorePaths[$reflParam->getName()])) {
-					throw InvalidAutowireDependency::throwPrimitiveDependencyFound($relevantClass);
+					throw InvalidAutowireDependency::throwPrimitiveDependencyFound($relevantClass, $reflParam->getName());
 				}
 
 				// Keeping PHPStan happy.

--- a/src/Manifest/AbstractManifest.php
+++ b/src/Manifest/AbstractManifest.php
@@ -73,7 +73,7 @@ abstract class AbstractManifest implements ServiceInterface, ManifestInterface
 	 */
 	public function getAssetsManifestItem(string $key): string
 	{
-		if (\defined('WP_CLI') || getenv('ES_TEST')) {
+		if (\defined('WP_CLI') || \getenv('ES_TEST')) {
 			return '';
 		}
 


### PR DESCRIPTION
# Description

- fixing namespace param name for autowiring.
- adding better error msg.