### PR TITLE
Fix fetching of ids for partials of provided templates

### DIFF
--- a/src/InitSetup/tailwind/theme/404.php
+++ b/src/InitSetup/tailwind/theme/404.php
@@ -11,7 +11,7 @@ use %g_namespace%\ThemeOptions\ThemeOptions;
 get_header();
 
 // Header reusable block.
-$partialId = get_option(ThemeOptions::OPTION_NAME)['fourOhFour'] ?? '';
+$partialId = json_decode(get_option(ThemeOptions::OPTION_NAME), true)['fourOhFour'] ?? '';
 ThemeOptions::renderPartial($partialId);
 
 get_footer();

--- a/src/InitSetup/tailwind/theme/404.php
+++ b/src/InitSetup/tailwind/theme/404.php
@@ -11,7 +11,6 @@ use %g_namespace%\ThemeOptions\ThemeOptions;
 get_header();
 
 // Header reusable block.
-$partialId = json_decode(get_option(ThemeOptions::OPTION_NAME), true)['fourOhFour'] ?? '';
-ThemeOptions::renderPartial($partialId);
+ThemeOptions::renderPartial(ThemeOptions::getOption('fourOhFour'));
 
 get_footer();

--- a/src/InitSetup/tailwind/theme/footer.php
+++ b/src/InitSetup/tailwind/theme/footer.php
@@ -15,8 +15,7 @@ use %g_namespace%\ThemeOptions\ThemeOptions;
 <footer class="layout-base">
 <?php
 // Footer reusable block.
-$footerPartialId = json_decode(get_option(ThemeOptions::OPTION_NAME), true)['footer'] ?? '';
-ThemeOptions::renderPartial($footerPartialId);
+ThemeOptions::renderPartial(ThemeOptions::getOption('footer'));
 ?>
 </footer>
 

--- a/src/InitSetup/tailwind/theme/footer.php
+++ b/src/InitSetup/tailwind/theme/footer.php
@@ -15,7 +15,7 @@ use %g_namespace%\ThemeOptions\ThemeOptions;
 <footer class="layout-base">
 <?php
 // Footer reusable block.
-$footerPartialId = get_option(ThemeOptions::OPTION_NAME)['footer'] ?? '';
+$footerPartialId = json_decode(get_option(ThemeOptions::OPTION_NAME), true)['footer'] ?? '';
 ThemeOptions::renderPartial($footerPartialId);
 ?>
 </footer>

--- a/src/InitSetup/tailwind/theme/header.php
+++ b/src/InitSetup/tailwind/theme/header.php
@@ -24,8 +24,7 @@ use %g_namespace%\ThemeOptions\ThemeOptions;
 
 <?php
 // Header reusable block.
-$headerPartialId = json_decode(get_option(ThemeOptions::OPTION_NAME), true)['header'] ?? '';
-ThemeOptions::renderPartial($headerPartialId);
+ThemeOptions::renderPartial(ThemeOptions::getOption('header'));
 ?>
 
 <main class="main-content layout-base" id="main-content">

--- a/src/InitSetup/tailwind/theme/header.php
+++ b/src/InitSetup/tailwind/theme/header.php
@@ -24,7 +24,7 @@ use %g_namespace%\ThemeOptions\ThemeOptions;
 
 <?php
 // Header reusable block.
-$headerPartialId = get_option(ThemeOptions::OPTION_NAME)['header'] ?? '';
+$headerPartialId = json_decode(get_option(ThemeOptions::OPTION_NAME), true)['header'] ?? '';
 ThemeOptions::renderPartial($headerPartialId);
 ?>
 

--- a/src/ThemeOptions/ThemeOptionsExample.php
+++ b/src/ThemeOptions/ThemeOptionsExample.php
@@ -90,6 +90,26 @@ class ThemeOptionsExample implements ServiceInterface
 	}
 
 	/**
+	 * Get theme option.
+	 *
+	 * @param string $item Item to get.
+	 *
+	 * @return string
+	 */
+	public static function getOption(string $item): string
+	{
+		$options = \get_option(ThemeOptions::OPTION_NAME);
+
+		if (!Helpers::isJson($options)) {
+			return '';
+		}
+
+		$options = \json_decode($options, true);
+
+		return $options[$item] ?? '';
+	}
+
+	/**
 	 * Get reusable blocks patterns.
 	 *
 	 * @return array<mixed> Available patterns.


### PR DESCRIPTION
# Description

Fetching newly structured eightshift-theme-options from db needs to be unserialised

e.g.
`$footerPartialId = get_option(ThemeOptions::OPTION_NAME)['footer'] ?? '';`
should look like:
`$footerPartialId = json_decode(get_option(ThemeOptions::OPTION_NAME), true)['footer'] ?? '';`