### PR TITLE
Feature/type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [12.3.4]
+
+### Changed
+
+- Narrowed generic `array<mixed>` PHPDoc annotations to accurate inline types across 19 files — string-keyed maps, typed list shapes, nested cache structures, CSS variable internals, union types, and precise shape annotations.
+
 ## [12.3.3]
 
 ### Fixed
@@ -1130,6 +1136,7 @@ Init setup
 - Gutenberg Blocks Registration.
 - Assets Manifest data.
 
+[12.3.4]: https://github.com/infinum/eightshift-libs/compare/12.3.3...12.3.4
 [12.3.3]: https://github.com/infinum/eightshift-libs/compare/12.3.2...12.3.3
 [12.3.2]: https://github.com/infinum/eightshift-libs/compare/12.3.1...12.3.2
 [12.3.1]: https://github.com/infinum/eightshift-libs/compare/12.3.0...12.3.1

--- a/src/AdminMenus/AdminPatternsHeaderFooterMenu/AdminPatternsHeaderFooterMenuExample.php
+++ b/src/AdminMenus/AdminPatternsHeaderFooterMenu/AdminPatternsHeaderFooterMenuExample.php
@@ -229,7 +229,7 @@ class AdminPatternsHeaderFooterMenuExample extends AbstractAdminMenu
 	/**
 	 * Renders the "Header partial" select menu.
 	 *
-	 * @param array<mixed> $args Arguments to pass.
+	 * @param array<string, mixed> $args Arguments to pass.
 	 * @return void
 	 */
 	public function renderPartialSelector($args): void

--- a/src/Cache/AbstractManifestCache.php
+++ b/src/Cache/AbstractManifestCache.php
@@ -83,7 +83,7 @@ abstract class AbstractManifestCache implements ManifestCacheInterface
 	/**
 	 * Get cache builder.
 	 *
-	 * @return array<string, array<mixed>> Array of cache builder.
+	 * @return array<string, array<string, array<string, mixed>>> Array of cache builder.
 	 */
 	protected function getCacheBuilder(): array
 	{

--- a/src/CustomPostType/PostTypeExample.php
+++ b/src/CustomPostType/PostTypeExample.php
@@ -72,7 +72,7 @@ class PostTypeExample extends AbstractPostType
 	/**
 	 * Get the arguments that configure the Projects custom post type.
 	 *
-	 * @return array<mixed> Array of arguments.
+	 * @return array<string, mixed> Array of arguments.
 	 */
 	protected function getPostTypeArguments(): array
 	{

--- a/src/CustomTaxonomy/TaxonomyExample.php
+++ b/src/CustomTaxonomy/TaxonomyExample.php
@@ -61,7 +61,7 @@ class TaxonomyExample extends AbstractTaxonomy
 	/**
 	 * Get the arguments that configure the custom taxonomy.
 	 *
-	 * @return array<mixed> Array of arguments.
+	 * @return array<string, mixed> Array of arguments.
 	 */
 	protected function getTaxonomyArguments(): array
 	{

--- a/src/Geolocation/AbstractGeolocation.php
+++ b/src/Geolocation/AbstractGeolocation.php
@@ -107,7 +107,7 @@ abstract class AbstractGeolocation implements ServiceInterface
 	/**
 	 * Gets additional locations for country list.
 	 *
-	 * @return array<mixed>
+	 * @return list<array{label: string, value: string, group: list<string>}>
 	 */
 	public function getAdditionalCountries(): array
 	{
@@ -127,7 +127,7 @@ abstract class AbstractGeolocation implements ServiceInterface
 	/**
 	 * Gets the list of all countries from the manifest.
 	 *
-	 * @return array<mixed>
+	 * @return list<array{label: string, value: string, group: list<string>}>
 	 */
 	public function getCountries(): array
 	{

--- a/src/Helpers/AttributesTrait.php
+++ b/src/Helpers/AttributesTrait.php
@@ -108,7 +108,7 @@ trait AttributesTrait
 	 * @throws Exception If missing responsiveAttributes or keyName in responsiveAttributes.
 	 * @throws Exception If missing keyName in responsiveAttributes.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function checkAttrResponsive(string $keyName, array $attributes, array $manifest, bool $undefinedAllowed = false): array
 	{

--- a/src/Helpers/CacheTrait.php
+++ b/src/Helpers/CacheTrait.php
@@ -23,14 +23,14 @@ trait CacheTrait
 	/**
 	 * Cache.
 	 *
-	 * @var array<mixed>
+	 * @var array<string, array<string, mixed>>
 	 */
 	private static $cache = [];
 
 	/**
 	 * Cache builder.
 	 *
-	 * @var array<mixed>
+	 * @var array<string, array<string, array<string, mixed>>>
 	 */
 	private static $cacheBuilder = [];
 
@@ -69,7 +69,7 @@ trait CacheTrait
 	/**
 	 * Set cache details with optimized validation.
 	 *
-	 * @param array<mixed> $cacheBuilder Cache builder.
+	 * @param array<string, array<string, array<string, mixed>>> $cacheBuilder Cache builder.
 	 * @param string $cacheName Cache name.
 	 * @param string $version Cache version.
 	 *
@@ -174,7 +174,7 @@ trait CacheTrait
 	/**
 	 * Get cache.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public static function getCache(): array
 	{
@@ -326,7 +326,7 @@ trait CacheTrait
 	/**
 	 * Get all manifests from the paths with optimized processing.
 	 *
-	 * @return array<string, array<mixed>> Array of manifests.
+	 * @return array<string, array<string, mixed>> Array of manifests.
 	 */
 	private static function getAllManifests(): array
 	{
@@ -370,7 +370,7 @@ trait CacheTrait
 	 * Get single item from the path with optimized file operations and error handling.
 	 *
 	 * @param string $path Path to the item.
-	 * @param array<mixed> $data Data array.
+	 * @param array<string, mixed> $data Data array.
 	 * @param string $parent Parent key.
 	 *
 	 * @throws InvalidManifest If manifest key is missing.
@@ -418,7 +418,7 @@ trait CacheTrait
 	 * Process autoset configuration efficiently.
 	 *
 	 * @param array<string, mixed> $fileDecoded Decoded file data.
-	 * @param array<mixed> $data Configuration data.
+	 * @param array<string, mixed> $data Configuration data.
 	 *
 	 * @return array<string, mixed> Processed file data.
 	 */
@@ -495,7 +495,7 @@ trait CacheTrait
 	 * Validate manifest keys efficiently.
 	 *
 	 * @param array<string, mixed> $fileDecoded Decoded file data.
-	 * @param array<mixed> $data Configuration data.
+	 * @param array<string, mixed> $data Configuration data.
 	 * @param string $path File path for error reporting.
 	 *
 	 * @throws InvalidManifest If required key is missing.
@@ -521,10 +521,10 @@ trait CacheTrait
 	 * Get multiple items from the path with optimized processing.
 	 *
 	 * @param string $path Path to the items.
-	 * @param array<mixed> $data Data array.
+	 * @param array<string, mixed> $data Data array.
 	 * @param string $parent Parent key.
 	 *
-	 * @return array<string, array<mixed>> Array of items.
+	 * @return array<string, array<string, mixed>> Array of items.
 	 */
 	private static function getItems(string $path, array $data, string $parent): array
 	{

--- a/src/Helpers/CssVariablesTrait.php
+++ b/src/Helpers/CssVariablesTrait.php
@@ -521,7 +521,7 @@ trait CssVariablesTrait
 	 * @param integer $breakpointIndex Index of responsiveAttribute's breakpoint in manifest.
 	 * @param integer $numberOfBreakpoints Number of responsiveAttribute breakpoints in block's/component's manifest.
 	 *
-	 * @return array<int, mixed>
+	 * @return list<array<string, mixed>>
 	 */
 	private static function setBreakpointResponsiveVariables(
 		array $attributeVariables,
@@ -791,7 +791,7 @@ trait CssVariablesTrait
 	 * @param array<string, mixed> $attributes Attributes that are read from component's/block's manifest.
 	 * @param array<string, mixed> $manifest Component/block manifest data.
 	 *
-	 * @return array<int, mixed>|string[]
+	 * @return list<string>
 	 */
 	private static function variablesInner(array $variables, $attributeValue, array $attributes, array $manifest): array
 	{

--- a/src/Helpers/CssVariablesTrait.php
+++ b/src/Helpers/CssVariablesTrait.php
@@ -348,8 +348,8 @@ trait CssVariablesTrait
 	 * Return CSS variables in default type. On the place where it was called.
 	 *
 	 * @param string $name Output css selector name.
-	 * @param array<mixed> $data Data prepared for checking.
-	 * @param array<mixed> $manifest Component/block manifest data.
+	 * @param array<int, array<string, mixed>> $data Data prepared for checking.
+	 * @param array<string, mixed> $manifest Component/block manifest data.
 	 * @param string $unique Unique key.
 	 *
 	 * @return string
@@ -417,11 +417,11 @@ trait CssVariablesTrait
 	 * Get css variables in inline type. In one place in dom.
 	 *
 	 * @param string $name Output css selector name.
-	 * @param array<mixed> $data Data prepared for checking.
-	 * @param array<mixed> $manifest Component/block manifest data.
+	 * @param array<int, array<string, mixed>> $data Data prepared for checking.
+	 * @param array<string, mixed> $manifest Component/block manifest data.
 	 * @param string $unique Unique key.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	private static function getCssVariablesTypeInline(string $name, array $data, array $manifest, string $unique): array
 	{

--- a/src/Helpers/DeprecatedTrait.php
+++ b/src/Helpers/DeprecatedTrait.php
@@ -118,7 +118,7 @@ trait DeprecatedTrait
 	 *
 	 * @deprecated 10.0.0 Use getApiResponsePublicOutput instead.
 	 *
-	 * @return array<string, array<mixed>|int|string>
+	 * @return array<string, array<int|string, mixed>|int|string>
 	 */
 	public static function getApiSuccessPublicOutput(string $msg, array $additional = []): array
 	{
@@ -143,7 +143,7 @@ trait DeprecatedTrait
 	 *
 	 * @deprecated 10.0.0 Use getApiResponsePublicOutput instead.
 	 *
-	 * @return array<string, array<mixed>|int|string>
+	 * @return array<string, array<int|string, mixed>|int|string>
 	 */
 	public static function getApiWarningPublicOutput(string $msg, array $additional = []): array
 	{
@@ -168,7 +168,7 @@ trait DeprecatedTrait
 	 *
 	 * @deprecated 10.0.0 Use getApiResponsePublicOutput instead.
 	 *
-	 * @return array<string, array<mixed>|int|string>
+	 * @return array<string, array<int|string, mixed>|int|string>
 	 */
 	public static function getApiErrorPublicOutput(string $msg, array $additional = []): array
 	{

--- a/src/Helpers/GeneralTrait.php
+++ b/src/Helpers/GeneralTrait.php
@@ -62,9 +62,9 @@ trait GeneralTrait
 	/**
 	 * Flatten multidimensional array with optimized performance.
 	 *
-	 * @param array<mixed> $arrayToFlatten Multidimensional array to flatten.
+	 * @param array<int|string, mixed> $arrayToFlatten Multidimensional array to flatten.
 	 *
-	 * @return array<mixed>
+	 * @return list<mixed>
 	 */
 	public static function flattenArray(array $arrayToFlatten): array
 	{
@@ -85,7 +85,7 @@ trait GeneralTrait
 	/**
 	 * Find array value by key in recursive array with optimized search.
 	 *
-	 * @param array<mixed> $array Array to find.
+	 * @param array<int|string, mixed> $array Array to find.
 	 * @param string $needle Key name to find.
 	 *
 	 * @return array<int, string>
@@ -110,10 +110,10 @@ trait GeneralTrait
 	 *
 	 * @link https://developer.wordpress.org/themes/theme-security/data-sanitization-escaping/
 	 *
-	 * @param array<mixed> $arrayToSanitize Provided array.
+	 * @param array<int|string, mixed> $arrayToSanitize Provided array.
 	 * @param string $sanitizationFunction WordPress function used for sanitization purposes.
 	 *
-	 * @return array<mixed>
+	 * @return array<int|string, mixed>
 	 */
 	public static function sanitizeArray(array $arrayToSanitize, string $sanitizationFunction): array
 	{
@@ -144,9 +144,9 @@ trait GeneralTrait
 	 * Sort array by order key. Used to sort terms.
 	 * Already optimized but added safety checks.
 	 *
-	 * @param array<mixed> $items Items array to sort. Must have order key.
+	 * @param list<array<string, mixed>> $items Items array to sort. Must have order key.
 	 *
-	 * @return array<mixed>
+	 * @return list<array<string, mixed>>
 	 */
 	public static function sortArrayByOrderKey(array $items): array
 	{

--- a/src/Helpers/ProjectInfoTrait.php
+++ b/src/Helpers/ProjectInfoTrait.php
@@ -78,7 +78,7 @@ trait ProjectInfoTrait
 	/**
 	 * Get the plugin details.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, bool|string>
 	 */
 	protected static function getPluginDetails(): array
 	{

--- a/src/Helpers/RenderTrait.php
+++ b/src/Helpers/RenderTrait.php
@@ -75,7 +75,7 @@ trait RenderTrait
 	 * @param string $renderPrefixPath Prefix path.
 	 * @param string $componentName Component name.
 	 *
-	 * @return array{path: string, manifest: array<mixed>}
+	 * @return array{path: string, manifest: array<string, mixed>}
 	 */
 	private static function handleComponentsRender(string $renderName, string $renderPrefixPath, string $componentName): array
 	{
@@ -97,7 +97,7 @@ trait RenderTrait
 	 *
 	 * @param string $renderName Render name.
 	 *
-	 * @return array{path: string, manifest: array<mixed>}
+	 * @return array{path: string, manifest: array<string, mixed>}
 	 */
 	private static function handleWrapperRender(string $renderName): array
 	{
@@ -114,7 +114,7 @@ trait RenderTrait
 	 * @param string $renderPrefixPath Prefix path.
 	 * @param string $componentName Component name.
 	 *
-	 * @return array{path: string, manifest: array<mixed>}
+	 * @return array{path: string, manifest: array<string, mixed>}
 	 */
 	private static function handleBlocksRender(string $renderName, string $renderPrefixPath, string $componentName): array
 	{

--- a/src/Helpers/ShortcodeTrait.php
+++ b/src/Helpers/ShortcodeTrait.php
@@ -19,7 +19,7 @@ trait ShortcodeTrait
 	 * Call a shortcode function by tag name.
 	 *
 	 * @param string $tag The shortcode whose function to call.
-	 * @param array<mixed> $attr The attributes to pass to the shortcode function. Optional.
+	 * @param array<string, mixed> $attr The attributes to pass to the shortcode function. Optional.
 	 * @param string $content The shortcode's content. Default is empty string.
 	 *
 	 * @return string|bool False on failure, the result of the shortcode on success.

--- a/src/Helpers/StoreBlocksTrait.php
+++ b/src/Helpers/StoreBlocksTrait.php
@@ -22,7 +22,7 @@ trait StoreBlocksTrait
 	/**
 	 * Styles key
 	 *
-	 * @var array<mixed>
+	 * @var list<array<string, mixed>>
 	 */
 	public static $styles = [];
 
@@ -36,7 +36,7 @@ trait StoreBlocksTrait
 	 * @param string $type Data type to retrieve.
 	 * @param string $key Data key to retrieve.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	private static function getCachedData(string $type, string $key): array
 	{
@@ -52,7 +52,7 @@ trait StoreBlocksTrait
 	 *
 	 * @throws InvalidBlock If blocks are missing.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public static function getBlocks(): array
 	{
@@ -66,7 +66,7 @@ trait StoreBlocksTrait
 	 *
 	 * @param string $block Block name to get.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getBlock(string $block): array
 	{
@@ -89,7 +89,7 @@ trait StoreBlocksTrait
 	 *
 	 * @throws InvalidBlock If components are missing.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public static function getComponents(): array
 	{
@@ -103,7 +103,7 @@ trait StoreBlocksTrait
 	 *
 	 * @throws InvalidBlock If component is missing.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getComponent(string $component): array
 	{
@@ -126,7 +126,7 @@ trait StoreBlocksTrait
 	 *
 	 * @throws InvalidBlock If variations are missing.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, array<string, mixed>>
 	 */
 	public static function getVariations(): array
 	{
@@ -140,7 +140,7 @@ trait StoreBlocksTrait
 	 *
 	 * @throws InvalidBlock If variation is missing.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getVariation(string $variation): array
 	{
@@ -163,7 +163,7 @@ trait StoreBlocksTrait
 	 *
 	 * @throws InvalidBlock If wrapper is missing.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getWrapper(): array
 	{
@@ -177,7 +177,7 @@ trait StoreBlocksTrait
 	/**
 	 * Get all global config settings with optimized caching.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getConfig(): array
 	{
@@ -272,7 +272,7 @@ trait StoreBlocksTrait
 	 *
 	 * @throws InvalidBlock If settings are missing.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getSettings(): array
 	{
@@ -307,7 +307,7 @@ trait StoreBlocksTrait
 	/**
 	 * Get global settings details - global variables with optimized access.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getSettingsGlobalVariables(): array
 	{
@@ -326,7 +326,7 @@ trait StoreBlocksTrait
 	/**
 	 * Get global settings details - global variables breakpoints with optimized access.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getSettingsGlobalVariablesBreakpoints(): array
 	{
@@ -345,7 +345,7 @@ trait StoreBlocksTrait
 	/**
 	 * Get global settings details - global variables colors with optimized access.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getSettingsGlobalVariablesColors(): array
 	{
@@ -368,7 +368,7 @@ trait StoreBlocksTrait
 	/**
 	 * Set styles details with validation.
 	 *
-	 * @param array<mixed> $style Style to store.
+	 * @param array<string, mixed> $style Style to store.
 	 *
 	 * @return void
 	 */
@@ -385,7 +385,7 @@ trait StoreBlocksTrait
 	/**
 	 * Get styles details.
 	 *
-	 * @return array<mixed>
+	 * @return list<array<string, mixed>>
 	 */
 	public static function getStyles(): array
 	{
@@ -430,7 +430,7 @@ trait StoreBlocksTrait
 	 *
 	 * @throws InvalidManifest If geolocation countries are missing.
 	 *
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public static function getGeolocationCountries(): array
 	{

--- a/src/Helpers/TailwindTrait.php
+++ b/src/Helpers/TailwindTrait.php
@@ -46,7 +46,7 @@ trait TailwindTrait
 	 * The part needs to be defined within the manifest, in the `tailwind` object.
 	 *
 	 * @param string $part Part name.
-	 * @param array<mixed> $manifest Component/block manifest data.
+	 * @param array<string, mixed> $manifest Component/block manifest data.
 	 * @param array<string> ...$custom Additional custom classes.
 	 *
 	 * @deprecated 9.2.0 Use `tailwindClasses` instead.
@@ -74,8 +74,8 @@ trait TailwindTrait
 	 * The part needs to be defined within the manifest, in the `tailwind` object.
 	 *
 	 * @param string $part Part name.
-	 * @param array<mixed> $attributes Component/block attributes.
-	 * @param array<mixed> $manifest Component/block manifest data.
+	 * @param array<string, mixed> $attributes Component/block attributes.
+	 * @param array<string, mixed> $manifest Component/block manifest data.
 	 * @param array<string> ...$custom Additional custom classes.
 	 *
 	 * @deprecated 9.2.0 Use `tailwindClasses` instead.
@@ -171,8 +171,8 @@ trait TailwindTrait
 	/**
 	 * Get Tailwind classes for the given component/block.
 	 *
-	 * @param array<mixed> $attributes Component/block attributes.
-	 * @param array<mixed> $manifest Component/block manifest data.
+	 * @param array<string, mixed> $attributes Component/block attributes.
+	 * @param array<string, mixed> $manifest Component/block manifest data.
 	 * @param array<string> ...$custom Additional custom classes.
 	 *
 	 * @deprecated 9.2.0 Use `tailwindClasses` instead.
@@ -324,7 +324,7 @@ trait TailwindTrait
 	 *
 	 * @param string $partName The name of the part for which the option is being processed.
 	 * @param mixed $optionValue The value of the option to be processed.
-	 * @param array<mixed> $defs The definitions that dictate how the option should be processed.
+	 * @param array<string, mixed> $defs The definitions that dictate how the option should be processed.
 	 *
 	 * @return string The processed option value.
 	 */
@@ -392,8 +392,8 @@ trait TailwindTrait
 	 *
 	 * @param string $partName The name of the part for which the combination is being processed.
 	 * @param mixed $combo The combination value to be processed.
-	 * @param array<mixed> $attributes The attributes that dictate how the combination should be processed.
-	 * @param array<mixed> $manifest The manifest that provides additional context for processing the combination.
+	 * @param array<string, mixed> $attributes The attributes that dictate how the combination should be processed.
+	 * @param array<string, mixed> $manifest The manifest that provides additional context for processing the combination.
 	 *
 	 * @throws JsonException If the combination was not defined correctly.
 	 *
@@ -441,8 +441,8 @@ trait TailwindTrait
 	 * Get Tailwind classes for the given component/block.
 	 *
 	 * @param string $part Part to get classes for.
-	 * @param array<mixed> $attributes Component/block attributes.
-	 * @param array<mixed> $manifest Component/block manifest data.
+	 * @param array<string, mixed> $attributes Component/block attributes.
+	 * @param array<string, mixed> $manifest Component/block manifest data.
 	 * @param array<string> ...$custom Additional custom classes.
 	 *
 	 * @throws Exception If the part is not defined in the manifest.

--- a/src/Helpers/TailwindTrait.php
+++ b/src/Helpers/TailwindTrait.php
@@ -303,7 +303,7 @@ trait TailwindTrait
 	 * Takes an array or string of CSS classes and unifies them into a single string,
 	 * ensuring that there are no duplicate classes and that the classes are properly formatted.
 	 *
-	 * @param mixed $input The input classes to be unified. This can be a string or an array of strings.
+	 * @param string|array<string> $input The input classes to be unified. This can be a string or an array of strings.
 	 *
 	 * @return string The unified string of CSS classes.
 	 */
@@ -323,7 +323,7 @@ trait TailwindTrait
 	 * It ensures that the option value is correctly handled according to the definitions.
 	 *
 	 * @param string $partName The name of the part for which the option is being processed.
-	 * @param mixed $optionValue The value of the option to be processed.
+	 * @param string|array<string, string> $optionValue The value of the option to be processed.
 	 * @param array<string, mixed> $defs The definitions that dictate how the option should be processed.
 	 *
 	 * @return string The processed option value.
@@ -391,7 +391,7 @@ trait TailwindTrait
 	 * It ensures that the combination is correctly handled according to the attributes and manifest.
 	 *
 	 * @param string $partName The name of the part for which the combination is being processed.
-	 * @param mixed $combo The combination value to be processed.
+	 * @param array<string, mixed> $combo The combination value to be processed.
 	 * @param array<string, mixed> $attributes The attributes that dictate how the combination should be processed.
 	 * @param array<string, mixed> $manifest The manifest that provides additional context for processing the combination.
 	 *

--- a/src/Media/AbstractMedia.php
+++ b/src/Media/AbstractMedia.php
@@ -38,9 +38,9 @@ abstract class AbstractMedia implements ServiceInterface
 	/**
 	 * Enable SVG preview in Media Library.
 	 *
-	 * @param array<mixed> $response   Array of prepared attachment data.
+	 * @param array<string, mixed> $response   Array of prepared attachment data.
 	 * @param int|object $attachment Attachment ID or object.
-	 * @return array<object>|false Array of attachment details, or void if the parameter does not correspond to an attachment.
+	 * @return array<string, mixed>|false Array of attachment details, or void if the parameter does not correspond to an attachment.
 	 */
 	public function enableSvgMediaLibraryPreview($response, $attachment)
 	{
@@ -88,7 +88,7 @@ abstract class AbstractMedia implements ServiceInterface
 	 * Check if SVG is valid on Add New Media Page.
 	 *
 	 * @param array<object|string> $response Response array.
-	 * @return array<mixed>
+	 * @return array<string, mixed>
 	 */
 	public function validateSvgOnUpload($response)
 	{

--- a/src/Media/RegenerateWebPMediaCli.php
+++ b/src/Media/RegenerateWebPMediaCli.php
@@ -162,8 +162,8 @@ class RegenerateWebPMediaCli extends AbstractCli
 	/**
 	 * Generate media.
 	 *
-	 * @param array<mixed> $options Options from WP-CLI.
-	 * @param array<mixed> $args Parameters from WP-CLI.
+	 * @param array{quality: int} $options Options from WP-CLI.
+	 * @param array<string, mixed> $args Parameters from WP-CLI.
 	 * @param bool $onlyUpdateDb Only update the database, not the media files as assumed that the media files are already converted and locaded on S3 or other storage.
 	 *
 	 * @return void

--- a/src/Menu/BemMenuWalker.php
+++ b/src/Menu/BemMenuWalker.php
@@ -58,7 +58,7 @@ class BemMenuWalker extends \Walker_Nav_Menu
 	 * Display element for walker
 	 *
 	 * @param object $element Data object.
-	 * @param array<mixed> $children_elements List of elements to continue traversing (passed by reference).
+	 * @param array<int|string, mixed> $children_elements List of elements to continue traversing (passed by reference).
 	 * @param int $max_depth Max depth to traverse.
 	 * @param int $depth Depth of current element.
 	 * @param Object[] $args An array of arguments.

--- a/src/ThemeOptions/ThemeOptionsExample.php
+++ b/src/ThemeOptions/ThemeOptionsExample.php
@@ -92,7 +92,7 @@ class ThemeOptionsExample implements ServiceInterface
 	/**
 	 * Get reusable blocks patterns.
 	 *
-	 * @return array<mixed> Available patterns.
+	 * @return list<array{value: string, label: string}> Available patterns.
 	 */
 	public static function getPatterns(): array
 	{


### PR DESCRIPTION
# Description

Replaces generic \`array<mixed>\` PHPDoc annotations with accurate inline types across 19 files in \`src/\`. Changes fall into a few categories:

- **String-keyed maps** (\`array<mixed>\` → \`array<string, mixed>\`): WP register args, manifest data, attributes, settings, admin/menu args, REST response arrays, media response arrays.
- **Typed list shapes** (\`array<mixed>\` → \`list<array{...}>\`): geolocation countries, block patterns — now carry explicit shape types with \`label\`, \`value\`, and \`group\` keys.
- **Nested cache structures**: \`$cache\` and \`$cacheBuilder\` narrowed to \`array<string, array<string, mixed>>\` and \`array<string, array<string, array<string, mixed>>>\` to reflect the three-level key hierarchy.
- **CSS variable internals**: \`$data\` params narrowed to \`array<int, array<string, mixed>>\`; \`setBreakpointResponsiveVariables\` return narrowed to \`list<array<string, mixed>>\`; \`variablesInner\` return narrowed to \`list<string>\`.
- **Union types instead of \`mixed\`**: \`$input\` in \`unifyClasses\` → \`string|array<string>\`; \`DeprecatedTrait\` API output returns → \`array<int|string, mixed>\`.
- **Precise shape annotations**: CLI \`$options\` → \`array{quality: int}\`; walker \`$children_elements\` → \`array<int|string, mixed>\`.

PHPStan passes cleanly after all changes.

## Why some `mixed` types remain

Four legitimate cases where `mixed` cannot be narrowed:

**1. `checkAttr` return type (`AttributesTrait:31`)**
Block attributes are genuinely polymorphic — a single attribute can be a `string`, `int`, `bool`, `array`, or `null` depending on what's declared in the manifest. PHPStan has no way to statically infer which, and callers handle all these cases. Narrowing to a union would be a lie; `mixed` is correct here.

**2. REST API return types (`CallableRouteInterface`, `CallableFieldInterface`, `RouteExample`)**
WordPress's `register_rest_route()` / `register_rest_field()` callbacks can return `WP_REST_Response|WP_Error|mixed` — this is the WP contract. Changing these would either misrepresent the interface or break PHPStan on the WP side.

**3. `ComponentException::$variable`**
The exception is designed to receive *any* invalid variable for diagnostic purposes. The variable that caused the type mismatch could be literally anything, so `mixed` is semantically correct.

**4. `CssVariablesTrait::variablesInner` `$attributeValue` param**
An attribute value piped into CSS variable resolution can be a `string`, `bool`, `int`, or `array`. Without a sealed union defined elsewhere in the system, `mixed` is the honest annotation — narrowing it would require changes to the attribute contract well beyond the scope of this PR.