### PR TITLE
Change getServiceClassesWithDi() visibility to protected

### DIFF
--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -31,14 +31,14 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * @var Object[]
 	 */
-	private array $services = [];
+	protected array $services = [];
 
 	/**
 	 * DI container instance.
 	 *
 	 * @var Container
 	 */
-	private Container $container;
+	protected Container $container;
 
 	/**
 	 * Constructs object and inserts prefixes from composer.

--- a/src/Main/AbstractMain.php
+++ b/src/Main/AbstractMain.php
@@ -120,7 +120,7 @@ abstract class AbstractMain extends Autowiring implements ServiceInterface
 	 *
 	 * @throws Exception Exception thrown by the DI container.
 	 */
-	private function getServiceClassesWithDi(): array
+	protected function getServiceClassesWithDi(): array
 	{
 		$services = $this->getServiceClassesPreparedArray();
 


### PR DESCRIPTION
This change allows the function to be called and/or redeclared from extending classes. Prior to this PR, it was set to private:

> Members declared protected can be accessed only within the class itself and by inheriting and parent classes. Members declared as private may only be accessed by the class that defines the member. 
>
> (https://www.php.net/manual/en/language.oop5.visibility.php)

# Description

Changes visibility so that I can override `registerServices()` in a project without replacing `getServiceClassesWithDi()`.

