### PR TITLE
Cache Autowiring::buildServiceClasses into a transient

### DIFF
--- a/src/Cache/AbstractManifestCache.php
+++ b/src/Cache/AbstractManifestCache.php
@@ -159,13 +159,18 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 
 	/**
 	 * Get an (abstract) cache item.
+	 *
 	 * @param string $key Cache array key.
 	 * @param string $cacheType Cache type to get.
 	 * @param callable|null $fallback Fallback function for getting a result when not set. Optional.
 	 * @param bool $isJson Determines whether we should try to decode the cached value as JSON.
-	 * @return array|mixed[] An array of cached values.
+	 *
+	 * @throws InvalidManifest If cache item is missing.
+	 *
+	 * @return array<string, mixed> An array of cached values.
 	 */
-	public function getCacheTopItem(string $key, string $cacheType = self::TYPE_BLOCKS, callable $fallback = null, bool $isJson = true): array {
+	public function getCacheTopItem(string $key, string $cacheType = self::TYPE_BLOCKS, callable $fallback = null, bool $isJson = true): array
+	{
 		$output = [];
 
 		if ((\defined('WP_ENVIRONMENT_TYPE') && \WP_ENVIRONMENT_TYPE !== 'development') && !\defined('WP_CLI')) {
@@ -312,8 +317,9 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 
 	/**
 	 * Set a custom (abstract) cache value.
+	 *
 	 * @param string $cacheType Cache type.
-	 * @param array $data Data to set. Does not get encoded, is set directly to a transient.
+	 * @param array<string, mixed> $data Data to set. Does not get encoded, is set directly to a transient.
 	 * @return void
 	 */
 	public function setCustomCache(string $cacheType = self::TYPE_BLOCKS, array $data = []): void
@@ -343,7 +349,7 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 			$this->setCache($cacheType);
 		}
 
-		return ($isJson ? \json_decode($cache, true) : $cache ?? []) ?? [];
+		return ($isJson ? \json_decode($cache, true) : $cache) ?? [];
 	}
 
 	/**

--- a/src/Cache/AbstractManifestCache.php
+++ b/src/Cache/AbstractManifestCache.php
@@ -306,6 +306,11 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 	 */
 	protected function setCache(string $cacheType = self::TYPE_BLOCKS): void
 	{
+		if ($cacheType === self::TYPE_SERVICES) {
+			// Services are set with setCustomCache.
+			return;
+		}
+
 		$name = self::TRANSIENT_NAME . $this->getCacheName() . "_{$cacheType}";
 
 		$cache = \get_transient($name);

--- a/src/Cache/AbstractManifestCache.php
+++ b/src/Cache/AbstractManifestCache.php
@@ -119,6 +119,13 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 	public const TYPE_GEOLOCATION = 'geolocation';
 
 	/**
+	 * Cache key for services.
+	 *
+	 * @var string
+	 */
+	public const TYPE_SERVICES = 'services';
+
+	/**
 	 * Namespace for blocks.
 	 *
 	 * @var string
@@ -151,6 +158,32 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 	}
 
 	/**
+	 * Get an (abstract) cache item.
+	 * @param string $key Cache array key.
+	 * @param string $cacheType Cache type to get.
+	 * @param callable|null $fallback Fallback function for getting a result when not set. Optional.
+	 * @param bool $isJson Determines whether we should try to decode the cached value as JSON.
+	 * @return array|mixed[] An array of cached values.
+	 */
+	public function getCacheTopItem(string $key, string $cacheType = self::TYPE_BLOCKS, callable $fallback = null, bool $isJson = true): array {
+		$output = [];
+
+		if ((\defined('WP_ENVIRONMENT_TYPE') && \WP_ENVIRONMENT_TYPE !== 'development') && !\defined('WP_CLI')) {
+			$output = $this->getCache($cacheType, $isJson)[$key] ?? [];
+		}
+
+		if (!$output && $cacheType !== self::TYPE_SERVICES) {
+			$output = $fallback ? $fallback($cacheType, $key) ?? [] : [];
+		}
+
+		if (!$output && !\defined('WP_CLI')) {
+			throw InvalidManifest::missingCacheTopItemException($key, $this->getFullPath($key, $cacheType));
+		}
+
+		return $output;
+	}
+
+	/**
 	 * Get manifest cache top item.
 	 *
 	 * @param string $key Key of the cache.
@@ -162,21 +195,9 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 	 */
 	public function getManifestCacheTopItem(string $key, string $cacheType = self::TYPE_BLOCKS): array
 	{
-		$output = [];
-
-		if ((\defined('WP_ENVIRONMENT_TYPE') && \WP_ENVIRONMENT_TYPE !== 'development') && !\defined('WP_CLI')) {
-			$output = $this->getCache($cacheType)[$key] ?? [];
-		}
-
-		if (!$output) {
-			$output = $this->getAllManifests($cacheType)[$key] ?? [];
-		}
-
-		if (!$output && !\defined('WP_CLI')) {
-			throw InvalidManifest::missingCacheTopItemException($key, $this->getFullPath($key, $cacheType));
-		}
-
-		return $output;
+		return $this->getCacheTopItem($key, $cacheType, function () use ($cacheType, $key) {
+			return $this->getAllManifests($cacheType)[$key] ?? [];
+		});
 	}
 
 	/**
@@ -290,13 +311,31 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 	}
 
 	/**
+	 * Set a custom (abstract) cache value.
+	 * @param string $cacheType Cache type.
+	 * @param array $data Data to set. Does not get encoded, is set directly to a transient.
+	 * @return void
+	 */
+	public function setCustomCache(string $cacheType = self::TYPE_BLOCKS, array $data = []): void
+	{
+		$name = self::TRANSIENT_NAME . $this->getCacheName() . "_{$cacheType}";
+
+		$cache = \get_transient($name);
+
+		if (!$cache) {
+			\set_transient($name, $data, $this->getDuration());
+		}
+	}
+
+	/**
 	 * Get cache.
 	 *
 	 * @param string $cacheType Type of the cache.
+	 * @param bool $isJson Determines if we should try to decode the cached value as JSON or not.
 	 *
 	 * @return array<string, array<mixed>> Array of cache.
 	 */
-	protected function getCache(string $cacheType = self::TYPE_BLOCKS): array
+	protected function getCache(string $cacheType = self::TYPE_BLOCKS, bool $isJson = true): array
 	{
 		$cache = \get_transient(self::TRANSIENT_NAME . $this->getCacheName() . "_{$cacheType}") ?: ''; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
@@ -304,7 +343,7 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 			$this->setCache($cacheType);
 		}
 
-		return \json_decode($cache, true) ?? [];
+		return ($isJson ? \json_decode($cache, true) : $cache ?? []) ?? [];
 	}
 
 	/**
@@ -451,6 +490,7 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 					'fileName' => "src{$sep}Geolocation{$sep}manifest.json",
 				],
 			],
+			self::TYPE_SERVICES => []
 		];
 	}
 

--- a/src/Cache/AbstractManifestCache.php
+++ b/src/Cache/AbstractManifestCache.php
@@ -343,7 +343,7 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 	 */
 	protected function getCache(string $cacheType = self::TYPE_BLOCKS, bool $isJson = true): array
 	{
-		$cache = \get_transient(self::TRANSIENT_NAME . $this->getCacheName() . "_{$cacheType}") ?: ''; // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
+		$cache = \get_transient(self::TRANSIENT_NAME . $this->getCacheName() . "_{$cacheType}") ?: ($isJson ? '' : []); // phpcs:ignore WordPress.PHP.DisallowShortTernary.Found
 
 		if (!$cache) {
 			$this->setCache($cacheType);

--- a/src/InitSetup/standard/plugin/eightshift-boilerplate-plugin.php
+++ b/src/InitSetup/standard/plugin/eightshift-boilerplate-plugin.php
@@ -69,11 +69,14 @@ if (\class_exists(PluginFactory::class)) {
 	);
 }
 
+
 /**
  * Set all the cache for the plugin.
  */
+$manifestCache = null;
 if (\class_exists(ManifestCache::class)) {
-	(new ManifestCache())->setAllCache();
+	$manifestCache = new ManifestCache();
+	$manifestCache->setAllCache();
 }
 
 /**
@@ -84,9 +87,10 @@ if (\class_exists(ManifestCache::class)) {
  * not affect the page life cycle.
  */
 if (\class_exists(Main::class)) {
-	(new Main($loader->getPrefixesPsr4(), __NAMESPACE__))->register();
+	$main = (new Main($loader->getPrefixesPsr4(), __NAMESPACE__));
+	$main->setManifestCache($manifestCache);
+	$main->register();
 }
-
 /**
  * Run all WPCLI commands.
  */

--- a/src/InitSetup/standard/plugin/eightshift-boilerplate-plugin.php
+++ b/src/InitSetup/standard/plugin/eightshift-boilerplate-plugin.php
@@ -88,7 +88,9 @@ if (\class_exists(ManifestCache::class)) {
  */
 if (\class_exists(Main::class)) {
 	$main = (new Main($loader->getPrefixesPsr4(), __NAMESPACE__));
-	$main->setManifestCache($manifestCache);
+	if ($manifestCache ?? false) {
+		$main->setManifestCache($manifestCache);
+	}
 	$main->register();
 }
 /**

--- a/src/InitSetup/standard/theme/functions.php
+++ b/src/InitSetup/standard/theme/functions.php
@@ -47,24 +47,28 @@ if (\file_exists(__DIR__ . '/vendor-prefixed/autoload.php')) {
 	require __DIR__ . '/vendor-prefixed/autoload.php';
 }
 
+
 /**
  * Set all the cache for the theme.
  */
+$manifestCache = null;
 if (\class_exists(ManifestCache::class)) {
-	(new ManifestCache())->setAllCache();
+	$manifestCache = new ManifestCache();
+	$manifestCache->setAllCache();
 }
 
 /**
  * Begins execution of the theme.
  *
- * Since everything within the theme is registered via hooks,
- * then kicking off the theme from this point in the file does
+ * Since everything within the plugin is registered via hooks,
+ * then kicking off the plugin from this point in the file does
  * not affect the page life cycle.
  */
 if (\class_exists(Main::class)) {
-	(new Main($loader->getPrefixesPsr4(), __NAMESPACE__))->register();
+	$main = (new Main($loader->getPrefixesPsr4(), __NAMESPACE__));
+	$main->setManifestCache($manifestCache);
+	$main->register();
 }
-
 /**
  * Run all WPCLI commands.
  */

--- a/src/InitSetup/standard/theme/functions.php
+++ b/src/InitSetup/standard/theme/functions.php
@@ -60,13 +60,15 @@ if (\class_exists(ManifestCache::class)) {
 /**
  * Begins execution of the theme.
  *
- * Since everything within the plugin is registered via hooks,
- * then kicking off the plugin from this point in the file does
+ * Since everything within the theme is registered via hooks,
+ * then kicking off the theme from this point in the file does
  * not affect the page life cycle.
  */
 if (\class_exists(Main::class)) {
 	$main = (new Main($loader->getPrefixesPsr4(), __NAMESPACE__));
-	$main->setManifestCache($manifestCache);
+	if ($manifestCache ?? false) {
+		$main->setManifestCache($manifestCache);
+	}
 	$main->register();
 }
 /**

--- a/src/InitSetup/tailwind/plugin/eightshift-boilerplate-plugin.php
+++ b/src/InitSetup/tailwind/plugin/eightshift-boilerplate-plugin.php
@@ -88,7 +88,9 @@ if (\class_exists(ManifestCache::class)) {
  */
 if (\class_exists(Main::class)) {
 	$main = (new Main($loader->getPrefixesPsr4(), __NAMESPACE__));
-	$main->setManifestCache($manifestCache);
+	if ($manifestCache ?? false) {
+		$main->setManifestCache($manifestCache);
+	}
 	$main->register();
 }
 

--- a/src/InitSetup/tailwind/plugin/eightshift-boilerplate-plugin.php
+++ b/src/InitSetup/tailwind/plugin/eightshift-boilerplate-plugin.php
@@ -69,11 +69,14 @@ if (\class_exists(PluginFactory::class)) {
 	);
 }
 
+
 /**
  * Set all the cache for the plugin.
  */
+$manifestCache = null;
 if (\class_exists(ManifestCache::class)) {
-	(new ManifestCache())->setAllCache();
+	$manifestCache = new ManifestCache();
+	$manifestCache->setAllCache();
 }
 
 /**
@@ -84,7 +87,9 @@ if (\class_exists(ManifestCache::class)) {
  * not affect the page life cycle.
  */
 if (\class_exists(Main::class)) {
-	(new Main($loader->getPrefixesPsr4(), __NAMESPACE__))->register();
+	$main = (new Main($loader->getPrefixesPsr4(), __NAMESPACE__));
+	$main->setManifestCache($manifestCache);
+	$main->register();
 }
 
 /**

--- a/src/InitSetup/tailwind/theme/functions.php
+++ b/src/InitSetup/tailwind/theme/functions.php
@@ -50,19 +50,23 @@ if (\file_exists(__DIR__ . '/vendor-prefixed/autoload.php')) {
 /**
  * Set all the cache for the theme.
  */
+$manifestCache = null;
 if (\class_exists(ManifestCache::class)) {
-	(new ManifestCache())->setAllCache();
+	$manifestCache = new ManifestCache();
+	$manifestCache->setAllCache();
 }
 
 /**
  * Begins execution of the theme.
  *
- * Since everything within the theme is registered via hooks,
- * then kicking off the theme from this point in the file does
+ * Since everything within the plugin is registered via hooks,
+ * then kicking off the plugin from this point in the file does
  * not affect the page life cycle.
  */
 if (\class_exists(Main::class)) {
-	(new Main($loader->getPrefixesPsr4(), __NAMESPACE__))->register();
+	$main = (new Main($loader->getPrefixesPsr4(), __NAMESPACE__));
+	$main->setManifestCache($manifestCache);
+	$main->register();
 }
 
 /**

--- a/src/InitSetup/tailwind/theme/functions.php
+++ b/src/InitSetup/tailwind/theme/functions.php
@@ -59,13 +59,15 @@ if (\class_exists(ManifestCache::class)) {
 /**
  * Begins execution of the theme.
  *
- * Since everything within the plugin is registered via hooks,
- * then kicking off the plugin from this point in the file does
+ * Since everything within the theme is registered via hooks,
+ * then kicking off the theme from this point in the file does
  * not affect the page life cycle.
  */
 if (\class_exists(Main::class)) {
 	$main = (new Main($loader->getPrefixesPsr4(), __NAMESPACE__));
-	$main->setManifestCache($manifestCache);
+	if ($manifestCache ?? false) {
+		$main->setManifestCache($manifestCache);
+	}
 	$main->register();
 }
 

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -140,7 +140,9 @@ class Autowiring
 
 		// Convert dependency tree into PHP-DI's definition list.
 		$serviceClasses = \array_merge($this->convertDependencyTreeIntoDefinitionList($dependencyTree), $manuallyDefinedDependencies);
-		$this->manifestCache->setCustomCache(AbstractManifestCache::TYPE_SERVICES, ['serviceClasses' => $serviceClasses]);
+		if (isset($this->manifestCache)) {
+			$this->manifestCache->setCustomCache(AbstractManifestCache::TYPE_SERVICES, ['serviceClasses' => $serviceClasses]);
+		}
 		return $serviceClasses;
 	}
 

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -53,9 +53,9 @@ class Autowiring
 	 */
 	public function buildServiceClasses(array $manuallyDefinedDependencies = [], bool $skipInvalid = false): array
 	{
-		if ( 
+		if (
 			(
-				(\defined('WP_ENVIRONMENT_TYPE') && \WP_ENVIRONMENT_TYPE !== 'development') 
+				(\defined('WP_ENVIRONMENT_TYPE') && \WP_ENVIRONMENT_TYPE !== 'development')
 				|| (\defined('EIGHTSHIFT_USE_AUTOWIRING_CACHE') && \EIGHTSHIFT_USE_AUTOWIRING_CACHE)
 			) && !\defined('WP_CLI')
 			 && $cachedValue = \get_transient("{$this->namespace}_autowiring_cache")

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -53,7 +53,13 @@ class Autowiring
 	 */
 	public function buildServiceClasses(array $manuallyDefinedDependencies = [], bool $skipInvalid = false): array
 	{
-		if ($cachedValue = \get_transient("{$this->namespace}_autowiring_cache")) {
+		if ( 
+			(
+				(\defined('WP_ENVIRONMENT_TYPE') && \WP_ENVIRONMENT_TYPE !== 'development') 
+				|| (\defined('EIGHTSHIFT_USE_AUTOWIRING_CACHE') && \EIGHTSHIFT_USE_AUTOWIRING_CACHE)
+			) && !\defined('WP_CLI')
+			 && $cachedValue = \get_transient("{$this->namespace}_autowiring_cache")
+		) {
 			return $cachedValue;
 		}
 

--- a/src/Main/Autowiring.php
+++ b/src/Main/Autowiring.php
@@ -53,6 +53,10 @@ class Autowiring
 	 */
 	public function buildServiceClasses(array $manuallyDefinedDependencies = [], bool $skipInvalid = false): array
 	{
+		if ($cachedValue = \get_transient("{$this->namespace}_autowiring_cache")) {
+			return $cachedValue;
+		}
+
 		$projectReflectionClasses = $this->validateAndBuildClasses(
 			$this->filterManuallyDefinedDependencies(
 				$this->getClassesInNamespace($this->namespace, $this->psr4Prefixes),
@@ -102,7 +106,9 @@ class Autowiring
 		}
 
 		// Convert dependency tree into PHP-DI's definition list.
-		return \array_merge($this->convertDependencyTreeIntoDefinitionList($dependencyTree), $manuallyDefinedDependencies);
+		$value = \array_merge($this->convertDependencyTreeIntoDefinitionList($dependencyTree), $manuallyDefinedDependencies);
+		\set_transient("{$this->namespace}_autowiring_cache", $value);
+		return $value;
 	}
 
 	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber


### PR DESCRIPTION
# Description

Using profiling we've gathered that we spend _a lot_ of time in `Autowiring::buildServiceClasses`. In particular, we spent 14% of the whole page generation time just running the method for `EightshiftForms`.

Here's a screenshot from an Excimer-grabbed profile opened up in Speedscope on my local machine:
<img width="805" alt="Screenshot 2024-10-30 at 16 24 21" src="https://github.com/user-attachments/assets/bd57f9e3-1691-45e8-b713-bbe99d3c5ccb">

I added caching this into a transient using the project namespace as a unique key. This requires transients to be cleared on all deployments, and can cause breakage if `manuallyDefinedDependencies` is changed dynamically at runtime. This should probably be documented in eightshift-docs.

I should probably add a way to toggle this off. Do you prefer `WP_ENVIRONMENT_TYPE`, a special constant or both?

After this change, it's no longer noticeable in the profile and the whole `registerServices` method now takes less time than just the `buildServiceClasses` method used to:
<img width="1714" alt="Screenshot 2024-10-30 at 16 31 00" src="https://github.com/user-attachments/assets/94e3eb45-b551-4bf8-92b3-dedbf92e64d6">

I will open up additional PRs for optimization opportunities if I notice them.
