### PR TITLE
release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [10.8.1]
+
+### Fixed
+
+- Updating `prepareSimpleApiParams` helper to be able to sanitize nested arrays also.
+
 ## [10.8.0]
 
 ### Changed
@@ -928,6 +934,7 @@ Init setup
 - Gutenberg Blocks Registration.
 - Assets Manifest data.
 
+[10.8.1]: https://github.com/infinum/eightshift-libs/compare/10.8.0...10.8.1
 [10.8.0]: https://github.com/infinum/eightshift-libs/compare/10.7.1...10.8.0
 [10.7.1]: https://github.com/infinum/eightshift-libs/compare/10.7.0...10.7.1
 [10.7.0]: https://github.com/infinum/eightshift-libs/compare/10.6.1...10.7.0

--- a/src/Rest/Routes/AbstractRoute.php
+++ b/src/Rest/Routes/AbstractRoute.php
@@ -197,20 +197,7 @@ abstract class AbstractRoute implements RouteInterface, ServiceInterface
 	 */
 	protected function prepareSimpleApiParams(WP_REST_Request $request, string $type = self::CREATABLE): array
 	{
-		// Get params.
-		$params = $this->getRequestParams($request, $type);
-
-		// Bailout if there are no params.
-		if (!$params) {
-			return [];
-		}
-
-		return \array_map(
-			static function ($item) {
-				return \sanitize_text_field($item);
-			},
-			$params
-		);
+		return Helpers::sanitizeArray($this->getRequestParams($request, $type), 'sanitize_text_field');
 	}
 
 	/**


### PR DESCRIPTION
### Fixed

- Updating `prepareSimpleApiParams` helper to be able to sanitize nested arrays also.
