### PR TITLE
Remove escaping from cliLog calls

### DIFF
--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -208,8 +208,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 			$this->cliLog('Dependency note:', 'B');
 			$this->cliLog(
 				\sprintf(
-					// translators: %s will be replaced with type of item.
-					\esc_html__("We have found that this %s has dependencies, please run these commands also if you don't have it in your project:", 'eightshift-libs'),
+					"We have found that this %s has dependencies, please run these commands also if you don't have it in your project:",
 					$type
 				)
 			);
@@ -245,8 +244,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 			$this->cliLog('Node_modules Note:', 'B');
 			$this->cliLog(
 				\sprintf(
-					// translators: %s will be replaced with type of item.
-					\esc_html__("We have found that this %s has some node_module dependencies, please run these commands also if you don't have it in your project:", 'eightshift-libs'),
+					"We have found that this %s has some node_module dependencies, please run these commands also if you don't have it in your project:",
 					$type
 				)
 			);

--- a/src/Init/InitBlocksCli.php
+++ b/src/Init/InitBlocksCli.php
@@ -152,7 +152,7 @@ class InitBlocksCli extends AbstractCli
 			$this->getIntroText();
 		}
 
-		$this->cliLog(\esc_html__('Creating block editor files:', 'eightshift-libs'), 'C');
+		$this->cliLog('Creating block editor files:', 'C');
 
 		$commands = static::COMMANDS;
 


### PR DESCRIPTION
# Description

This PR fixes the issue in #325 

Luckily there were only two files where `esc_html__` was used. In other files, I've left it because those are mostly examples and abstract classes or exception classes.

