### PR TITLE
Paths not resolved correctly on Windows

### DIFF
--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -461,7 +461,11 @@ class Helpers
 		);
 
 		$path = \implode($sep, $paths);
-		$path = "{$sep}{$path}";
+
+		// only add the separator if there is not a disk indicator - enables this to work in windows
+		if (!\str_contains(\mb_strstr($path, $sep, true) ?? '', ':')) {
+			$path = "{$sep}{$path}";
+		}
 
 		if (!\pathinfo($path, \PATHINFO_EXTENSION)) {
 			$path = "{$path}{$sep}";


### PR DESCRIPTION
On Windows, no paths are resolved from the manifest, leading to a InvalidManifest exception.

# Description

The `Helpers::joinPaths()` method prepends the directory separator onto the generated base file path. On Windows this causes the paths not to be resolved, leading to it being unable to read any files from `manifest.json`. This fix checks to see if the base path has a disk indicator prefixing the path, and only prepends the separator when it doesn't.