### PR TITLE
CLI commands default block variation update

### DIFF
--- a/src/Blocks/UseVariationCli.php
+++ b/src/Blocks/UseVariationCli.php
@@ -47,7 +47,7 @@ class UseVariationCli extends AbstractBlocksCli
 	public function getDefaultArgs(): array
 	{
 		return [
-			'name' => 'button-block',
+			'name' => 'card-simple',
 		];
 	}
 
@@ -76,7 +76,7 @@ class UseVariationCli extends AbstractBlocksCli
 				## EXAMPLES
 
 				# Copy variation by name:
-				$ wp {$this->commandParentName} {$this->getCommandParentName()} {$this->getCommandName()} --name='button-block'
+				$ wp {$this->commandParentName} {$this->getCommandParentName()} {$this->getCommandName()} --name='card-simple'
 
 				## RESOURCES
 

--- a/src/Init/InitBlocksCli.php
+++ b/src/Init/InitBlocksCli.php
@@ -87,10 +87,10 @@ class InitBlocksCli extends AbstractCli
 		],
 		UseVariationCli::class => [
 			'default' => [
-				'button-block'
+				'card-simple'
 			],
 			'test' => [
-				'button-block'
+				'card-simple'
 			]
 		]
 	];


### PR DESCRIPTION
# Description

Changes the default args for init blocks and use block variation CLI commands, as the `button-block` variation will not exist anymore in FE libs v8.0.

# Screenshots / Videos

\-

# Linked documentation PR

\-