### PR TITLE
Wrong variable denotation

### DIFF
--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -162,7 +162,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 				$path = $this->getShortenCliPathOutput($destination);
 				$itemName = \ucfirst($item);
 
-				$msgTitle = "{$itemName} ${type} added";
+				$msgTitle = "{$itemName} {$type} added";
 
 				if ($groupOutput) {
 					$this->cliLog("%g│ %n{$msgTitle} %w({$path})%n", 'mixed');
@@ -171,7 +171,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 						$path,
 						'',
 						'Run %Unpm start%n to make sure everything works correctly.'
-					]), 'success', "{$itemName} ${type} added");
+					]), 'success', "{$itemName} {$type} added");
 				}
 
 				$checkDependency = $args['checkDependency'] ?? true;
@@ -187,7 +187,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 				if ($groupOutput) {
 					$this->cliLog("%g│ %n{$type} created %w({$path})%n", 'mixed');
 				} else {
-					$this->cliLogAlert($path, 'success', "${type} added");
+					$this->cliLogAlert($path, 'success', "{$type} added");
 				}
 			}
 		}

--- a/src/Cli/AbstractCli.php
+++ b/src/Cli/AbstractCli.php
@@ -369,9 +369,9 @@ abstract class AbstractCli implements CliInterface
 			$path = $this->getShortenCliPathOutput($destinationFile);
 
 			if ($skipExisting) {
-				$this->cliLogAlert($path, 'success', "'${fileName}' renamed");
+				$this->cliLogAlert($path, 'success', "'{$fileName}' renamed");
 			} else {
-				$this->cliLogAlert($path, 'success', "'${fileName}' created");
+				$this->cliLogAlert($path, 'success', "'{$fileName}' created");
 			}
 		}
 


### PR DESCRIPTION
# Description

Fixed "Using ${var} in strings is deprecated, use {$var} instead" notice
