### PR TITLE
11.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [11.0.4]
+
+### Added
+
+- `outputCssVariablesGlobalClean` method to the `CssVariablesTrait` helper. Not wrapped in a style tag. Used in patterns.
+- `outputCssVariablesGlobal` method to the `CssVariablesTrait` helper.
+- `outputCssVariablesInlineClean` method to the `CssVariablesTrait` helper. Not wrapped in a style tag. Used in patterns.
+- `outputCssVariablesInline` method to the `CssVariablesTrait` helper.
+
 ## [11.0.3]
 
 ### Fixed
@@ -1066,6 +1075,7 @@ Init setup
 - Gutenberg Blocks Registration.
 - Assets Manifest data.
 
+[11.0.4]: https://github.com/infinum/eightshift-libs/compare/11.0.3...11.0.4
 [11.0.3]: https://github.com/infinum/eightshift-libs/compare/11.0.2...11.0.3
 [11.0.2]: https://github.com/infinum/eightshift-libs/compare/11.0.1...11.0.2
 [11.0.1]: https://github.com/infinum/eightshift-libs/compare/11.0.0...11.0.1

--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,13 @@
 		"php-di/php-di": "^7.1.1"
 	},
 	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "1.1.2",
+		"dealerdirect/phpcodesniffer-composer-installer": "1.2.0",
 		"infinum/eightshift-coding-standards": "^3.0.0",
 		"php-parallel-lint/php-parallel-lint": "^v1.4.0",
-		"php-stubs/wordpress-stubs": "6.8.2",
-		"szepeviktor/phpstan-wordpress": "2.0.2",
+		"php-stubs/wordpress-stubs": "6.9.0",
+		"szepeviktor/phpstan-wordpress": "2.0.3",
 		"wp-cli/wp-cli": "2.12.0",
-		"phpunit/phpunit": "^12.3.10",
+		"phpunit/phpunit": "^12.5.0",
 		"brain/monkey": "^2.6.2",
 		"mockery/mockery": "^1.6.12"
 	},

--- a/src/Helpers/CssVariablesTrait.php
+++ b/src/Helpers/CssVariablesTrait.php
@@ -16,13 +16,13 @@ namespace EightshiftLibs\Helpers;
 trait CssVariablesTrait
 {
 	/**
-	 * Get Global Manifest.json and return globalVariables as CSS variables.
+	 * Get Global Manifest.json and return globalVariables as CSS variables. Not wrapped in a style tag.
 	 *
 	 * @param array<string, mixed> $globalSettings Global settings.
 	 *
 	 * @return string
 	 */
-	public static function outputCssVariablesGlobal(array $globalSettings = []): string
+	public static function outputCssVariablesGlobalClean(array $globalSettings = []): string
 	{
 		$output = '';
 
@@ -38,15 +38,28 @@ trait CssVariablesTrait
 			}
 		}
 
-		$id = Helpers::getConfigOutputCssSelectorName();
-
-		$output = "<style id='{$id}-global'>:root {{$output}}</style>";
+		$output = ":root {{$output}}";
 
 		if (Helpers::getConfigOutputCssOptimize()) {
 			$output = \str_replace(["\n", "\r"], '', $output);
 		}
 
 		return $output;
+	}
+
+	/**
+	 * Get Global Manifest.json and return globalVariables as CSS variables. Wrapped in a style tag.
+	 *
+	 * @param array<string, mixed> $globalSettings Global settings.
+	 *
+	 * @return string
+	 */
+	public static function outputCssVariablesGlobal(array $globalSettings = []): string
+	{
+		$output = self::outputCssVariablesGlobalClean($globalSettings);
+		$id = Helpers::getConfigOutputCssSelectorName() . '-global';
+
+		return "<style id='{$id}'>{$output}</style>";
 	}
 
 	/**
@@ -142,13 +155,13 @@ trait CssVariablesTrait
 	}
 
 	/**
-	 * Output css variables as a one inline style tag. Used with wp_footer filter.
+	 * Output css variables as a one inline style tag. Used with wp_footer filter. Not wrapped in a style tag.
 	 *
 	 * @param array<string, mixed> $globalSettings Global settings.
 	 *
 	 * @return string
 	 */
-	public static function outputCssVariablesInline(array $globalSettings = []): string
+	public static function outputCssVariablesInlineClean(array $globalSettings = []): string
 	{
 		// Load normal styles if server side render is used.
 		$context = isset($_GET['context']) ? \sanitize_text_field(\wp_unslash($_GET['context'])) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -266,9 +279,22 @@ trait CssVariablesTrait
 		$additionalStyles = Helpers::getConfigOutputCssGloballyAdditionalStyles();
 		$additionalStylesOutput = $additionalStyles ? \esc_html(\implode(";\n", $additionalStyles)) : '';
 
+		return "{$output} {$additionalStylesOutput}";
+	}
+
+	/**
+	 * Output css variables as a one inline style tag. Used with wp_footer filter. Wrapped in a style tag.
+	 *
+	 * @param array<string, mixed> $globalSettings Global settings.
+	 *
+	 * @return string
+	 */
+	public static function outputCssVariablesInline(array $globalSettings = []): string
+	{
+		$output = self::outputCssVariablesInlineClean($globalSettings);
 		$selector = Helpers::getConfigOutputCssSelectorName();
 
-		return "<style id='{$selector}'>{$output} {$additionalStylesOutput}</style>";
+		return "<style id='{$selector}'>{$output}</style>";
 	}
 
 	/**
@@ -366,9 +392,9 @@ trait CssVariablesTrait
 
 		// Prepare final output for testing.
 		$fullOutput = "
-			{$output}
-			{$manual}
-		";
+				{$output}
+				{$manual}
+			";
 
 		// Check if final output is empty and and remove if it is.
 		if (empty(\trim($fullOutput))) {


### PR DESCRIPTION
### Added

- `outputCssVariablesGlobalClean` method to the `CssVariablesTrait` helper. Not wrapped in a style tag. Used in patterns.
- `outputCssVariablesGlobal` method to the `CssVariablesTrait` helper.
- `outputCssVariablesInlineClean` method to the `CssVariablesTrait` helper. Not wrapped in a style tag. Used in patterns.
- `outputCssVariablesInline` method to the `CssVariablesTrait` helper.