### PR TITLE
Update libs with wpcs 3 changes [beta]

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -63,8 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version:
-          - ["7.4", "8.0", "8.1", "8.2"]
+        php-version: ["7.4", "8.0", "8.1", "8.2"]
         dependencies:
           - "lowest"
           - "highest"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Check file permissions"
         run: |
@@ -40,7 +40,7 @@ jobs:
           coverage: "none"
 
       - name: "Checkout code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Find non-printable ASCII characters (box-drawing characters excluded)"
         run: |
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.4"
+          - ["7.4", "8.0", "8.1", "8.2"]
         dependencies:
           - "lowest"
           - "highest"
@@ -77,14 +77,18 @@ jobs:
           coverage: "xdebug"
 
       - name: "Checkout code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Install dependencies"
         uses: "ramsey/composer-install@v2"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
 
-      - name: "Execute unit tests"
+      - name: "Execute unit tests without coverage"
+        run: "composer run test:unit"
+
+      - name: "Execute unit tests with coverage"
+        if: "${{ env.CODECOV_TOKEN && matrix.php-version == '7.4' && matrix.dependencies == 'highest' }}"
         run: "composer run test:coverage"
 
       - name: "Upload coverage to Codecov"
@@ -113,7 +117,7 @@ jobs:
           coverage: "none"
 
       - name: "Checkout code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Validate Composer configuration"
         run: "composer validate --strict"
@@ -142,7 +146,7 @@ jobs:
           tools: "cs2pr"
 
       - name: "Checkout code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Check adherence to EditorConfig"
         uses: "greut/eclint-action@v0"
@@ -166,7 +170,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@v3"
+        uses: "actions/checkout@v4"
 
       - name: "Check exported files"
         run: |

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -67,7 +67,13 @@ jobs:
         dependencies:
           - "lowest"
           - "highest"
+        allowed_failure: [ false ]
+        # Allow failure on non-released version of PHP.
+        include:
+          - php: '8.3'
+            allowed_failure: true
     runs-on: "ubuntu-latest"
+    continue-on-error: ${{ matrix.allowed_failure }}
     steps:
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -70,7 +70,13 @@ jobs:
         allowed_failure: [ false ]
         # Allow failure on non-released version of PHP.
         include:
-          - php: '8.3'
+          - php: "8.1"
+            dependencies: "lowest"
+            allowed_failure: true
+          - php: "8.2"
+            dependencies: "lowest"
+            allowed_failure: true
+          - php: "8.3"
             allowed_failure: true
     runs-on: "ubuntu-latest"
     continue-on-error: ${{ matrix.allowed_failure }}

--- a/composer.json
+++ b/composer.json
@@ -24,21 +24,21 @@
 		"source": "https://github.com/infinum/eightshift-libs"
 	},
 	"require": {
-		"php": "^7.4",
+		"php": "^7.4 || >=8.0",
 		"ext-dom": "*",
 		"ext-json": "*",
 		"ext-libxml": "*",
 		"php-di/invoker": "^2.3",
-		"php-di/php-di": "^6.3"
+		"php-di/php-di": "^7"
 	},
 	"require-dev": {
-		"captainhook/captainhook": "^5.10",
 		"brain/monkey": "^2.6.1",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-		"infinum/eightshift-coding-standards": "^1.6",
+		"captainhook/captainhook": "^5.10",
+		"dealerdirect/phpcodesniffer-composer-installer": "^v1.0.0",
+		"infinum/eightshift-coding-standards": "2.0.0-beta",
 		"pestphp/pest": "^1.20",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
-		"php-stubs/wordpress-stubs": "^5.9",
+		"php-stubs/wordpress-stubs": "^6.3",
 		"roave/security-advisories": "dev-master",
 		"szepeviktor/phpstan-wordpress": "^1.0.3",
 		"wp-cli/wp-cli": "^2.4",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -24,7 +24,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 
 	<!-- Support only latest 3 WP versions. -->
-	<config name="minimum_supported_wp_version" value="5.6"/>
+	<config name="minimum_supported_wp_version" value="6.0"/>
 
 	<exclude-pattern>/src/CompiledContainer\.php</exclude-pattern>
 
@@ -55,9 +55,26 @@
 		<exclude-pattern>*/src/Cli/*</exclude-pattern>
 	</rule>
 
-	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
-		<exclude-pattern>*/src/**/*Cli.php</exclude-pattern>
-		<exclude-pattern>*/src/Cli/*</exclude-pattern>
+	<!-- Ignore unescaped exceptions. All Eightshift exceptions are escaped. -->
+	<rule ref="Eightshift.Security.ComponentsEscape.ExceptionNotEscaped">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Ignore filesystem alternative functions. -->
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_mkdir">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.WP.AlternativeFunctions.unlink_unlink">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_fopen">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_fwrite">
+		<severity>0</severity>
+	</rule>
+	<rule ref="WordPress.WP.AlternativeFunctions.file_system_operations_fclose">
+		<severity>0</severity>
 	</rule>
 
 	<rule ref="Generic.Files.LineLength">

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,7 +13,5 @@ parameters:
 	excludePaths:
 		- src/**/*Example.php
 	ignoreErrors:
-		# Uses func_get_args()
-		- '/^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$/'
 		# Ignore errors about reflection class variable being undefined. Errors are caught.
 		- '/^Variable \$reflectionClass might not be defined\.$/'

--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -56,7 +56,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 			self::cliError(
 				\sprintf(
 					// translators: %s will be replaced with type of item, and shorten cli path.
-					"%s files doesn't exist on this path: `%s`. Please check if you have eightshift-frontend-libs installed.",
+					"%s file doesn't exist on this path: `%s`. Please check if you have eightshift-frontend-libs installed.",
 					$type,
 					$this->getShortenCliPathOutput($source)
 				)
@@ -91,8 +91,16 @@ abstract class AbstractBlocksCli extends AbstractCli
 			);
 		}
 
+		$itemExists = false;
 		foreach ($itemsList as $item) {
-			if (!isset($sourceItems[$item])) {
+			foreach ($sourceItems as $sourceName => $sourceFolder) {
+				if (strpos($sourceName, $item) !== false) {
+					$itemExists = true;
+					break;
+				}
+			}
+
+			if (!$itemExists) {
 				self::cliError(
 					\sprintf(
 						// translators: %s will be replaced with type of item, item name and shorten cli path.
@@ -103,8 +111,6 @@ abstract class AbstractBlocksCli extends AbstractCli
 					)
 				);
 			}
-
-			$source = $sourceItems[$item];
 
 			$fullSource = Components::joinPaths([$source, $item]);
 			$fullDestination = Components::joinPaths([$destination, $item]);

--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -74,18 +74,13 @@ abstract class AbstractBlocksCli extends AbstractCli
 
 		$sourceItems = \array_merge($sourceItems, $sourceItemsPrivate);
 
-		if (($isSingleFolder || $isFile) && isset($sourceItems[$name])) {
-			$sourceItems = [
-				$name => $sourceItems[$name],
-			];
-		}
-
 		if (!$sourceItems) {
 			self::cliError(
 				\sprintf(
-					// translators: %s will be replaced with type of item, and shorten cli path.
-					"%s files doesn't exist on this path: `%s`. Please check if you have eightshift-frontend-libs installed.",
+					// translators: %1$s will be replaced with type of item, %2$s the type and %3$s and shorten cli path.
+					'%1$s %2$s doesn\'t exist on this path: `%3$s`. Please check if you have eightshift-frontend-libs installed.',
 					$type,
+					$isFile ? 'file' : 'folder',
 					$this->getShortenCliPathOutput($source)
 				)
 			);
@@ -93,8 +88,8 @@ abstract class AbstractBlocksCli extends AbstractCli
 
 		$itemExists = false;
 		foreach ($itemsList as $item) {
-			foreach ($sourceItems as $sourceName => $sourceFolder) {
-				if (\strpos($sourceName, $item) !== false) {
+			foreach ($sourceItems as $sourceItem => $sourceFolder) {
+				if (\strpos($sourceItem, $item) !== false) {
 					$itemExists = true;
 					break;
 				}

--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -93,7 +93,14 @@ abstract class AbstractBlocksCli extends AbstractCli
 					$itemExists = true;
 					break;
 				}
+
+				// in the case of folders, we should also check the source folders.
+				if (\strpos($sourceFolder, $item) !== false) {
+					$itemExists = true;
+					break;
+				}
 			}
+
 
 			if (!$itemExists) {
 				self::cliError(

--- a/src/Blocks/AbstractBlocksCli.php
+++ b/src/Blocks/AbstractBlocksCli.php
@@ -94,7 +94,7 @@ abstract class AbstractBlocksCli extends AbstractCli
 		$itemExists = false;
 		foreach ($itemsList as $item) {
 			foreach ($sourceItems as $sourceName => $sourceFolder) {
-				if (strpos($sourceName, $item) !== false) {
+				if (\strpos($sourceName, $item) !== false) {
 					$itemExists = true;
 					break;
 				}

--- a/src/Blocks/UseAssetsCli.php
+++ b/src/Blocks/UseAssetsCli.php
@@ -82,7 +82,7 @@ class UseAssetsCli extends AbstractBlocksCli
 			),
 			Components::getProjectPaths('blocksAssetsSource'),
 			Components::getProjectPaths('blocksAssetsDestination'),
-			'assets',
+			'assets folder',
 			true
 		);
 

--- a/src/Blocks/UseGlobalAssetsCli.php
+++ b/src/Blocks/UseGlobalAssetsCli.php
@@ -82,7 +82,7 @@ class UseGlobalAssetsCli extends AbstractBlocksCli
 			),
 			Components::getProjectPaths('blocksGlobalAssetsSource'),
 			Components::getProjectPaths('blocksGlobalAssetsDestination'),
-			'assets',
+			'assets folder',
 			true
 		);
 

--- a/src/Blocks/UseManifestCli.php
+++ b/src/Blocks/UseManifestCli.php
@@ -81,7 +81,7 @@ class UseManifestCli extends AbstractBlocksCli
 			),
 			Components::getProjectPaths('blocksSource'),
 			Components::getProjectPaths('blocksDestination'),
-			'manifest.json'
+			'file'
 		);
 
 		if (!$groupOutput) {

--- a/src/Blocks/UseStorybookCli.php
+++ b/src/Blocks/UseStorybookCli.php
@@ -87,7 +87,7 @@ class UseStorybookCli extends AbstractBlocksCli
 			),
 			Components::getProjectPaths('blocksStorybookSource'),
 			Components::getProjectPaths('blocksStorybookDestination'),
-			'storybook',
+			'storybook folder',
 			true
 		);
 

--- a/src/Db/DbExport.php
+++ b/src/Db/DbExport.php
@@ -27,7 +27,11 @@ if (!function_exists('dbExport')) {
 
 		// Change execution folder.
 		if (!is_dir($projectRootPath)) {
-			CliHelpers::cliError("Folder doesn't exist on this path: {$projectRootPath}.");
+			$errorClass = new class () {
+				use CliHelpers;
+			};
+
+			$errorClass::cliError("Folder doesn't exist on this path: {$projectRootPath}.");
 		}
 
 		chdir($projectRootPath);

--- a/src/Db/DbImport.php
+++ b/src/Db/DbImport.php
@@ -26,17 +26,21 @@ if (!function_exists('dbImport')) {
 		$from = $args['from'] ?? '';
 		$to = $args['to'] ?? '';
 
+		$errorClass = new class () {
+			use CliHelpers;
+		};
+
 		if (empty($from)) {
-			CliHelpers::cliError("--from parameter is mandatory. Please provide one url key from setup.json file.");
+			$errorClass::cliError("--from parameter is mandatory. Please provide one url key from setup.json file.");
 		}
 
 		if (empty($to)) {
-			CliHelpers::cliError("--to parameter is mandatory. Please provide one url key from setup.json file.");
+			$errorClass::cliError("--to parameter is mandatory. Please provide one url key from setup.json file.");
 		}
 
 		// Check if file exists.
 		if (is_dir($setupFile) && !file_exists($setupFile)) {
-			CliHelpers::cliError("Setup file doesn't exist on this path: {$setupFile}.");
+			$errorClass::cliError("Setup file doesn't exist on this path: {$setupFile}.");
 		}
 
 		// Parse json file to array.
@@ -44,14 +48,14 @@ if (!function_exists('dbImport')) {
 
 		// Check if $data is empty.
 		if (empty($data)) {
-			CliHelpers::cliError("Setup file is empty on this path: {$setupFile}.");
+			$errorClass::cliError("Setup file is empty on this path: {$setupFile}.");
 		}
 
 		// Check if urls key exists.
 		$urls = $data['urls'] ?? [];
 
 		if (empty($urls)) {
-			CliHelpers::cliError('Urls key is missing or empty.');
+			$errorClass::cliError('Urls key is missing or empty.');
 		}
 
 		$fromHost = '';
@@ -59,7 +63,7 @@ if (!function_exists('dbImport')) {
 
 		// Die if from key is missing and not valid.
 		if (!isset($urls[$from]) || empty($urls[$from])) {
-			CliHelpers::cliError("{$from} key is missing or empty in urls.");
+			$errorClass::cliError("{$from} key is missing or empty in urls.");
 		} else {
 			$from = wp_parse_url($urls[$from]);
 			$fromHost = $from['host'];
@@ -71,7 +75,7 @@ if (!function_exists('dbImport')) {
 
 		// Die if to key is missing and not valid.
 		if (!isset($urls[$to]) || empty($urls[$to])) {
-			CliHelpers::cliError("{$to} key is missing or empty in urls.");
+			$errorClass::cliError("{$to} key is missing or empty in urls.");
 		} else {
 			$to = wp_parse_url($urls[$to]);
 			$toHost = $to['host'];

--- a/src/Init/InitBlocksCli.php
+++ b/src/Init/InitBlocksCli.php
@@ -156,7 +156,6 @@ class InitBlocksCli extends AbstractCli
 
 		$this->cliLog("%w╭\n│ %nCreating block editor files", 'mixed');
 
-
 		$commands = static::COMMANDS;
 
 		if ($all) {

--- a/src/Menu/BemMenuWalker.php
+++ b/src/Menu/BemMenuWalker.php
@@ -72,7 +72,7 @@ class BemMenuWalker extends \Walker_Nav_Menu
 		$element,
 		&$children_elements,
 		$max_depth, // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps, PEAR.Functions.ValidDefaultValue.NotAtEnd
-		$depth = 0,
+		$depth,
 		$args, // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps, PEAR.Functions.ValidDefaultValue.NotAtEnd
 		&$output
 	) {

--- a/src/Readme/README.md
+++ b/src/Readme/README.md
@@ -4,8 +4,8 @@ This is the official repository of the {Project name}.
 
 ## Requirements
 
-1. PHP 7.4
-2. Node 12
+1. PHP 7.4 or higher
+2. Node 16+
 3. [Node.js](https://nodejs.org/en/)
 4. [Composer](https://getcomposer.org/)
 5. [(Optional) WP cli](https://wp-cli.org/)

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -13,6 +13,47 @@ use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
 class BaseTest extends TestCase
 {
+	// Preventing dynamic properties deprecation notices in tests.
+	protected $adminEnqueue;
+	protected $blocksEnqueue;
+	protected $blocksExample;
+	protected $cli;
+	protected $example;
+	protected $field;
+	protected $geolocation;
+	protected $geolocationCli;
+	protected $germanIp;
+	protected $hookSuffix;
+	protected $i18n;
+	protected $login;
+	protected $main;
+	protected $manualDepsNoPrimitive;
+	protected $manuallyDefinedDependencies;
+	protected $media;
+	protected $mediaCli;
+	protected $mock;
+	protected $mockFileName;
+	protected $mockHelper;
+	protected $mockLogger;
+	protected $mockMedia;
+	protected $mockPath;
+	protected $mockRequestKey;
+	protected $modifyAdminAppearance;
+	protected $pluginManage;
+	protected $post;
+	protected $projectName;
+	protected $projectNamespace;
+	protected $projectVersion;
+	protected $regenerateWebPMediaCli;
+	protected $route;
+	protected $service;
+	protected $shortcode;
+	protected $themeEnqueue;
+	protected $webPMediaColumnCliMock;
+	protected $webPMediaColumnExampleMock;
+	protected $webPMediaColumnExampleMockColumns;
+	protected $wpRestServer;
+
 	protected MockInterface $wpCliMock;
 
 	protected function set_up()

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -150,6 +150,30 @@ class BaseTest extends TestCase
 		Functions\when('is_wp_version_compatible')->justReturn(true);
 
 		Functions\when('wp_nonce_field')->justReturn('nonce');
+
+		// Mock https://developer.wordpress.org/reference/functions/wp_is_json_media_type/ function
+		Functions\when('wp_is_json_media_type')->alias(function ($mediaType) {
+			static $cache = array();
+
+			if ( ! isset( $cache[ $mediaType ] ) ) {
+				$cache[ $mediaType ] = (bool) preg_match( '/(^|\s|,)application\/([\w!#\$&-\^\.\+]+\+)?json(\+oembed)?($|\s|;|,)/i', $mediaType );
+			}
+
+			return $cache[ $mediaType ];
+		});
+
+		// Mock https://developer.wordpress.org/reference/functions/wp_is_json_request/ function
+		Functions\when('wp_is_json_request')->alias(function () {
+			if ( isset( $_SERVER['HTTP_ACCEPT'] ) && wp_is_json_media_type( $_SERVER['HTTP_ACCEPT'] ) ) {
+				return true;
+			}
+
+			if ( isset( $_SERVER['CONTENT_TYPE'] ) && wp_is_json_media_type( $_SERVER['CONTENT_TYPE'] ) ) {
+				return true;
+			}
+
+			return false;
+		});
 	}
 
 	protected function tear_down()

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -12,7 +12,8 @@ use Mockery\MockInterface;
  *
  * @return void
  */
-function buildTestBlocks() {
+function buildTestBlocks()
+{
 	(new InitBlocksCli('boilerplate'))->__invoke([], []);
 
 	(new BlocksExample())->getBlocksDataFullRaw();

--- a/tests/Unit/Blocks/BlocksExampleTest.php
+++ b/tests/Unit/Blocks/BlocksExampleTest.php
@@ -84,7 +84,7 @@ test('Asserts that getAllBlocksList with all types of arguments throw error for 
 })->throws(\TypeError::class)
 ->with('getAllAllowedBlocksListAllTypesArguments');
 
-test('Asserts that getAllBlocksList is not influence by the first parameter', function ($argument) {
+test('Asserts that getAllBlocksList is not influenced by the first parameter', function ($argument) {
 
 	$blockContext = mock(WP_Block_Editor_Context::class);
 	$blockContext->post = null;

--- a/tests/Unit/Cli/CliHelpersTest.php
+++ b/tests/Unit/Cli/CliHelpersTest.php
@@ -5,5 +5,9 @@ namespace Tests\Unit\Cli;
 use EightshiftLibs\Cli\CliHelpers;
 
 test('cliError wrapper will return a WPCLI error', function () {
-	CliHelpers::cliError('Some random cli error happened');
+	$class = new class {
+		use CliHelpers;
+	};
+
+	$class::cliError('Some random cli error happened');
 })->expectExceptionMessage('Some random cli error happened');

--- a/tests/Unit/Columns/Media/MediaColumnsTest.php
+++ b/tests/Unit/Columns/Media/MediaColumnsTest.php
@@ -27,10 +27,10 @@ test('Hooks are registered for the custom user columns', function() {
 
 	$mockUserColumn->register();
 
-	$this->assertNotFalse(has_filter('manage_media_columns', 'Tests\Unit\Columns\MediaColumnMock->addColumnName()'), 'manage_media_columns filter wasn\'t registered');
+	$this->assertNotFalse(has_filter('manage_upload_columns', 'Tests\Unit\Columns\MediaColumnMock->addColumnName()'), 'manage_upload_columns filter wasn\'t registered');
 	$this->assertNotFalse(has_filter('manage_media_custom_column', 'Tests\Unit\Columns\MediaColumnMock->renderColumnContent()'), 'manage_media_custom_column filter wasn\'t registered');
-	$this->assertNotFalse(has_filter('manage_media_sortable_columns', 'Tests\Unit\Columns\MediaColumnMock->sortAddedColumns()'), 'manage_media_sortable_columns filter wasn\'t registered');
-	$this->assertSame(10, has_filter('manage_media_columns', 'Tests\Unit\Columns\MediaColumnMock->addColumnName()'), 'manage_media_columns filter priority was not correct');
+	$this->assertNotFalse(has_filter('manage_upload_sortable_columns', 'Tests\Unit\Columns\MediaColumnMock->sortAddedColumns()'), 'manage_upload_sortable_columns filter wasn\'t registered');
+	$this->assertSame(10, has_filter('manage_upload_columns', 'Tests\Unit\Columns\MediaColumnMock->addColumnName()'), 'manage_upload_columns filter priority was not correct');
 	$this->assertSame(10, has_filter('manage_media_custom_column', 'Tests\Unit\Columns\MediaColumnMock->renderColumnContent()'), 'manage_media_custom_column filter priority was not correct');
-	$this->assertSame(10, has_filter('manage_media_sortable_columns', 'Tests\Unit\Columns\MediaColumnMock->sortAddedColumns()'), 'manage_media_sortable_columns filter priority was not correct');
+	$this->assertSame(10, has_filter('manage_upload_sortable_columns', 'Tests\Unit\Columns\MediaColumnMock->sortAddedColumns()'), 'manage_upload_sortable_columns filter priority was not correct');
 });

--- a/tests/Unit/Exception/ComponentExceptionTest.php
+++ b/tests/Unit/Exception/ComponentExceptionTest.php
@@ -9,32 +9,37 @@ test('Checks if the throwNotStringOrArray method functions correctly.',
 	function ($argument) {
 		$exceptionObject = ComponentException::throwNotStringOrArray($argument);
 		$type = \gettype($argument);
+		$message = "{$argument} variable is not a string or array but rather {$type}";
 
-		$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of ComponentException class");
-		$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
-		$this->assertSame("{$argument} variable is not a string or array but rather {$type}", $exceptionObject->getMessage(), "Strings for message if item is {$type} do not match!");
+		expect($exceptionObject)->toBeObject()
+			->toBeInstanceOf(ComponentException::class)
+			->toHaveProperty('message')
+			->and($message)
+			->toEqual($exceptionObject->getMessage());
+})
+->with('exceptionArguments');
 
-	})
-	->with('exceptionArguments');
+test('Checks if the throwNotStringOrArray method functions correctly with objects.',
+function () {
 
-	test('Checks if the throwNotStringOrArray method functions correctly with objects.',
-	function () {
+	$object = new stdClass();
+	$exceptionObject = ComponentException::throwNotStringOrArray($object);
 
-		$object = new stdClass();
-		$exceptionObject = ComponentException::throwNotStringOrArray($object);
-
-		$this->assertIsObject($exceptionObject, "The object should be an instance of ComponentException class");
-		$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
-		$this->assertSame('Object couldn\'t be converted to string. Please provide only string or array.', $exceptionObject->getMessage(), "Strings for 'Object couldn't be converted to string' message do not match!");
-
-	});
+	expect($exceptionObject)->toBeObject()
+		->toBeInstanceOf(ComponentException::class)
+		->toHaveProperty('message')
+		->and('Object couldn\'t be converted to string. Please provide only string or array.')
+		->toEqual($exceptionObject->getMessage());
+});
 
 test('Checks if throwUnableToLocateComponent method will return correct response.', function () {
 
 	$component = 'nonexistent';
 	$output = ComponentException::throwUnableToLocateComponent($component);
 
-	$this->assertIsObject($output, "The {$output} should be an instance of ComponentException class");
-	$this->assertObjectHasProperty('message', $output, "Object doesn't contain message attribute");
-	$this->assertSame("Unable to locate component by path: {$component}", $output->getMessage(), "Strings for 'Unable to locate component by path' message do not match!");
+	expect($output)->toBeObject()
+		->toBeInstanceOf(ComponentException::class)
+		->toHaveProperty('message')
+		->and("Unable to locate component by path: {$component}")
+		->toEqual($output->getMessage());
 });

--- a/tests/Unit/Exception/ComponentExceptionTest.php
+++ b/tests/Unit/Exception/ComponentExceptionTest.php
@@ -11,7 +11,7 @@ test('Checks if the throwNotStringOrArray method functions correctly.',
 		$type = \gettype($argument);
 
 		$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of ComponentException class");
-		$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");
+		$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
 		$this->assertSame("{$argument} variable is not a string or array but rather {$type}", $exceptionObject->getMessage(), "Strings for message if item is {$type} do not match!");
 
 	})
@@ -24,7 +24,7 @@ test('Checks if the throwNotStringOrArray method functions correctly.',
 		$exceptionObject = ComponentException::throwNotStringOrArray($object);
 
 		$this->assertIsObject($exceptionObject, "The object should be an instance of ComponentException class");
-		$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");
+		$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
 		$this->assertSame('Object couldn\'t be converted to string. Please provide only string or array.', $exceptionObject->getMessage(), "Strings for 'Object couldn't be converted to string' message do not match!");
 
 	});
@@ -35,6 +35,6 @@ test('Checks if throwUnableToLocateComponent method will return correct response
 	$output = ComponentException::throwUnableToLocateComponent($component);
 
 	$this->assertIsObject($output, "The {$output} should be an instance of ComponentException class");
-	$this->assertObjectHasAttribute('message', $output, "Object doesn't contain message attribute");
+	$this->assertObjectHasProperty('message', $output, "Object doesn't contain message attribute");
 	$this->assertSame("Unable to locate component by path: {$component}", $output->getMessage(), "Strings for 'Unable to locate component by path' message do not match!");
 });

--- a/tests/Unit/Exception/FailedToLoadViewTest.php
+++ b/tests/Unit/Exception/FailedToLoadViewTest.php
@@ -11,8 +11,11 @@ test('Checks if the viewException method will return correct response.', functio
 	$exception = new Exception('Error message');
 
 	$exceptionObject = FailedToLoadView::viewException($uri, $exception);
+	$message = "Could not load the View URI: {$uri}. Reason: {$exception->getMessage()}.";
 
-	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of FailedToLoadView class");
-	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
-	$this->assertSame("Could not load the View URI: {$uri}. Reason: {$exception->getMessage()}.", $exceptionObject->getMessage(), "Strings for exception messages do not match!");
+	expect($exceptionObject)->toBeObject()
+		->toBeInstanceOf(FailedToLoadView::class)
+		->toHaveProperty('message')
+		->and($message)
+		->toEqual($exceptionObject->getMessage());
 });

--- a/tests/Unit/Exception/FailedToLoadViewTest.php
+++ b/tests/Unit/Exception/FailedToLoadViewTest.php
@@ -13,6 +13,6 @@ test('Checks if the viewException method will return correct response.', functio
 	$exceptionObject = FailedToLoadView::viewException($uri, $exception);
 
 	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of FailedToLoadView class");
-	$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");
+	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
 	$this->assertSame("Could not load the View URI: {$uri}. Reason: {$exception->getMessage()}.", $exceptionObject->getMessage(), "Strings for exception messages do not match!");
 });

--- a/tests/Unit/Exception/InvalidBlockTest.php
+++ b/tests/Unit/Exception/InvalidBlockTest.php
@@ -8,18 +8,22 @@ test('Checks if missingBlocksException will return correct response.', function 
 
 	$missingBlocks = InvalidBlock::missingBlocksException();
 
-	$this->assertIsObject($missingBlocks, "The {$missingBlocks} should be an instance of InvalidBlock class");
-	$this->assertObjectHasProperty('message', $missingBlocks, "Object doesn't contain message attribute");
-	$this->assertSame('There are no blocks added in your project.', $missingBlocks->getMessage(), "Strings for message if there are no blocks added to the project do not match!");
+	expect($missingBlocks)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and('There are no blocks added in your project.')
+		->toEqual($missingBlocks->getMessage());
 });
 
 test('Checks if missingComponentsException will return correct response.', function () {
 
 	$missingComponents = InvalidBlock::missingComponentsException();
 
-	$this->assertIsObject($missingComponents);
-	$this->assertObjectHasProperty('message', $missingComponents);
-	$this->assertSame('There are no components added in your project.', $missingComponents->getMessage(), "Strings for message if there are no components added to the project do not match!");
+	expect($missingComponents)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and('There are no components added in your project.')
+		->toEqual($missingComponents->getMessage());
 });
 
 test('Checks if missingNameException will return correct response.', function () {
@@ -27,9 +31,11 @@ test('Checks if missingNameException will return correct response.', function ()
 	$blockPath = 'some/random/path';
 	$missingName = InvalidBlock::missingNameException($blockPath);
 
-	$this->assertIsObject($missingName);
-	$this->assertObjectHasProperty('message', $missingName);
-	$this->assertSame("Block in this path {$blockPath} is missing blockName key in its manifest.json.", $missingName->getMessage(), "Strings for message if blockName key is missing in manifest.json do not match!");
+	expect($missingName)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and("Block in this path {$blockPath} is missing blockName key in its manifest.json.")
+		->toEqual($missingName->getMessage());
 });
 
 test('Checks if missingViewException will return correct response.', function () {
@@ -38,9 +44,11 @@ test('Checks if missingViewException will return correct response.', function ()
 	$blockPath = 'some/random/path';
 	$missingView = InvalidBlock::missingViewException($blockName, $blockPath);
 
-	$this->assertIsObject($missingView);
-	$this->assertObjectHasProperty('message', $missingView);
-	$this->assertSame("Block with this name {$blockName} is missing view template. Template name should be called {$blockName}.php, and it should be located in this path {$blockPath}", $missingView->getMessage(), "Strings for message if block is missing view template do not match!");
+	expect($missingView)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and("Block with this name {$blockName} is missing view template. Template name should be called {$blockName}.php, and it should be located in this path {$blockPath}")
+		->toEqual($missingView->getMessage());
 });
 
 test('Checks if missingRenderViewException will return correct response.', function () {
@@ -48,9 +56,11 @@ test('Checks if missingRenderViewException will return correct response.', funct
 	$blockPath = 'some/random/path';
 	$missingRenderView = InvalidBlock::missingRenderViewException($blockPath);
 
-	$this->assertIsObject($missingRenderView);
-	$this->assertObjectHasProperty('message', $missingRenderView);
-	$this->assertSame("Block view is missing in the provided path. Please check if {$blockPath} is the right path for your block view.", $missingRenderView->getMessage(), "Strings for message if block view is missing provided path do not match!");
+	expect($missingRenderView)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and("Block view is missing in the provided path. Please check if {$blockPath} is the right path for your block view.")
+		->toEqual($missingRenderView->getMessage());
 });
 
 test('Checks if missingSettingsManifestException will return correct response.', function () {
@@ -58,9 +68,11 @@ test('Checks if missingSettingsManifestException will return correct response.',
 	$manifestPath = 'some/random/path';
 	$missingManifestPath = InvalidBlock::missingSettingsManifestException($manifestPath);
 
-	$this->assertIsObject($missingManifestPath);
-	$this->assertObjectHasProperty('message', $missingManifestPath);
-	$this->assertSame("Global blocks settings manifest.json is missing on this location: {$manifestPath}.", $missingManifestPath->getMessage(), "Strings for message if global blocks settings manifest.json is missing do not match!");
+	expect($missingManifestPath)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and("Global blocks settings manifest.json is missing on this location: {$manifestPath}.")
+		->toEqual($missingManifestPath->getMessage());
 });
 
 test('Checks if missingWrapperManifestException will return correct response.', function () {
@@ -68,9 +80,11 @@ test('Checks if missingWrapperManifestException will return correct response.', 
 	$manifestPath = 'some/random/path';
 	$missingManifestPath = InvalidBlock::missingWrapperManifestException($manifestPath);
 
-	$this->assertIsObject($missingManifestPath);
-	$this->assertObjectHasProperty('message', $missingManifestPath);
-	$this->assertSame("Wrapper blocks settings manifest.json is missing on this location: {$manifestPath}.", $missingManifestPath->getMessage(), "Strings for message if wrapper blocks settings manifest.json is missing do not match!");
+	expect($missingManifestPath)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and("Wrapper blocks settings manifest.json is missing on this location: {$manifestPath}.")
+		->toEqual($missingManifestPath->getMessage());
 });
 
 test('Checks if missingComponentManifestException will return correct response.', function () {
@@ -78,9 +92,11 @@ test('Checks if missingComponentManifestException will return correct response.'
 	$manifestPath = 'some/random/path';
 	$missingComponentManifest = InvalidBlock::missingComponentManifestException($manifestPath);
 
-	$this->assertIsObject($missingComponentManifest);
-	$this->assertObjectHasProperty('message', $missingComponentManifest);
-	$this->assertSame("Component manifest.json is missing on this location: {$manifestPath}.", $missingComponentManifest->getMessage(), "Strings for message if component manifest.json is missing do not match!");
+	expect($missingComponentManifest)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and("Component manifest.json is missing on this location: {$manifestPath}.")
+		->toEqual($missingComponentManifest->getMessage());
 });
 
 test('Checks if missingWrapperViewException will return correct response.', function () {
@@ -88,16 +104,20 @@ test('Checks if missingWrapperViewException will return correct response.', func
 	$wrapperPath = 'some/random/path';
 	$missingWrapperView = InvalidBlock::missingWrapperViewException($wrapperPath);
 
-	$this->assertIsObject($missingWrapperView);
-	$this->assertObjectHasProperty('message', $missingWrapperView);
-	$this->assertSame("Wrapper view is missing. Template should be located in this path {$wrapperPath}", $missingWrapperView->getMessage(), "Strings for message if wrapper view is missing do not match!");
+	expect($missingWrapperView)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and("Wrapper view is missing. Template should be located in this path {$wrapperPath}")
+		->toEqual($missingWrapperView->getMessage());
 });
 
 test('Checks if missingNamespaceException will return correct response.', function () {
 
 	$missingNamespace = InvalidBlock::missingNamespaceException();
 
-	$this->assertIsObject($missingNamespace);
-	$this->assertObjectHasProperty('message', $missingNamespace);
-	$this->assertSame('Global Blocks settings manifest.json is missing a key called namespace. This key prefixes all block names.', $missingNamespace->getMessage(), "Strings for message global settings manifest.json is missing a key called namespace do not match!");
+	expect($missingNamespace)->toBeObject()
+		->toBeInstanceOf(InvalidBlock::class)
+		->toHaveProperty('message')
+		->and('Global Blocks settings manifest.json is missing a key called namespace. This key prefixes all block names.')
+		->toEqual($missingNamespace->getMessage());
 });

--- a/tests/Unit/Exception/InvalidBlockTest.php
+++ b/tests/Unit/Exception/InvalidBlockTest.php
@@ -9,7 +9,7 @@ test('Checks if missingBlocksException will return correct response.', function 
 	$missingBlocks = InvalidBlock::missingBlocksException();
 
 	$this->assertIsObject($missingBlocks, "The {$missingBlocks} should be an instance of InvalidBlock class");
-	$this->assertObjectHasAttribute('message', $missingBlocks, "Object doesn't contain message attribute");
+	$this->assertObjectHasProperty('message', $missingBlocks, "Object doesn't contain message attribute");
 	$this->assertSame('There are no blocks added in your project.', $missingBlocks->getMessage(), "Strings for message if there are no blocks added to the project do not match!");
 });
 
@@ -18,7 +18,7 @@ test('Checks if missingComponentsException will return correct response.', funct
 	$missingComponents = InvalidBlock::missingComponentsException();
 
 	$this->assertIsObject($missingComponents);
-	$this->assertObjectHasAttribute('message', $missingComponents);
+	$this->assertObjectHasProperty('message', $missingComponents);
 	$this->assertSame('There are no components added in your project.', $missingComponents->getMessage(), "Strings for message if there are no components added to the project do not match!");
 });
 
@@ -28,7 +28,7 @@ test('Checks if missingNameException will return correct response.', function ()
 	$missingName = InvalidBlock::missingNameException($blockPath);
 
 	$this->assertIsObject($missingName);
-	$this->assertObjectHasAttribute('message', $missingName);
+	$this->assertObjectHasProperty('message', $missingName);
 	$this->assertSame("Block in this path {$blockPath} is missing blockName key in its manifest.json.", $missingName->getMessage(), "Strings for message if blockName key is missing in manifest.json do not match!");
 });
 
@@ -39,7 +39,7 @@ test('Checks if missingViewException will return correct response.', function ()
 	$missingView = InvalidBlock::missingViewException($blockName, $blockPath);
 
 	$this->assertIsObject($missingView);
-	$this->assertObjectHasAttribute('message', $missingView);
+	$this->assertObjectHasProperty('message', $missingView);
 	$this->assertSame("Block with this name {$blockName} is missing view template. Template name should be called {$blockName}.php, and it should be located in this path {$blockPath}", $missingView->getMessage(), "Strings for message if block is missing view template do not match!");
 });
 
@@ -49,7 +49,7 @@ test('Checks if missingRenderViewException will return correct response.', funct
 	$missingRenderView = InvalidBlock::missingRenderViewException($blockPath);
 
 	$this->assertIsObject($missingRenderView);
-	$this->assertObjectHasAttribute('message', $missingRenderView);
+	$this->assertObjectHasProperty('message', $missingRenderView);
 	$this->assertSame("Block view is missing in the provided path. Please check if {$blockPath} is the right path for your block view.", $missingRenderView->getMessage(), "Strings for message if block view is missing provided path do not match!");
 });
 
@@ -59,7 +59,7 @@ test('Checks if missingSettingsManifestException will return correct response.',
 	$missingManifestPath = InvalidBlock::missingSettingsManifestException($manifestPath);
 
 	$this->assertIsObject($missingManifestPath);
-	$this->assertObjectHasAttribute('message', $missingManifestPath);
+	$this->assertObjectHasProperty('message', $missingManifestPath);
 	$this->assertSame("Global blocks settings manifest.json is missing on this location: {$manifestPath}.", $missingManifestPath->getMessage(), "Strings for message if global blocks settings manifest.json is missing do not match!");
 });
 
@@ -69,7 +69,7 @@ test('Checks if missingWrapperManifestException will return correct response.', 
 	$missingManifestPath = InvalidBlock::missingWrapperManifestException($manifestPath);
 
 	$this->assertIsObject($missingManifestPath);
-	$this->assertObjectHasAttribute('message', $missingManifestPath);
+	$this->assertObjectHasProperty('message', $missingManifestPath);
 	$this->assertSame("Wrapper blocks settings manifest.json is missing on this location: {$manifestPath}.", $missingManifestPath->getMessage(), "Strings for message if wrapper blocks settings manifest.json is missing do not match!");
 });
 
@@ -79,7 +79,7 @@ test('Checks if missingComponentManifestException will return correct response.'
 	$missingComponentManifest = InvalidBlock::missingComponentManifestException($manifestPath);
 
 	$this->assertIsObject($missingComponentManifest);
-	$this->assertObjectHasAttribute('message', $missingComponentManifest);
+	$this->assertObjectHasProperty('message', $missingComponentManifest);
 	$this->assertSame("Component manifest.json is missing on this location: {$manifestPath}.", $missingComponentManifest->getMessage(), "Strings for message if component manifest.json is missing do not match!");
 });
 
@@ -89,7 +89,7 @@ test('Checks if missingWrapperViewException will return correct response.', func
 	$missingWrapperView = InvalidBlock::missingWrapperViewException($wrapperPath);
 
 	$this->assertIsObject($missingWrapperView);
-	$this->assertObjectHasAttribute('message', $missingWrapperView);
+	$this->assertObjectHasProperty('message', $missingWrapperView);
 	$this->assertSame("Wrapper view is missing. Template should be located in this path {$wrapperPath}", $missingWrapperView->getMessage(), "Strings for message if wrapper view is missing do not match!");
 });
 
@@ -98,6 +98,6 @@ test('Checks if missingNamespaceException will return correct response.', functi
 	$missingNamespace = InvalidBlock::missingNamespaceException();
 
 	$this->assertIsObject($missingNamespace);
-	$this->assertObjectHasAttribute('message', $missingNamespace);
+	$this->assertObjectHasProperty('message', $missingNamespace);
 	$this->assertSame('Global Blocks settings manifest.json is missing a key called namespace. This key prefixes all block names.', $missingNamespace->getMessage(), "Strings for message global settings manifest.json is missing a key called namespace do not match!");
 });

--- a/tests/Unit/Exception/InvalidCallbackTest.php
+++ b/tests/Unit/Exception/InvalidCallbackTest.php
@@ -11,6 +11,6 @@ test('Checks if the fromCallback method will return correct response.', function
 	$exceptionObject = InvalidCallback::fromCallback($callback);
 
 	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidBlock class");
-	$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");
+	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
 	$this->assertSame("The callback {$callback} is not recognized and cannot be registered.", $exceptionObject->getMessage(), "Strings for message if callback isn't recognised do not match!");
 });

--- a/tests/Unit/Exception/InvalidCallbackTest.php
+++ b/tests/Unit/Exception/InvalidCallbackTest.php
@@ -10,7 +10,9 @@ test('Checks if the fromCallback method will return correct response.', function
 
 	$exceptionObject = InvalidCallback::fromCallback($callback);
 
-	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidBlock class");
-	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
-	$this->assertSame("The callback {$callback} is not recognized and cannot be registered.", $exceptionObject->getMessage(), "Strings for message if callback isn't recognised do not match!");
+	expect($exceptionObject)->toBeObject()
+		->toBeInstanceOf(InvalidCallback::class)
+		->toHaveProperty('message')
+		->and("The callback {$callback} is not recognized and cannot be registered.")
+		->toEqual($exceptionObject->getMessage());
 });

--- a/tests/Unit/Exception/InvalidManifestTest.php
+++ b/tests/Unit/Exception/InvalidManifestTest.php
@@ -11,7 +11,7 @@ test('Checks if the missingManifestItemException method will return correct resp
 	$exceptionObject = InvalidManifest::missingManifestItemException($key);
 
 	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidManifest class");
-	$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");
+	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
 	$this->assertSame("{$key} key does not exist in manifest.json. Please check if provided key is correct.", $exceptionObject->getMessage(), "Strings for message if manifest key is missing do not match!");
 });
 
@@ -22,7 +22,7 @@ test('Checks if the missingManifestException method will return correct response
 	$exceptionObject = InvalidManifest::missingManifestException($manifestPath);
 
 	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidManifest class");
-	$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");
+	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
 	$this->assertSame("manifest.json is missing at this path: {$manifestPath}. Bundle the theme before using it. Or your bundling process is returning an error.", $exceptionObject->getMessage(), "Strings for message if manifest is missing do not match!");
 });
 
@@ -33,6 +33,6 @@ test('Checks if the manifestStructureException method will return correct respon
 	$exceptionObject = InvalidManifest::manifestStructureException($errorMessage);
 
 	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidManifest class");
-	$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");
+	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
 	$this->assertSame($errorMessage, $exceptionObject->getMessage(), "Strings for manifest structure error message do not match!");
 });

--- a/tests/Unit/Exception/InvalidManifestTest.php
+++ b/tests/Unit/Exception/InvalidManifestTest.php
@@ -10,9 +10,11 @@ test('Checks if the missingManifestItemException method will return correct resp
 
 	$exceptionObject = InvalidManifest::missingManifestItemException($key);
 
-	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidManifest class");
-	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
-	$this->assertSame("{$key} key does not exist in manifest.json. Please check if provided key is correct.", $exceptionObject->getMessage(), "Strings for message if manifest key is missing do not match!");
+	expect($exceptionObject)->toBeObject()
+		->toBeInstanceOf(InvalidManifest::class)
+		->toHaveProperty('message')
+		->and("{$key} key does not exist in manifest.json. Please check if provided key is correct.")
+		->toEqual($exceptionObject->getMessage());
 });
 
 test('Checks if the missingManifestException method will return correct response.', function () {
@@ -21,9 +23,11 @@ test('Checks if the missingManifestException method will return correct response
 
 	$exceptionObject = InvalidManifest::missingManifestException($manifestPath);
 
-	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidManifest class");
-	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
-	$this->assertSame("manifest.json is missing at this path: {$manifestPath}. Bundle the theme before using it. Or your bundling process is returning an error.", $exceptionObject->getMessage(), "Strings for message if manifest is missing do not match!");
+	expect($exceptionObject)->toBeObject()
+		->toBeInstanceOf(InvalidManifest::class)
+		->toHaveProperty('message')
+		->and("manifest.json is missing at this path: {$manifestPath}. Bundle the theme before using it. Or your bundling process is returning an error.")
+		->toEqual($exceptionObject->getMessage());
 });
 
 test('Checks if the manifestStructureException method will return correct response.', function () {
@@ -32,7 +36,9 @@ test('Checks if the manifestStructureException method will return correct respon
 
 	$exceptionObject = InvalidManifest::manifestStructureException($errorMessage);
 
-	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidManifest class");
-	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
-	$this->assertSame($errorMessage, $exceptionObject->getMessage(), "Strings for manifest structure error message do not match!");
+	expect($exceptionObject)->toBeObject()
+		->toBeInstanceOf(InvalidManifest::class)
+		->toHaveProperty('message')
+		->and($errorMessage)
+		->toEqual($exceptionObject->getMessage());
 });

--- a/tests/Unit/Exception/InvalidServiceTest.php
+++ b/tests/Unit/Exception/InvalidServiceTest.php
@@ -10,7 +10,9 @@ test('Checks if the fromService method will return correct response.', function 
 
 	$exceptionObject = InvalidService::fromService($service);
 
-	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidService class");
-	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
-	$this->assertSame("The service {$service} is not recognized and cannot be registered.", $exceptionObject->getMessage(), "Strings for message if service name isn't recognised do not match!");
+	expect($exceptionObject)->toBeObject()
+		->toBeInstanceOf(InvalidService::class)
+		->toHaveProperty('message')
+		->and("The service {$service} is not recognized and cannot be registered.")
+		->toEqual($exceptionObject->getMessage());
 });

--- a/tests/Unit/Exception/InvalidServiceTest.php
+++ b/tests/Unit/Exception/InvalidServiceTest.php
@@ -11,6 +11,6 @@ test('Checks if the fromService method will return correct response.', function 
 	$exceptionObject = InvalidService::fromService($service);
 
 	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of InvalidService class");
-	$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");
+	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
 	$this->assertSame("The service {$service} is not recognized and cannot be registered.", $exceptionObject->getMessage(), "Strings for message if service name isn't recognised do not match!");
 });

--- a/tests/Unit/Exception/PluginActivationFailureTest.php
+++ b/tests/Unit/Exception/PluginActivationFailureTest.php
@@ -10,7 +10,9 @@ test('Checks if the activationMessage method will return correct response.', fun
 
 	$exceptionObject = PluginActivationFailure::activationMessage($message);
 
-	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of PluginActivationFailure class");
-	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
-	$this->assertSame($message, $exceptionObject->getMessage(), "Strings for error activation message do not match!");
+	expect($exceptionObject)->toBeObject()
+		->toBeInstanceOf(PluginActivationFailure::class)
+		->toHaveProperty('message')
+		->and($message)
+		->toEqual($exceptionObject->getMessage());
 });

--- a/tests/Unit/Exception/PluginActivationFailureTest.php
+++ b/tests/Unit/Exception/PluginActivationFailureTest.php
@@ -11,6 +11,6 @@ test('Checks if the activationMessage method will return correct response.', fun
 	$exceptionObject = PluginActivationFailure::activationMessage($message);
 
 	$this->assertIsObject($exceptionObject, "The {$exceptionObject} should be an instance of PluginActivationFailure class");
-	$this->assertObjectHasAttribute('message', $exceptionObject, "Object doesn't contain message attribute");
+	$this->assertObjectHasProperty('message', $exceptionObject, "Object doesn't contain message attribute");
 	$this->assertSame($message, $exceptionObject->getMessage(), "Strings for error activation message do not match!");
 });


### PR DESCRIPTION
# Description

This PR will:

- Update coding standards to the latest beta version which should make the libs compatible with PHP 7.4, 8.0, 8.1, 8.2 (and the 8.3 tests seem to be passing)
- Fix the code so that the tests pass (the latest addition of adding private folders broke a lot of tests (95))
- Fix existing issues with phpcs and phpstan 
  - I've excluded some errors from phpcs reporting, as they are false positives, mainly the exception ones, as the exception messages are escaped in the exception classes
  - Also excluded file creation methods. The WP replacements are not ideal - [wp_mkdir_p()](https://developer.wordpress.org/reference/functions/wp_mkdir_p/) will create directories recursively but with 777 permission, and some other `WP_Filesystem_*` methods are just wrappers with filters added (which is not desired)
- Fix the deprecated test code:
  - assertions replaced with expectations to avoid breaking change of replacing `assertObjectHasAttribute` with `assertObjectHasProperty` in PHPUnit 9 (we could just create a custom assertion, but expectations are cleaner and don't suffer from this issue)
  - Added dynamically created properties to fix the [deprecation about dynamically created properties](https://www.php.net/manual/en/migration82.deprecated.php) in PHP 8.2+. The only deprecations about this come on versions where the composer was installed with the lowest versions of dependencies - `composer update --prefer-lowest --prefer-stable`, and that is due to Mockery mocks. On newer versions this issue [is fixed](https://github.com/mockery/mockery/issues/1209), but on older versions, it's not, and any on-the-fly property creation will cause this deprecation, which will fail on PHP9 (all deprecations will become fatal errors then).

Note that some tests do fail but those are _allowed failures_, and shouldn't matter as it's unlikely people would install the lowest stable packages anyhow.
Regarding the deprecation notices, I can, if you agree, just remove the `lowest` condition when installing the packages from the integrate.yml (would make the CI checks faster as well, as we would be removing extra checks).

Please review the code and test this code before tagging the v7 beta.

CC: @iruzevic @goranalkovic-infinum 


#### EDIT:

I've realized that the boilerplate will have to be updated with the beta release as well, as the coding standards would block installation (they are still on 1.6, which is locked to 7.4).

Closes #315 