### PR TITLE
PHP issues fixes

### DIFF
--- a/src/Helpers/CssVariablesTrait.php
+++ b/src/Helpers/CssVariablesTrait.php
@@ -772,7 +772,7 @@ trait CssVariablesTrait
 			}
 
 			// Output the custom CSS variable by adding the attribute key + custom object key.
-			$output[] = "--{$internalKey}: ${variableValue};";
+			$output[] = "--{$internalKey}: {$variableValue};";
 		}
 
 		return $output;

--- a/tests/Unit/Helpers/PostTraitTest.php
+++ b/tests/Unit/Helpers/PostTraitTest.php
@@ -42,7 +42,7 @@ beforeEach(function() {
  */
 test('Correct get reading time function', function ($posts) {
   Functions\when('get_the_content')
-    ->alias(function($more_link_text=null, $strip_teaser=false, $postId) use ($posts) {
+    ->alias(function($more_link_text=null, $strip_teaser=false, $postId=null) use ($posts) {
       return $posts[$postId];
     });
 


### PR DESCRIPTION
# Description

Fix deprecated string concatenation in CssVariablesTrait (php 8.2 deprecation), and fix the optional parameters before required in the test alias method for the get_the_content function.

