### PR TITLE
Feature/api3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [13.1.0]
+
+### Fixed
+
+- `enqueueBlockEditorScript` and `enqueueBlockEditorStyle` methods in `AbstractEnqueueBlocks` now check for `is_admin()` to prevent unnecessary execution on the frontend when using `enqueue_block_assets` hook required with the Block Editor API 3 version.
+
+### Migration guide
+
+- If you are using `enqueue_block_editor_assets` hooks replace them with `enqueue_block_assets` and make sure to check for `is_admin()` if you are overriding the `enqueueBlockEditorScript` and `enqueueBlockEditorStyle` methods in your custom enqueue class.
+
 ## [13.0.0]
 
 ### Added
@@ -1182,6 +1192,7 @@ Init setup
 - Gutenberg Blocks Registration.
 - Assets Manifest data.
 
+[13.1.0]: https://github.com/infinum/eightshift-libs/compare/13.0.0...13.1.0
 [13.0.0]: https://github.com/infinum/eightshift-libs/compare/12.3.4...13.0.0
 [12.3.4]: https://github.com/infinum/eightshift-libs/compare/12.3.3...12.3.4
 [12.3.3]: https://github.com/infinum/eightshift-libs/compare/12.3.2...12.3.3

--- a/src/AdminMenus/AdminPatternsHeaderFooterMenu/AdminPatternsHeaderFooterMenuExample.php
+++ b/src/AdminMenus/AdminPatternsHeaderFooterMenu/AdminPatternsHeaderFooterMenuExample.php
@@ -78,8 +78,8 @@ class AdminPatternsHeaderFooterMenuExample extends AbstractAdminMenu
 	 */
 	public function register(): void
 	{
-		\add_action('admin_init', [$this, 'registerWpSettings']);
-		\add_action('admin_menu', [$this, 'callback'], $this->getPriorityOrder());
+		\add_action('admin_init', $this->registerWpSettings(...));
+		\add_action('admin_menu', $this->callback(...), $this->getPriorityOrder());
 	}
 
 	/**
@@ -204,7 +204,7 @@ class AdminPatternsHeaderFooterMenuExample extends AbstractAdminMenu
 		\add_settings_field(
 			self::HEADER_PARTIAL,
 			\__('Header partial', '%g_textdomain%'),
-			[$this, 'renderPartialSelector'],
+			$this->renderPartialSelector(...),
 			self::ADMIN_MENU_SLUG,
 			self::SETTINGS_SECTION_NAME,
 			[
@@ -216,7 +216,7 @@ class AdminPatternsHeaderFooterMenuExample extends AbstractAdminMenu
 		\add_settings_field(
 			self::FOOTER_PARTIAL,
 			\__('Footer partial', '%g_textdomain%'),
-			[$this, 'renderPartialSelector'],
+			$this->renderPartialSelector(...),
 			self::ADMIN_MENU_SLUG,
 			self::SETTINGS_SECTION_NAME,
 			[

--- a/src/Blocks/BlocksExample.php
+++ b/src/Blocks/BlocksExample.php
@@ -26,25 +26,25 @@ class BlocksExample extends AbstractBlocks
 	public function register(): void
 	{
 		// Register all custom blocks.
-		\add_action('init', [$this, 'registerBlocks'], 10);
+		\add_action('init', $this->registerBlocks(...), 10);
 
 		// Remove P tags from content.
 		\remove_filter('the_content', 'wpautop');
 
 		// Create new custom category for custom blocks.
-		\add_filter('block_categories_all', [$this, 'getCustomCategory'], 10, 2);
+		\add_filter('block_categories_all', $this->getCustomCategory(...), 10, 2);
 
 		// Register custom theme support options.
-		\add_action('after_setup_theme', [$this, 'addThemeSupport'], 25);
+		\add_action('after_setup_theme', $this->addThemeSupport(...), 25);
 
 		// Register custom project color palette.
-		\add_action('after_setup_theme', [$this, 'changeEditorColorPalette'], 11);
+		\add_action('after_setup_theme', $this->changeEditorColorPalette(...), 11);
 
 		// Filter block content.
-		\add_filter('render_block_data', [$this, 'filterBlocksContent'], 10, 2);
+		\add_filter('render_block_data', $this->filterBlocksContent(...), 10, 2);
 
 		// Output inline css variables.
-		\add_action('wp_head', [$this, 'outputCssVariablesGlobal']);
-		\add_action('wp_footer', [$this, 'outputCssVariablesInline']);
+		\add_action('wp_head', $this->outputCssVariablesGlobal(...));
+		\add_action('wp_footer', $this->outputCssVariablesInline(...));
 	}
 }

--- a/src/Enqueue/Admin/EnqueueAdminExample.php
+++ b/src/Enqueue/Admin/EnqueueAdminExample.php
@@ -27,8 +27,8 @@ class EnqueueAdminExample extends AbstractEnqueueAdmin
 	 */
 	public function register(): void
 	{
-		\add_action('admin_enqueue_scripts', [$this, 'enqueueAdminStyles'], 50);
-		\add_action('admin_enqueue_scripts', [$this, 'enqueueAdminScripts']);
+		\add_action('admin_enqueue_scripts', $this->enqueueAdminStyles(...), 50);
+		\add_action('admin_enqueue_scripts', $this->enqueueAdminScripts(...));
 	}
 
 	/**

--- a/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
+++ b/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
@@ -48,6 +48,10 @@ abstract class AbstractEnqueueBlocks extends AbstractAssets
 	 */
 	public function enqueueBlockEditorScript(): void
 	{
+		if (!\is_admin()) {
+			return;
+		}
+
 		$handle = $this->getBlockEditorScriptsHandle();
 
 		\wp_register_script(
@@ -105,6 +109,10 @@ abstract class AbstractEnqueueBlocks extends AbstractAssets
 	 */
 	public function enqueueBlockEditorStyle(): void
 	{
+		if (!\is_admin()) {
+			return;
+		}
+
 		$handle = $this->getBlockEditorStyleHandle();
 
 		\wp_register_style(

--- a/src/Enqueue/Blocks/EnqueueBlocksExample.php
+++ b/src/Enqueue/Blocks/EnqueueBlocksExample.php
@@ -24,22 +24,22 @@ class EnqueueBlocksExample extends AbstractEnqueueBlocks
 	public function register(): void
 	{
 		// Editor only script.
-		\add_action('enqueue_block_assets', [$this, 'enqueueBlockEditorScript']);
+		\add_action('enqueue_block_assets', $this->enqueueBlockEditorScript(...));
 
 		// Editor only style.
-		\add_action('enqueue_block_assets', [$this, 'enqueueBlockEditorStyle'], 50);
+		\add_action('enqueue_block_assets', $this->enqueueBlockEditorStyle(...), 50);
 
 		// Editor and frontend style.
-		\add_action('enqueue_block_assets', [$this, 'enqueueBlockStyle'], 50);
+		\add_action('enqueue_block_assets', $this->enqueueBlockStyle(...), 50);
 
 		// Frontend only script.
-		\add_action('wp_enqueue_scripts', [$this, 'enqueueBlockFrontendScript']);
+		\add_action('wp_enqueue_scripts', $this->enqueueBlockFrontendScript(...));
 
 		// Frontend only style.
-		\add_action('wp_enqueue_scripts', [$this, 'enqueueBlockFrontendStyle'], 50);
+		\add_action('wp_enqueue_scripts', $this->enqueueBlockFrontendStyle(...), 50);
 
 		// Unregister default style overrides.
-		\add_action('enqueue_block_editor_assets', [$this, 'unregisterDefaultStyleOverrides'], 102);
+		\add_action('enqueue_block_editor_assets', $this->unregisterDefaultStyleOverrides(...), 102);
 	}
 
 	/**

--- a/src/Enqueue/Blocks/EnqueueBlocksExample.php
+++ b/src/Enqueue/Blocks/EnqueueBlocksExample.php
@@ -24,10 +24,10 @@ class EnqueueBlocksExample extends AbstractEnqueueBlocks
 	public function register(): void
 	{
 		// Editor only script.
-		\add_action('enqueue_block_editor_assets', [$this, 'enqueueBlockEditorScript']);
+		\add_action('enqueue_block_assets', [$this, 'enqueueBlockEditorScript']);
 
 		// Editor only style.
-		\add_action('enqueue_block_editor_assets', [$this, 'enqueueBlockEditorStyle'], 50);
+		\add_action('enqueue_block_assets', [$this, 'enqueueBlockEditorStyle'], 50);
 
 		// Editor and frontend style.
 		\add_action('enqueue_block_assets', [$this, 'enqueueBlockStyle'], 50);

--- a/src/Enqueue/Theme/EnqueueThemeExample.php
+++ b/src/Enqueue/Theme/EnqueueThemeExample.php
@@ -25,8 +25,8 @@ class EnqueueThemeExample extends AbstractEnqueueTheme
 	 */
 	public function register(): void
 	{
-		\add_action('wp_enqueue_scripts', [$this, 'enqueueThemeStyles'], 10);
-		\add_action('wp_enqueue_scripts', [$this, 'enqueueThemeScripts']);
+		\add_action('wp_enqueue_scripts', $this->enqueueThemeStyles(...));
+		\add_action('wp_enqueue_scripts', $this->enqueueThemeScripts(...));
 	}
 
 	/**

--- a/src/Geolocation/GeolocationExample.php
+++ b/src/Geolocation/GeolocationExample.php
@@ -23,7 +23,7 @@ class GeolocationExample extends AbstractGeolocation
 	 */
 	public function register(): void
 	{
-		\add_action('init', [$this, 'setLocationCookie']);
+		\add_action('init', $this->setLocationCookie(...));
 	}
 
 	/**

--- a/src/I18n/I18nPluginExample.php
+++ b/src/I18n/I18nPluginExample.php
@@ -28,7 +28,7 @@ class I18nPluginExample implements ServiceInterface
 	 */
 	public function register(): void
 	{
-		\add_action('load_plugin_textdomain', [$this, 'loadThemeTextdomain'], 20);
+		\add_action('load_plugin_textdomain', $this->loadThemeTextdomain(...), 20);
 	}
 
 	/**

--- a/src/I18n/I18nThemeExample.php
+++ b/src/I18n/I18nThemeExample.php
@@ -28,8 +28,8 @@ class I18nThemeExample implements ServiceInterface
 	 */
 	public function register(): void
 	{
-		\add_action('after_setup_theme', [$this, 'loadThemeTextdomain'], 20);
-		\add_action('enqueue_block_editor_assets', [$this, 'setScriptTranslations'], 20);
+		\add_action('after_setup_theme', $this->loadThemeTextdomain(...), 20);
+		\add_action('enqueue_block_editor_assets', $this->setScriptTranslations(...), 20);
 	}
 
 	/**

--- a/src/Login/LoginExample.php
+++ b/src/Login/LoginExample.php
@@ -26,7 +26,7 @@ class LoginExample implements ServiceInterface
 	 */
 	public function register(): void
 	{
-		\add_filter('login_headerurl', [$this, 'customLoginUrl']);
+		\add_filter('login_headerurl', $this->customLoginUrl(...));
 	}
 
 	/**

--- a/src/Main/MainExample.php
+++ b/src/Main/MainExample.php
@@ -37,6 +37,6 @@ class MainExample extends AbstractMain
 	 */
 	public function register(): void
 	{
-		\add_action('after_setup_theme', [$this, 'registerServices']);
+		\add_action('after_setup_theme', $this->registerServices(...));
 	}
 }

--- a/src/Media/MediaExample.php
+++ b/src/Media/MediaExample.php
@@ -26,16 +26,16 @@ class MediaExample extends AbstractMedia
 	 */
 	public function register(): void
 	{
-		\add_action('after_setup_theme', [$this, 'addThemeSupport'], 20);
-		\add_filter('upload_mimes', [$this, 'enableMimeTypes']);
-		\add_filter('wp_prepare_attachment_for_js', [$this, 'enableSvgMediaLibraryPreview'], 10, 2);
-		\add_filter('wp_handle_upload_prefilter', [$this, 'validateSvgOnUpload']);
-		\add_filter('wp_check_filetype_and_ext', [$this, 'enableSvgUpload'], 10, 3);
-		\add_filter('wp_check_filetype_and_ext', [$this, 'enableJsonUpload'], 10, 3);
+		\add_action('after_setup_theme', $this->addThemeSupport(...), 20);
+		\add_filter('upload_mimes', $this->enableMimeTypes(...));
+		\add_filter('wp_prepare_attachment_for_js', $this->enableSvgMediaLibraryPreview(...), 10, 2);
+		\add_filter('wp_handle_upload_prefilter', $this->validateSvgOnUpload(...));
+		\add_filter('wp_check_filetype_and_ext', $this->enableSvgUpload(...), 10, 3);
+		\add_filter('wp_check_filetype_and_ext', $this->enableJsonUpload(...), 10, 3);
 
 		// WebP.
 		if (\extension_loaded('gd') || \extension_loaded('imagick')) {
-			\add_filter('wp_handle_upload', [$this, 'convertMediaToWebP']);
+			\add_filter('wp_handle_upload', $this->convertMediaToWebP(...));
 		}
 	}
 

--- a/src/Menu/MenuExample.php
+++ b/src/Menu/MenuExample.php
@@ -24,7 +24,7 @@ class MenuExample extends AbstractMenu
 	 */
 	public function register(): void
 	{
-		\add_action('after_setup_theme', [$this, 'registerMenuPositions'], 11);
+		\add_action('after_setup_theme', $this->registerMenuPositions(...), 11);
 	}
 
 	/**

--- a/src/ModifyAdminAppearance/ModifyAdminAppearanceExample.php
+++ b/src/ModifyAdminAppearance/ModifyAdminAppearanceExample.php
@@ -38,7 +38,7 @@ class ModifyAdminAppearanceExample implements ServiceInterface
 	 */
 	public function register(): void
 	{
-		\add_filter('get_user_option_admin_color', [$this, 'adminColor'], 10, 0);
+		\add_filter('get_user_option_admin_color', $this->adminColor(...));
 	}
 
 	/**

--- a/src/Optimization/OptimizationExample.php
+++ b/src/Optimization/OptimizationExample.php
@@ -26,8 +26,8 @@ class OptimizationExample implements ServiceInterface
 	 */
 	public function register(): void
 	{
-		\add_action('wp_enqueue_scripts', [$this, 'dequeueStyles'], 100);
-		\add_action('wp_enqueue_scripts', [$this, 'dequeueScripts'], 100);
+		\add_action('wp_enqueue_scripts', $this->dequeueStyles(...), 100);
+		\add_action('wp_enqueue_scripts', $this->dequeueScripts(...), 100);
 
 		\remove_action('wp_head', 'print_emoji_detection_script', 7);
 	}

--- a/src/Rest/Fields/FieldExample.php
+++ b/src/Rest/Fields/FieldExample.php
@@ -48,7 +48,7 @@ class FieldExample extends AbstractField implements CallableFieldInterface
 	protected function getCallbackArguments(): array
 	{
 		return [
-			'get_callback' => [$this, 'fieldCallback'],
+			'get_callback' => $this->fieldCallback(...),
 		];
 	}
 

--- a/src/Rest/Routes/RouteExample.php
+++ b/src/Rest/Routes/RouteExample.php
@@ -59,7 +59,7 @@ class RouteExample extends AbstractRoute implements CallableRouteInterface
 	{
 		return [
 			'methods' => '%method%',
-			'callback' => [$this, 'routeCallback'],
+			'callback' => $this->routeCallback(...),
 			'permission_callback' => '__return_true'
 		];
 	}

--- a/src/ThemeOptions/ThemeOptionsExample.php
+++ b/src/ThemeOptions/ThemeOptionsExample.php
@@ -33,7 +33,7 @@ class ThemeOptionsExample implements ServiceInterface
 	 */
 	public function register(): void
 	{
-		\add_action('init', [$this, 'addRbHfSettings']);
+		\add_action('init', $this->addRbHfSettings(...));
 	}
 
 	/**

--- a/src/WpCli/WpCliExample.php
+++ b/src/WpCli/WpCliExample.php
@@ -33,7 +33,7 @@ class WpCliExample implements ServiceCliInterface
 	 */
 	public function register(): void
 	{
-		\add_action('cli_init', [$this, 'registerCommand']);
+		\add_action('cli_init', $this->registerCommand(...));
 	}
 
 	/**


### PR DESCRIPTION
### Fixed

- `enqueueBlockEditorScript` and `enqueueBlockEditorStyle` methods in `AbstractEnqueueBlocks` now check for `is_admin()` to prevent unnecessary execution on the frontend when using `enqueue_block_assets` hook required with the Block Editor API 3 version.

### Migration guide

- If you are using `enqueue_block_editor_assets` hooks replace them with `enqueue_block_assets` and make sure to check for `is_admin()` if you are overriding the `enqueueBlockEditorScript` and `enqueueBlockEditorStyle` methods in your custom enqueue class.