### PR TITLE
Fix phpcs issues and geolocation errors

### DIFF
--- a/src/Geolocation/GeolocationExample.php
+++ b/src/Geolocation/GeolocationExample.php
@@ -42,7 +42,7 @@ class GeolocationExample extends AbstractGeolocation
 	 */
 	public function getGeolocationPharLocation(): string
 	{
-		return __DIR__ . \DIRECTORY_SEPARATOR . 'geoip2.phar';;
+		return __DIR__ . \DIRECTORY_SEPARATOR . 'geoip2.phar';
 	}
 
 	/**
@@ -52,6 +52,6 @@ class GeolocationExample extends AbstractGeolocation
 	 */
 	public function getGeolocationDbLocation(): string
 	{
-		return __DIR__ . \DIRECTORY_SEPARATOR . 'GeoLite2-Country.mmdb';;
+		return __DIR__ . \DIRECTORY_SEPARATOR . 'GeoLite2-Country.mmdb';
 	}
 }

--- a/tests/Unit/Geolocation/GeolocationExampleTest.php
+++ b/tests/Unit/Geolocation/GeolocationExampleTest.php
@@ -22,10 +22,16 @@ test('getGeolocationCookieName will return correct cookie name', function () {
 	expect($this->geolocation->getGeolocationCookieName())->toEqual('%cookie_name%');
 });
 
-test('getGeolocationPharLocation will throw Exception if file is missing in path', function () {
-	$this->geolocation->getGeolocationPharLocation();
-})->throws(Exception::class);
+test('getGeolocationPharLocation will return the location of the geiop2.phar file', function () {
+	$reflection = new \ReflectionClass(GeolocationExample::class);
+	$path = dirname($reflection->getFileName());
 
-test('getGeolocationDbLocation will throw Exception if file is missing in path', function () {
-	$this->geolocation->getGeolocationDbLocation();
-})->throws(Exception::class);
+	expect($this->geolocation->getGeolocationPharLocation())->toEqual($path . \DIRECTORY_SEPARATOR . 'geoip2.phar');
+});
+
+test('getGeolocationDbLocation will return the location of the Geolite2-Country.mmdb file', function () {
+	$reflection = new \ReflectionClass(GeolocationExample::class);
+	$path = dirname($reflection->getFileName());
+
+	expect($this->geolocation->getGeolocationDbLocation())->toEqual($path . \DIRECTORY_SEPARATOR . 'GeoLite2-Country.mmdb');
+});


### PR DESCRIPTION
# Description

Geolocation wasn't handling errors properly which caused some issues with the tests. Also, I couldn't reproduce the 'headers already sent' errors in the error log, so output buffering was also removed (that caused some minor issues in the tests for me as well).

The tests have been cleaned up a bit (some tests didn't really make sense, and some didn't test the code properly). Not sure if the code coverage was increased or not.

Also fixed the phpcs errors. Not sure how these got merged tbh.