### PR TITLE
Improve getAssetsPrefix method

### DIFF
--- a/src/Enqueue/Admin/EnqueueAdminExample.php
+++ b/src/Enqueue/Admin/EnqueueAdminExample.php
@@ -39,7 +39,7 @@ class EnqueueAdminExample extends AbstractEnqueueAdmin
 	 */
 	public function getAssetsPrefix(): string
 	{
-		return Config::getProjectName();
+		return Config::getProjectTextDomain();
 	}
 
 	/**

--- a/src/Enqueue/Blocks/EnqueueBlocksExample.php
+++ b/src/Enqueue/Blocks/EnqueueBlocksExample.php
@@ -49,7 +49,7 @@ class EnqueueBlocksExample extends AbstractEnqueueBlocks
 	 */
 	public function getAssetsPrefix(): string
 	{
-		return Config::getProjectName();
+		return Config::getProjectTextDomain();
 	}
 
 	/**

--- a/src/Enqueue/Theme/EnqueueThemeExample.php
+++ b/src/Enqueue/Theme/EnqueueThemeExample.php
@@ -36,7 +36,7 @@ class EnqueueThemeExample extends AbstractEnqueueTheme
 	 */
 	public function getAssetsPrefix(): string
 	{
-		return Config::getProjectName();
+		return Config::getProjectTextDomain();
 	}
 
 	/**


### PR DESCRIPTION
# Description

Previously used getProjectName has potential issue if project name consists of more than one word separated with a blank space.
