### PR TITLE
Fix WP-CLI command for generating patterns

### DIFF
--- a/src/BlockPatterns/BlockPatternCli.php
+++ b/src/BlockPatterns/BlockPatternCli.php
@@ -36,7 +36,7 @@ class BlockPatternCli extends AbstractCli
 	 */
 	public function getCommandName(): string
 	{
-		return 'create block-pattern';
+		return 'create-block-pattern';
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes wrong WP-CLI command name for generating block patterns. Closes #346 
