### PR TITLE
WP 6.4 lodash fix

### DIFF
--- a/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
+++ b/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
@@ -313,6 +313,7 @@ abstract class AbstractEnqueueBlocks extends AbstractAssets
 			'wp-viewport',
 			'wp-blob',
 			'wp-url',
+			'lodash',
 		];
 	}
 }


### PR DESCRIPTION
Re-enqueues `lodash` to hopefully make everything work with WP 6.4.