### PR TITLE
Add is_admin() guard to unregisterDefaultStyleOverrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This projects adheres to [Semantic Versioning](https://semver.org/) and [Keep a CHANGELOG](https://keepachangelog.com/).
 
+## [13.2.1]
+
+### Fixed
+
+- `unregisterDefaultStyleOverrides` in `AbstractEnqueueBlocks` now checks for `is_admin()` and returns early on the frontend, preventing an unnecessary request to the `wp-admin/css` URL used to re-register the `forms` and `reset` style dependencies. This is an additional safeguard in case the hook is accidentally changed from `enqueue_block_editor_assets` to `enqueue_block_assets`, which also fires on the frontend.
+
 ## [13.2.0]
 
 ### Changed
@@ -1212,6 +1218,7 @@ Init setup
 - Gutenberg Blocks Registration.
 - Assets Manifest data.
 
+[13.2.1]: https://github.com/infinum/eightshift-libs/compare/13.2.0...13.2.1
 [13.2.0]: https://github.com/infinum/eightshift-libs/compare/13.1.1...13.2.0
 [13.1.1]: https://github.com/infinum/eightshift-libs/compare/13.1.0...13.1.1
 [13.1.0]: https://github.com/infinum/eightshift-libs/compare/13.0.0...13.1.0

--- a/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
+++ b/src/Enqueue/Blocks/AbstractEnqueueBlocks.php
@@ -299,6 +299,10 @@ abstract class AbstractEnqueueBlocks extends AbstractAssets
 	 */
 	public function unregisterDefaultStyleOverrides(): void
 	{
+		if (!\is_admin()) {
+			return;
+		}
+
 		// Unregister unneeded default styles.
 		\wp_deregister_style('forms');
 		\wp_deregister_style('reset');


### PR DESCRIPTION
# Description

Prevents a frontend request to wp-admin/css caused by re-registering the forms/reset style handles with a fake URL.

Theoretically, this isn't needed as the `EnqueueBlocksExample` file does use `enqueue_block_editor_assets`, but in case your agent misreads the migration guide and updates this one as well to `enqueue_block_assets`, you'll be safe.

