### PR TITLE
10.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [10.11.1]
+
+### Fixed
+
+- Replace `$attributes` check with `$part` for `tailwindClasses` helper method because component can be without attributes.
+
 ## [10.11.0]
 
 ### Added
@@ -990,6 +996,7 @@ Init setup
 - Gutenberg Blocks Registration.
 - Assets Manifest data.
 
+[10.11.1]: https://github.com/infinum/eightshift-libs/compare/10.11.0...10.11.1
 [10.11.0]: https://github.com/infinum/eightshift-libs/compare/10.10.0...10.11.0
 [10.10.0]: https://github.com/infinum/eightshift-libs/compare/10.9.4...10.10.0
 [10.9.4]: https://github.com/infinum/eightshift-libs/compare/10.9.3...10.9.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a 
 
 - Replace `$attributes` check with `$part` for `tailwindClasses` helper method because component can be without attributes.
 
+### Updated
+
+- Replace deprecated `classnames` helper with `clsx`
+
+### Added
+
+- Output block/component title in `tailwindClasses` if WP_DEBUG is true
+
 ## [10.11.0]
 
 ### Added

--- a/src/Helpers/TailwindTrait.php
+++ b/src/Helpers/TailwindTrait.php
@@ -452,7 +452,7 @@ trait TailwindTrait
 	public static function tailwindClasses($part, $attributes, $manifest, ...$custom): string
 	{
 		// If nothing is set, return custom classes as a fallback.
-		if (!$attributes || !$manifest || !isset($manifest['tailwind']) || \array_keys($manifest['tailwind']) === []) {
+		if (!$part || !$manifest || !isset($manifest['tailwind']) || \array_keys($manifest['tailwind']) === []) {
 			return $custom ? Helpers::classnames($custom) : ''; // @phpstan-ignore-line
 		}
 

--- a/src/Helpers/TailwindTrait.php
+++ b/src/Helpers/TailwindTrait.php
@@ -56,7 +56,7 @@ trait TailwindTrait
 	public static function getTwPart($part, $manifest, ...$custom)
 	{
 		if (!$part || !$manifest || !isset($manifest['tailwind']) || \array_keys($manifest['tailwind']) === []) {
-			return $custom ? Helpers::classnames($custom) : ''; // @phpstan-ignore-line
+			return $custom ? Helpers::clsx($custom) : ''; // @phpstan-ignore-line
 		}
 
 		$partClasses = $manifest['tailwind']['parts'][$part]['twClasses'] ?? '';
@@ -65,7 +65,7 @@ trait TailwindTrait
 			$partClasses = \implode(' ', $partClasses);
 		}
 
-		return Helpers::classnames([$partClasses, ...$custom]);
+		return Helpers::clsx([$partClasses, ...$custom]);
 	}
 
 	/**
@@ -85,7 +85,7 @@ trait TailwindTrait
 	public static function getTwDynamicPart($part, $attributes, $manifest, ...$custom)
 	{
 		if (!$part || !$manifest || !isset($manifest['tailwind']) || \array_keys($manifest['tailwind']) === []) {
-			return $custom ? Helpers::classnames($custom) : ''; // @phpstan-ignore-line
+			return $custom ? Helpers::clsx($custom) : ''; // @phpstan-ignore-line
 		}
 
 		$baseClasses = $manifest['tailwind']['parts'][$part]['twClasses'] ?? '';
@@ -165,7 +165,7 @@ trait TailwindTrait
 			}
 		}
 
-		return Helpers::classnames([$baseClasses, ...$mainClasses, ...$custom]);
+		return Helpers::clsx([$baseClasses, ...$mainClasses, ...$custom]);
 	}
 
 	/**
@@ -182,7 +182,7 @@ trait TailwindTrait
 	public static function getTwClasses($attributes, $manifest, ...$custom)
 	{
 		if (!$attributes || !$manifest || !isset($manifest['tailwind']) || \array_keys($manifest['tailwind']) === []) {
-			return $custom ? Helpers::classnames($custom) : ''; // @phpstan-ignore-line
+			return $custom ? Helpers::clsx($custom) : ''; // @phpstan-ignore-line
 		}
 
 		$baseClasses = $manifest['tailwind']['base']['twClasses'] ?? '';
@@ -294,7 +294,7 @@ trait TailwindTrait
 			}
 		}
 
-		return Helpers::classnames([$baseClasses, ...$mainClasses, ...$combinationClasses, ...$custom]);
+		return Helpers::clsx([$baseClasses, ...$mainClasses, ...$combinationClasses, ...$custom]);
 	}
 
 	/**
@@ -310,7 +310,7 @@ trait TailwindTrait
 	private static function unifyClasses($input): string
 	{
 		if (\is_array($input)) {
-			return Helpers::classnames($input);
+			return Helpers::clsx($input);
 		}
 
 		return \trim($input);
@@ -453,7 +453,7 @@ trait TailwindTrait
 	{
 		// If nothing is set, return custom classes as a fallback.
 		if (!$part || !$manifest || !isset($manifest['tailwind']) || \array_keys($manifest['tailwind']) === []) {
-			return $custom ? Helpers::classnames($custom) : ''; // @phpstan-ignore-line
+			return $custom ? Helpers::clsx($custom) : ''; // @phpstan-ignore-line
 		}
 
 		$allParts = isset($manifest['tailwind']['parts']) ? ['base', ...\array_keys($manifest['tailwind']['parts'])] : ['base'];
@@ -493,6 +493,6 @@ trait TailwindTrait
 			$combinationClasses[] = self::processCombination($partName, $combo, $attributes, $manifest);
 		}
 
-		return Helpers::classnames([$baseClasses, ...$optionClasses, ...$combinationClasses, ...$custom]);
+		return Helpers::clsx([$baseClasses, ...$optionClasses, ...$combinationClasses, ...$custom]);
 	}
 }

--- a/src/Helpers/TailwindTrait.php
+++ b/src/Helpers/TailwindTrait.php
@@ -493,6 +493,9 @@ trait TailwindTrait
 			$combinationClasses[] = self::processCombination($partName, $combo, $attributes, $manifest);
 		}
 
-		return Helpers::clsx([$baseClasses, ...$optionClasses, ...$combinationClasses, ...$custom]);
+		$partPrefix = \strtolower(\preg_replace('/[^a-zA-Z]+/', '-', $manifest['title']));
+		$isWpDebugActive = \defined('WP_DEBUG') && \WP_DEBUG;
+
+		return Helpers::clsx([$isWpDebugActive ? "_es__{$partPrefix}/{$part}" : '', $baseClasses, ...$optionClasses, ...$combinationClasses, ...$custom]);
 	}
 }


### PR DESCRIPTION
# Description

## Fixed:

- Replace `$attributes` check with `$part` for `tailwindClasses` helper method because component can be without attributes. e.g. `tracking-head` component.