### PR TITLE
[FEATURE] Create helper that can load reusable block in the template without the need to write large iterations of the code

### DIFF
--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -73,6 +73,11 @@ class Helpers
 	 */
 	use DeprecatedTrait;
 
+		/**
+	 * Deprecated trait.
+	 */
+	use ReusableBlockTrait;
+
 	/**
 	 * Get all project paths allowed to be used in the different render methods.
 	 *

--- a/src/Helpers/ReusableBlockTrait.php
+++ b/src/Helpers/ReusableBlockTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Helpers for reusable blocks.
+ *
+ * @package EightshiftLibs\Helpers
+ */
+
+declare(strict_types=1);
+
+namespace EightshiftLibs\Helpers;
+
+/**
+ * Trait ReusableBlockTrait helper.
+ */
+trait ReusableBlockTrait
+{
+	/**
+	 * Render reusable blocks content.
+	 *
+	 * This helper will get reusable blocks content and render it.
+	 *
+	 * @param int $commonContent ID of the reusable block content to render.
+	 *
+	 * @return string Rendered content.
+	 */
+	public static function renderReusableBlock(int $commonContent): string
+	{
+		$blocks = \parse_blocks(\get_the_content(null, false, $commonContent));
+
+		$renderedContent = '';
+
+		foreach ($blocks as $block) {
+			$renderedContent .= \apply_filters('the_content', \render_block($block));
+		}
+
+		return $renderedContent;
+	}
+}


### PR DESCRIPTION
# Description

Develop a helper function in PHP for WordPress that simplifies the process of loading reusable block content into templates. This function aims to reduce redundancy and improve code readability by encapsulating the common pattern of fetching, parsing, and rendering reusable blocks into a single, reusable utility.

# Productive task
https://app.productive.io/1-infinum/tasks/7979972
# Issue
https://github.com/infinum/eightshift-frontend-libs/issues/459


