### PR TITLE
addings render security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [6.5.6] - 2023-10-24
+
+## Changed
+- `render` and `renderPartial` methods are now no longer able to call the php files outside of themes/plugin folders. This is a security measure to prevent the execution of arbitrary code.
+- `render` method can now call `wrapper` as a component name.
+
 ## [6.5.5] - 2023-07-07
 
 ### Fixed
@@ -434,6 +440,7 @@ Init setup
 
 [Unreleased]: https://github.com/infinum/eightshift-libs/compare/main...HEAD
 
+[6.5.6]: https://github.com/infinum/eightshift-libs/compare/6.5.5...v6.5.6
 [6.5.5]: https://github.com/infinum/eightshift-libs/compare/6.5.4...v6.5.5
 [6.5.4]: https://github.com/infinum/eightshift-libs/compare/6.5.3...v6.5.4
 [6.5.3]: https://github.com/infinum/eightshift-libs/compare/6.5.2...v6.5.3

--- a/src/Exception/ComponentException.php
+++ b/src/Exception/ComponentException.php
@@ -75,4 +75,16 @@ final class ComponentException extends InvalidArgumentException implements Gener
 			)
 		);
 	}
+
+	/**
+	 * Throws exception if path is private.
+	 *
+	 * @return static
+	 */
+	public static function throwPrivatePath(): ComponentException
+	{
+		return new ComponentException(
+			\esc_html__('You are not allowed to access paths outside of themes or plugins folder!', 'eightshift-libs'),
+		);
+	}
 }

--- a/src/Helpers/Components.php
+++ b/src/Helpers/Components.php
@@ -139,10 +139,19 @@ class Components
 			$component = \ltrim($component, $sep);
 			$componentPath = $component;
 		} else {
-			$componentPath = Components::getProjectPaths('blocksDestinationComponents', "{$component}{$sep}{$component}.php", $sep);
+			if ($component === 'wrapper') {
+				$componentPath = Components::getProjectPaths('blocksDestinationWrapper', "{$component}.php", $sep);
+			} else {
+				$componentPath = Components::getProjectPaths('blocksDestinationComponents', "{$component}{$sep}{$component}.php", $sep);
+			}
 		}
 
 		$componentPath = "{$parentPath}{$componentPath}";
+
+		// Security check.
+		if (!\preg_match('(themes|plugins)', $componentPath)) {
+			throw ComponentException::throwPrivatePath();
+		}
 
 		if ($useComponentDefaults) {
 			$manifest = Components::getManifest($componentPath);
@@ -230,6 +239,11 @@ class Components
 		// Bailout if file is missing.
 		if (!\file_exists($path)) {
 			throw ComponentException::throwUnableToLocatePartial($path);
+		}
+
+		// Security check.
+		if (!\preg_match('(themes|plugins)', $path)) {
+			throw ComponentException::throwPrivatePath();
 		}
 
 		\ob_start();


### PR DESCRIPTION
## Changed
- `render` and `renderPartial` methods are now no longer able to call the php files outside of themes/plugin folders. This is a security measure to prevent the execution of arbitrary code.
- `render` method can now call `wrapper` as a component name.